### PR TITLE
added ktest capabilites to makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ yellowpaper/
 paper/paper.pdf
 *.bbl
 *.blg
+
+*.DS_Store

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,20 @@
 defn_files=k/ethereum.k k/data.k k/evm-dasm.k k/evm.k
+ktest_file=tests/config.xml
 
 build: k/ethereum-kompiled/timestamp
 all: build split-tests
 defn: $(defn_files)
 split-tests: tests/tests-develop/VMTests/vmArithmeticTest/make.timestamp \
 			 tests/tests-develop/VMTests/vmBitwiseLogicOperationTest/make.timestamp
-.PHONY: all defn build split-tests
+ktest: defn split-tests 
+
+.PHONY: all defn build split-tests ktest
 
 tests/tests-develop/%/make.timestamp: tests/ethereum-tests/%.json
 	@echo "==   split: $@"
 	mkdir -p $(dir $@)
-	tests/split-test.py $< $(dir $@)
+	tests/split-test.py $< $(dir $@) tests/templates/output.txt
+	cp tests/templates/config.xml $(dir $@)
 	touch $@
 
 k/ethereum-kompiled/timestamp: $(defn_files)
@@ -22,6 +26,9 @@ k/%.k: %.md
 	@echo "==  tangle: $@"
 	mkdir -p k
 	pandoc-tangle --from markdown --to code-k --code k $< > $@
+
+ktest: $(ktest_file)
+	cd k; ktest $(realpath .)/$< 
 
 tests/ethereum-tests/%.json:
 	@echo "==  git submodule: cloning upstreams test repository"

--- a/tests/config.xml
+++ b/tests/config.xml
@@ -2,5 +2,6 @@
 
 <tests>
     <include file="tests-develop/VMTests/vmArithmeticTest/config.xml" />
+    <include file="tests-develop/VMTests/vmBitwiseLogicOperationTest/config.xml" />
 </tests>
         

--- a/tests/split-test.py
+++ b/tests/split-test.py
@@ -3,14 +3,23 @@
 
 import sys
 import json
+import os
 
-# Example usage: tests/ethereum-tests/VMTests/abc.json tests/test-devel/VMTests/abc/
-source_file=sys.argv[1]
-target_dir=sys.argv[2]
+# Example usage: tests/ethereum-tests/VMTests/abc.json tests/test-devel/VMTests/abc/ <template_file> 
+source_file = sys.argv[1]
+target_dir = sys.argv[2]
 
 with open (source_file, "r") as source:
     original_test = json.load(source)
     for subtest in original_test.iterkeys():
-        target_file=target_dir + "/" + subtest + ".json"
+        target_file = os.path.join(target_dir, subtest + ".json")
         with open (target_file, "w+") as target:
             json.dump({ subtest: original_test[subtest] }, target, indent=4)
+        if (len(sys.argv) == 4):
+            target_out_file = os.path.join(target_dir, subtest + ".json.out")
+            template_file = sys.argv[3] 
+            with open (target_out_file, "w+") as outfile:
+                with open (template_file, "r") as template:
+                    outfile.write(template.read())
+
+

--- a/tests/templates/config.xml
+++ b/tests/templates/config.xml
@@ -3,7 +3,7 @@
 <tests>
     <test
          definition="ethereum.k"
-         extension="kson" 
+         extension="json" 
          programs="." 
          results=".">
         <kompile-option name="--main-module" value="ETHEREUM-SIMULATION" />


### PR DESCRIPTION
This allow the makefile to use ktest to run all the generate test programs. 
call `make ktest` to use it. @nishantjr I'm merging this for now, but do review it, and we can make changes.