### PR TITLE
fast interpreter for evm

### DIFF
--- a/KRYPTO.ml
+++ b/KRYPTO.ml
@@ -2,5 +2,9 @@ open Constants.K
 
 let h = Cryptokit.Hash.keccak 256
 
-let hook_keccak256 c lbl sort config ff = match c with
-  [String input] -> [String (Cryptokit.hash_string h input)]
+let hook_keccak256 c lbl sort config ff = 
+  let buf = Buffer.create 64 in
+  let bytes = match c with
+    [String input] -> Cryptokit.hash_string h input in
+  String.iter (fun c -> Buffer.add_string buf (Printf.sprintf "%x" (int_of_char c))) bytes;
+  [String (Buffer.contents buf)]

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ ktest: defn split-tests
 K:=$(shell krun --version)
 
 passing_test_file=tests/passing.expected
+#passing_tests=$(wildcard tests/tests-develop/VMTests/*/*.json)
 passing_tests=$(shell cat ${passing_test_file})
 passing_targets=${passing_tests:=.test}
 
@@ -41,7 +42,7 @@ tests/tests-develop/%/make.timestamp: tests/ethereum-tests/%.json
 
 ifneq (,$(findstring RV-K, $(K)))
 k/ethereum-kompiled/extras/timestamp: k/ethereum-kompiled/interpreter
-k/ethereum-kompiled/interpreter: $(defn_files)
+k/ethereum-kompiled/interpreter: $(defn_files) KRYPTO.ml
 	@echo "== kompile: $@"
 	@echo "== Detected RV-K, kompile will use $(K)"
 	kompile --debug --main-module ETHEREUM-SIMULATION \

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ ifneq (,$(findstring RV-K, $(K)))
 	kompile --debug --main-module ETHEREUM-SIMULATION \
 					--syntax-module ETHEREUM-SIMULATION $< --directory k \
 					--hook-namespaces KRYPTO --packages ethereum-semantics-plugin -O2
+	cd k/ethereum-kompiled && ocamlfind opt -o interpreter constants.cmx prelude.cmx plugin.cmx parser.cmx lexer.cmx run.cmx interpreter.ml -package gmp -package dynlink -package zarith -package str -package uuidm -package unix -linkpkg -inline 20 -nodynlink -O3
 else
 	@echo "== Detected UIUC-K, kompile will use $(K)"
 	kompile --debug --main-module ETHEREUM-SIMULATION \

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,15 @@ split-tests: tests/tests-develop/VMTests/vmArithmeticTest/make.timestamp \
 ktest: defn split-tests 
 K:=$(shell krun --version)
 
+passing_test_file=tests/passing.expected
+passing_tests=$(shell cat ${passing_test_file})
+passing_targets=${passing_tests:=.test}
+
+test: $(passing_targets)
+
+tests/tests-develop/%.test: tests/tests-develop/% build
+	./evm $<
+
 codeship: build split-tests
 	./Build passing
 
@@ -30,9 +39,10 @@ tests/tests-develop/%/make.timestamp: tests/ethereum-tests/%.json
 	cp tests/templates/config.xml $(dir $@)
 	touch $@
 
-k/ethereum-kompiled/extras/timestamp: $(defn_files)
-	@echo "== kompile: $@"
 ifneq (,$(findstring RV-K, $(K)))
+k/ethereum-kompiled/extras/timestamp: k/ethereum-kompiled/interpreter
+k/ethereum-kompiled/interpreter: $(defn_files)
+	@echo "== kompile: $@"
 	@echo "== Detected RV-K, kompile will use $(K)"
 	kompile --debug --main-module ETHEREUM-SIMULATION \
 					--syntax-module ETHEREUM-SIMULATION $< --directory k \
@@ -47,6 +57,8 @@ ifneq (,$(findstring RV-K, $(K)))
 					--hook-namespaces KRYPTO --packages ethereum-semantics-plugin -O2
 	cd k/ethereum-kompiled && ocamlfind opt -o interpreter constants.cmx prelude.cmx plugin.cmx parser.cmx lexer.cmx run.cmx interpreter.ml -package gmp -package dynlink -package zarith -package str -package uuidm -package unix -linkpkg -inline 20 -nodynlink -O3
 else
+k/ethereum-kompiled/extras/timestamp: $(defn_files)
+	@echo "== kompile: $@"
 	@echo "== Detected UIUC-K, kompile will use $(K)"
 	kompile --debug --main-module ETHEREUM-SIMULATION \
 					--syntax-module ETHEREUM-SIMULATION $< --directory k

--- a/data.md
+++ b/data.md
@@ -8,7 +8,7 @@ EVM also has bytes (8 bit words) for some encodings of data, but only a very lig
 It's doubtful that having two different ways of reading the base data-units (or that limiting yourself to machine-representable units) is beneficial.
 Arguably hardware should evolve to directly support more elegant languages, rather than our languages evolving towards our hardware.
 
-```rvk
+```k
 requires "krypto.k"
 ```
 
@@ -91,7 +91,7 @@ Primitives provide the basic conversion from K's sorts `Int` and `Bool` to EVM's
 
 Note: Comment out this block (remove the `k` tag) if using RV K.
 
-```k
+```uiuck
     syntax Word ::= "#symbolicWord" [function]
  // ------------------------------------------
     rule #symbolicWord => ?X:Int

--- a/data.md
+++ b/data.md
@@ -460,7 +460,7 @@ We need to interperet a `WordStack` as a `String` again so that we can call `Kec
     syntax String ::= #unparseByteStack ( WordStack ) [function]
  // ------------------------------------------------------------
     rule #unparseByteStack( .WordStack )   => ""
-    rule #unparseByteStack( (W:Int) : WS ) => #padByte(Base2String(16, (W %Int (2 ^Int 8)))) +String #unparseByteStack(WS)
+    rule #unparseByteStack( (W:Int) : WS ) => #padByte(Base2String((W %Int (2 ^Int 8)), 16)) +String #unparseByteStack(WS)
 
     syntax String ::= #padByte( String ) [function]
  // -----------------------------------------------

--- a/data.md
+++ b/data.md
@@ -216,8 +216,8 @@ Bitwise logical operators are lifted from the integer versions.
     syntax Word ::= bit  ( Word , Word ) [function]
                   | byte ( Word , Word ) [function]
  // -----------------------------------------------
-    rule bit(N:Int, W:Int)  => (W >>Int (253 -Int N)) %Int 2 requires N >=Int 0
-    rule byte(N:Int, W:Int) => (W >>Int (256 -Int (8 *Int (N +Int 1)))) %Int (2 ^Int 8) requires N >=Int 0
+    rule bit(N:Int, W:Int)  => (W >>Int (253 -Int N)) %Int 2
+    rule byte(N:Int, W:Int) => (W >>Int (256 -Int (8 *Int (N +Int 1)))) %Int (2 ^Int 8)
 ```
 
 -   `#nBits` shifts in $N$ ones from the right.

--- a/data.md
+++ b/data.md
@@ -216,8 +216,8 @@ Bitwise logical operators are lifted from the integer versions.
     syntax Word ::= bit  ( Word , Word ) [function]
                   | byte ( Word , Word ) [function]
  // -----------------------------------------------
-    rule bit(N:Int, W:Int)  => (W >>Int (255 -Int N)) %Int 2
-    rule byte(N:Int, W:Int) => (W >>Int (256 -Int (8 *Int (N +Int 1)))) %Int (2 ^Int 8)
+    rule bit(N:Int, W:Int)  => (W >>Int (253 -Int N)) %Int 2 requires N >=Int 0
+    rule byte(N:Int, W:Int) => (W >>Int (256 -Int (8 *Int (N +Int 1)))) %Int (2 ^Int 8) requires N >=Int 0
 ```
 
 -   `#nBits` shifts in $N$ ones from the right.

--- a/ethereum.md
+++ b/ethereum.md
@@ -290,7 +290,7 @@ TODO: `check` on `"gas"` and `"logs"` is dropped.
     syntax EthereumCommand ::= "success" | "exception" String | "failure" String
  // ----------------------------------------------------------------------------
     rule <k> exception _ => . ... </k> <op> #exception ... </op>
-    rule success   => .
+    rule <k> success   => . ... </k> <exit-code> _ => 0 </exit-code>
     rule failure _ => .
 
     syntax EthereumSpecCommand ::= "run"

--- a/evm
+++ b/evm
@@ -1,0 +1,11 @@
+#!/bin/sh
+interpreter="$(dirname "$0")/k/ethereum-kompiled/interpreter"
+kast="$(mktemp)"
+output="$(mktemp)"
+kast_output="$(mktemp)"
+"$(dirname "$0")/kast-json.py" "$1" > "$kast"
+$interpreter "$(dirname "$0")/k/ethereum-kompiled/realdef.cma" -c PGM "$kast" textfile --output-file "$output"
+k-bin-to-text "$output" "$kast_output"
+cat "$kast_output"
+printf "\n"
+rm -rf "$kast" "$output" "$kast_output"

--- a/evm
+++ b/evm
@@ -3,9 +3,14 @@ interpreter="$(dirname "$0")/k/ethereum-kompiled/interpreter"
 kast="$(mktemp)"
 output="$(mktemp)"
 kast_output="$(mktemp)"
+trap "rm -rf $kast $output $kast_output" INT TERM EXIT
 "$(dirname "$0")/kast-json.py" "$1" > "$kast"
 $interpreter "$(dirname "$0")/k/ethereum-kompiled/realdef.cma" -c PGM "$kast" textfile --output-file "$output"
+exit=$?
+if [ $exit -eq 0 ]; then
+  exit 0
+fi
 k-bin-to-text "$output" "$kast_output"
 cat "$kast_output"
 printf "\n"
-rm -rf "$kast" "$output" "$kast_output"
+exit $exit

--- a/evm.md
+++ b/evm.md
@@ -86,7 +86,7 @@ module ETHEREUM
                       <activeAccounts> .Set </activeAccounts>
 
                       <accounts>
-                        <account multiplicity="*">
+                        <account multiplicity="*" type="Set">
                           <acctID>  .AcctID </acctID>
                           <balance> .Value  </balance>
                           <code>    .Code   </code>
@@ -142,7 +142,7 @@ Execution follows a simple cycle where first the state is checked for exceptions
 -   `#exception` is used to indicate exceptional states (it consumes any operations to be performed after it).
 
 ```k
-    syntax Exception ::= "#exception" | "#throw" KList
+    syntax Exception ::= "#exception" | "#throw" K
  // --------------------------------------------------
     rule <op> EX:Exception ~> (OP:OpCode => .) ... </op>
     rule <op> EX:Exception ~> (W:Word    => .) ... </op>
@@ -154,7 +154,7 @@ Execution follows a simple cycle where first the state is checked for exceptions
 Note: `#catch_` and `#end` are `KItem`, not `OpCode`, so exceptions will not remove them from the `op` cell.
 
 ```k
-    syntax KItem ::= "#catch" KList | "#end"
+    syntax KItem ::= "#catch" K | "#end"
  // ----------------------------------------
     rule <op> #catch _ => . ... </op>
     rule <op> #exception ~> #catch KL => KL ... </op>

--- a/evm.md
+++ b/evm.md
@@ -112,7 +112,7 @@ module ETHEREUM
 
                   </ethereum>
                   <k> $PGM:EthereumSimulation </k>
-                  <exit-code exit=""> 0 </exit-code>
+                  <exit-code exit=""> 1 </exit-code>
 
     syntax EthereumSimulation
     syntax AcctID ::= Word | ".AcctID"

--- a/k/data.k
+++ b/k/data.k
@@ -476,7 +476,7 @@ module EVM-DATA
     syntax String ::= #unparseByteStack ( WordStack ) [function]
  // ------------------------------------------------------------
     rule #unparseByteStack( .WordStack )   => ""
-    rule #unparseByteStack( (W:Int) : WS ) => #padByte(Base2String(16, (W %Int (2 ^Int 8)))) +String #unparseByteStack(WS)
+    rule #unparseByteStack( (W:Int) : WS ) => #padByte(Base2String((W %Int (2 ^Int 8)), 16)) +String #unparseByteStack(WS)
 
     syntax String ::= #padByte( String ) [function]
  // -----------------------------------------------

--- a/k/data.k
+++ b/k/data.k
@@ -12,6 +12,10 @@
 // towards our hardware.
 
 
+requires "krypto.k"
+
+
+
 requires "domains.k"
 
 module EVM-DATA
@@ -92,12 +96,6 @@ module EVM-DATA
 // -   `#symbolicWord` generates a fresh existentially-bound symbolic word.
 
 // Note: Comment out this block (remove the `k` tag) if using RV K.
-
-
-    syntax Word ::= "#symbolicWord" [function]
- // ------------------------------------------
-    rule #symbolicWord => ?X:Int
-
 
 // Arithmetic
 // ----------
@@ -220,8 +218,8 @@ module EVM-DATA
     syntax Word ::= bit  ( Word , Word ) [function]
                   | byte ( Word , Word ) [function]
  // -----------------------------------------------
-    rule bit(N:Int, W:Int)  => (W >>Int (255 -Int N)) %Int 2
-    rule byte(N:Int, W:Int) => (W >>Int (256 -Int (8 *Int (N +Int 1)))) %Int (2 ^Int 8)
+    rule bit(N:Int, W:Int)  => (W >>Int (253 -Int N)) %Int 2 requires N >=Int 0
+    rule byte(N:Int, W:Int) => (W >>Int (256 -Int (8 *Int (N +Int 1)))) %Int (2 ^Int 8) requires N >=Int 0
 
 
 // -   `#nBits` shifts in $N$ ones from the right.

--- a/k/ethereum.k
+++ b/k/ethereum.k
@@ -293,7 +293,7 @@ module ETHEREUM-SIMULATION
     syntax EthereumCommand ::= "success" | "exception" String | "failure" String
  // ----------------------------------------------------------------------------
     rule <k> exception _ => . ... </k> <op> #exception ... </op>
-    rule success   => .
+    rule <k> success   => . ... </k> <exit-code> _ => 0 </exit-code>
     rule failure _ => .
 
     syntax EthereumSpecCommand ::= "run"

--- a/k/evm.k
+++ b/k/evm.k
@@ -91,7 +91,7 @@ module ETHEREUM
                       <activeAccounts> .Set </activeAccounts>
 
                       <accounts>
-                        <account multiplicity="*">
+                        <account multiplicity="*" type="Set">
                           <acctID>  .AcctID </acctID>
                           <balance> .Value  </balance>
                           <code>    .Code   </code>
@@ -117,7 +117,7 @@ module ETHEREUM
 
                   </ethereum>
                   <k> $PGM:EthereumSimulation </k>
-                  <exit-code exit=""> 0 </exit-code>
+                  <exit-code exit=""> 1 </exit-code>
 
     syntax EthereumSimulation
     syntax AcctID ::= Word | ".AcctID"
@@ -149,7 +149,7 @@ module ETHEREUM
 //     operations to be performed after it).
 
 
-    syntax Exception ::= "#exception" | "#throw" KList
+    syntax Exception ::= "#exception" | "#throw" K
  // --------------------------------------------------
     rule <op> EX:Exception ~> (OP:OpCode => .) ... </op>
     rule <op> EX:Exception ~> (W:Word    => .) ... </op>
@@ -163,7 +163,7 @@ module ETHEREUM
 // remove them from the `op` cell.
 
 
-    syntax KItem ::= "#catch" KList | "#end"
+    syntax KItem ::= "#catch" K | "#end"
  // ----------------------------------------
     rule <op> #catch _ => . ... </op>
     rule <op> #exception ~> #catch KL => KL ... </op>

--- a/kast-json.py
+++ b/kast-json.py
@@ -39,6 +39,10 @@ def print_kast(data):
     sys.stdout.write('#token('),
     sys.stdout.write(json.dumps(json.dumps(data)))
     sys.stdout.write(',"String")')
+  elif isinstance(data, long) or isinstance(data, int):
+    sys.stdout.write('#token("'),
+    sys.stdout.write(str(data))
+    sys.stdout.write('","Int")')
   else:
     sys.stdout.write(type(data))
     raise AssertionError

--- a/kast-json.py
+++ b/kast-json.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+
+import json
+import sys
+from collections import OrderedDict
+
+filename = sys.argv[1]
+
+with open(filename) as data_file:    
+    data = json.load(data_file, object_pairs_hook=OrderedDict)
+
+def escape(data):
+  return data.encode('unicode_escape')
+
+def print_kast(data):
+  if isinstance(data, list):
+    sys.stdout.write('`[_]_EVM-DATA`(')
+    for elem in data:
+      sys.stdout.write('`_,__EVM-DATA`(')
+      print_kast(elem)
+      sys.stdout.write(',')
+    sys.stdout.write('`.List{"_,__EVM-DATA"}`(.KList)')
+    for elem in data:
+      sys.stdout.write(')')
+    sys.stdout.write(')')
+  elif isinstance(data, OrderedDict):
+    sys.stdout.write('`{_}_EVM-DATA`(')
+    for key, value in data.iteritems():
+      sys.stdout.write('`_,__EVM-DATA`(`_:__EVM-DATA`(')
+      print_kast(key)
+      sys.stdout.write(',')
+      print_kast(value)
+      sys.stdout.write('),')
+    sys.stdout.write('`.List{"_,__EVM-DATA"}`(.KList)')
+    for key in data:
+      sys.stdout.write(')')
+    sys.stdout.write(')')
+  elif isinstance(data, unicode):
+    sys.stdout.write('#token('),
+    sys.stdout.write(json.dumps(json.dumps(data)))
+    sys.stdout.write(',"String")')
+  else:
+    sys.stdout.write(type(data))
+    raise AssertionError
+
+print_kast(data)
+print


### PR DESCRIPTION
I haven't hooked this into anything yet, and the parser probably won't work for the academic K, but I created a simple script that should do fast execution of the evm semantics. Tested on some of the json in the tests-develop directory and it takes about 100 ms to get stuck. It gets stuck pretty quickly (after <100 steps) so it's not much of a benchmark but it means there's essentially now negligible overhead and nearly all the user time is being spent executing steps.

Dunno how you want to hook it into your testing infrastructure; it looks like you're using ktest which means it won't really play well because it never actually calls krun. It also doesn't do any pretty printing, just spits out the configuration in kast format. But it should give you very very fast execution with pretty much no overhead. Note that you need to have a kserver running for it to work.