### PR TITLE
Build test: exit with correct error code on failure

### DIFF
--- a/Build
+++ b/Build
@@ -22,7 +22,6 @@ tangle_test() {
 
     output_file="tests/templates/output.txt"
     local test_file test_fail_count=0
-    list_tests "$@" | sort |
     while read test_file; do
         local output_differs=false
         progress "running: $test_file..."
@@ -34,7 +33,7 @@ tangle_test() {
         else
             success "$test_file"
         fi
-    done
+    done < <(list_tests "$@" | sort)
     return $test_fail_count
 }
 


### PR DESCRIPTION
Using a pipe caused bash to create a subshell for the while loop, and
"forget" the value of `$test_fail_count` when this subshell exits.