### PR TITLE
recover old build system that runs 12x faster on Jenkins

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,18 @@ split-tests: tests/VMTests/vmArithmeticTest/make.timestamp \
 			 tests/VMTests/vmtests/make.timestamp \
 			 tests/VMTests/vmInputLimits/make.timestamp \
 			 tests/VMTests/vmInputLimitsLight/make.timestamp
-.PHONY: all defn build split-tests proofs
+.PHONY: all defn build split-tests proofs test
+
+passing_test_file=tests/passing.expected
+all_tests=$(wildcard tests/VMTests/*/*.json)
+skipped_tests=$(wildcard tests/VMTests/vmPerformanceTest/*.json) tests/VMTests/vmIOandFlowOperationsTest/loop_stacklimit_1021.json
+passing_tests=$(filter-out ${skipped_tests}, ${all_tests})
+passing_targets=${passing_tests:=.test}
+
+test: $(passing_targets)
+
+tests/%.test: tests/% build
+	./evm $<
 
 tests/%/make.timestamp: tests/ethereum-tests/%.json
 	@echo "==   split: $@"

--- a/evm
+++ b/evm
@@ -5,7 +5,7 @@ output="$(mktemp)"
 kast_output="$(mktemp)"
 trap "rm -rf $kast $output $kast_output" INT TERM EXIT
 "$(dirname "$0")/kast-json.py" "$1" > "$kast"
-$interpreter "$(dirname "$0")/k/ethereum-kompiled/realdef.cma" -c PGM "$kast" textfile -c SCHEDULE '`DEFAULT_ETHEREUM`(.KList)' text -c MODE '`VMTESTS_ETHEREUM`(.KList)' text --output-file "$output"
+$interpreter "$(dirname "$0")/.build/rvk/ethereum-kompiled/realdef.cma" -c PGM "$kast" textfile -c SCHEDULE '`DEFAULT_ETHEREUM`(.KList)' text -c MODE '`VMTESTS_ETHEREUM`(.KList)' text --output-file "$output"
 exit=$?
 if [ $exit -eq 0 ]; then
   exit 0

--- a/evm
+++ b/evm
@@ -1,0 +1,16 @@
+#!/bin/sh
+interpreter="$(dirname "$0")/.build/rvk/ethereum-kompiled/interpreter"
+kast="$(mktemp)"
+output="$(mktemp)"
+kast_output="$(mktemp)"
+trap "rm -rf $kast $output $kast_output" INT TERM EXIT
+"$(dirname "$0")/kast-json.py" "$1" > "$kast"
+$interpreter "$(dirname "$0")/k/ethereum-kompiled/realdef.cma" -c PGM "$kast" textfile -c SCHEDULE '`DEFAULT_ETHEREUM`(.KList)' text -c MODE '`VMTESTS_ETHEREUM`(.KList)' text --output-file "$output"
+exit=$?
+if [ $exit -eq 0 ]; then
+  exit 0
+fi
+k-bin-to-text "$output" "$kast_output"
+cat "$kast_output"
+printf "\n"
+exit $exit


### PR DESCRIPTION
The old build system, which ran the tests in parallel, is substantially faster than the new one that was created since I left, so I am reviving the old build system on rv-jenkins.