### PR TITLE
Fix the paths of VMTests in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,11 @@ Not everyone wants to go through the process of installing K, so the script `./t
 The following calls to `./Build` are prefixed with a call to `with-k` to download, build, and set up a fresh copy of RV-K or UIUC-K (as specified).
 
 ```sh
-$ ./tests/ci/with-k rvk   ./Build run tests/VMTests/vmArithmeticTest/add0.json
+$ ./tests/ci/with-k rvk   ./Build run tests/ethereum-tests/VMTests/vmArithmeticTest/add0.json
 $ ./tests/ci/with-k uiuck ./Build prove tests/proofs/hkg/transfer-else-spec.k
-$ ./tests/ci/with-k rvk   ./Build test tests/VMTests/vmArithmeticTest/add0.json
+$ ./tests/ci/with-k rvk   ./Build test tests/ethereum-tests/VMTests/vmArithmeticTest/add0.json
 $ ./tests/ci/with-k uiuck ./Build prove tests/proofs/hkg/transfer-else-spec.k
-$ ./tests/ci/with-k uiuck ./Build debug tests/VMTests/vmArithmeticTest/add0.json
+$ ./tests/ci/with-k uiuck ./Build debug tests/ethereum-tests/VMTests/vmArithmeticTest/add0.json
 ```
 
 See `./Build help` to see more detailed usage information; `./Build` can build and test the definition as well as run EVM programs and proofs.
@@ -78,27 +78,27 @@ To only download and setup K once for each session, you can do the following:
 $ ./tests/ci/with-k rvk `which bash`
 
 # Now can just run `./Build` directly
-$ ./Build run tests/VMTests/vmArithmeticTest/add0.json
-$ ./Build test tests/VMTests/vmArithmeticTest/add0.json
+$ ./Build run tests/ethereum-tests/VMTests/vmArithmeticTest/add0.json
+$ ./Build test tests/ethereum-tests/VMTests/vmArithmeticTest/add0.json
 ```
 
 The script `with-k` sets up the development environment with the fresh copy of K built and prefixed to `PATH` for the remaining commands.
 
 ### Example Runs
 
-Run the file `tests/VMTests/vmArithmeticTest/add0.json`:
+Run the file `tests/ethereum-tests/VMTests/vmArithmeticTest/add0.json`:
 
 ```sh
-$ ./Build run tests/VMTests/vmArithmeticTest/add0.json
+$ ./Build run tests/ethereum-tests/VMTests/vmArithmeticTest/add0.json
 
 # Which actually calls:
-$ krun --directory .build/uiuck/ -cSCHEDULE=DEFAULT -cMODE=VMTESTS tests/VMTests/vmArithmeticTest/add0.json
+$ krun --directory .build/uiuck/ -cSCHEDULE=DEFAULT -cMODE=VMTESTS tests/ethereum-tests/VMTests/vmArithmeticTest/add0.json
 ```
 
 Run the same file as a test:
 
 ```sh
-$ ./Build test tests/VMTests/vmArithmeticTest/add0.json
+$ ./Build test tests/ethereum-tests/VMTests/vmArithmeticTest/add0.json
 ```
 
 To run proofs, you can similarly use `./Build`.
@@ -116,7 +116,7 @@ $ krun --directory .build/uiuck/ -cSCHEDULE=DEFAULT -cMODE=NORMAL \
 Finally, if you want to debug a given program (by stepping through its execution), you can use the `debug` option:
 
 ```sh
-$ ./Build debug tests/VMTests/vmArithmeticTest/add0.json
+$ ./Build debug tests/ethereum-tests/VMTests/vmArithmeticTest/add0.json
 ...
 KDebug> s
 1 Step(s) Taken.


### PR DESCRIPTION
VMTests are currently located at tests/ethereum-tests/VMTests.

Fixes #121.