### PR TITLE
Disallow #symbolicWord becoming exactly pow256

### DIFF
--- a/data.md
+++ b/data.md
@@ -135,7 +135,7 @@ Note: Comment out this block (remove the `k` tag) if using RV K.
 ```{.k .uiuck}
     syntax Int ::= "#symbolicWord" [function]
  // -----------------------------------------
-    rule #symbolicWord => ?X:Int requires ?X >=Int 0 andBool ?X <=Int pow256
+    rule #symbolicWord => chop ( ?X:Int )
 ```
 
 Word Operations


### PR DESCRIPTION
I thought the range of a word should be up to `pow256` exclusive, rather than inclusive.

This is my PR.  Let me know what I should try locally before submitting a PR.