### PR TITLE
gitmodules: Change remote to gh:ethereum from gh:ethereumproject

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "tests/ethereum-tests"]
 	path = tests/ethereum-tests
-	url = https://github.com/ethereumproject/tests.git
+	url = https://github.com/ethereum/tests.git
 	branch = develop


### PR DESCRIPTION
The `ethereumproject` organization holds the tests for Ethereum
Classic.