### PR TITLE
compute touched accounts of each transaction 

### DIFF
--- a/driver.md
+++ b/driver.md
@@ -122,6 +122,7 @@ To do so, we'll extend sort `JSON` with some EVM specific syntax, and provide a 
          <origin> _ => ACCTFROM </origin>
          <callDepth> _ => -1 </callDepth>
          <txPending> ListItem(TXID:Int) ... </txPending>
+         <coinbase> MINER </coinbase>
          <message>
            <msgID>      TXID     </msgID>
            <txGasPrice> GPRICE   </txGasPrice>
@@ -138,6 +139,7 @@ To do so, we'll extend sort `JSON` with some EVM specific syntax, and provide a 
            ...
          </account>
          <activeAccounts> ... ACCTFROM |-> (_ => false) ... </activeAccounts>
+         <touchedAccounts> _ => SetItem(MINER) </touchedAccounts>
 
     rule <k> loadTx(ACCTFROM)
           => #call ACCTFROM ACCTTO ACCTTO (GLIMIT -Int G0(SCHED, DATA, false)) VALUE VALUE DATA false
@@ -149,6 +151,7 @@ To do so, we'll extend sort `JSON` with some EVM specific syntax, and provide a 
          <origin> _ => ACCTFROM </origin>
          <callDepth> _ => -1 </callDepth>
          <txPending> ListItem(TXID:Int) ... </txPending>
+         <coinbase> MINER </coinbase>
          <message>
            <msgID>      TXID   </msgID>
            <txGasPrice> GPRICE </txGasPrice>
@@ -165,6 +168,7 @@ To do so, we'll extend sort `JSON` with some EVM specific syntax, and provide a 
            ...
          </account>
          <activeAccounts> ... ACCTFROM |-> (_ => false) ... </activeAccounts>
+         <touchedAccounts> _ => SetItem(MINER) </touchedAccounts>
       requires ACCTTO =/=K .Account
 
     syntax EthereumCommand ::= "#finishTx"
@@ -339,27 +343,28 @@ State Manipulation
     syntax EthreumCommand ::= "clearTX"
  // -----------------------------------
     rule <k> clearTX => . ... </k>
-         <output>       _ => .WordStack </output>
-         <memoryUsed>   _ => 0          </memoryUsed>
-         <callDepth>    _ => 0          </callDepth>
-         <callStack>    _ => .List      </callStack>
-         <callLog>      _ => .Set       </callLog>
-         <program>      _ => .Map       </program>
-         <programBytes> _ => .WordStack </programBytes>
-         <id>           _ => 0          </id>
-         <caller>       _ => 0          </caller>
-         <callData>     _ => .WordStack </callData>
-         <callValue>    _ => 0          </callValue>
-         <wordStack>    _ => .WordStack </wordStack>
-         <localMem>     _ => .Map       </localMem>
-         <pc>           _ => 0          </pc>
-         <gas>          _ => 0          </gas>
-         <previousGas>  _ => 0          </previousGas>
-         <selfDestruct> _ => .Set       </selfDestruct>
-         <log>          _ => .List      </log>
-         <refund>       _ => 0          </refund>
-         <gasPrice>     _ => 0          </gasPrice>
-         <origin>       _ => 0          </origin>
+         <output>          _ => .WordStack </output>
+         <memoryUsed>      _ => 0          </memoryUsed>
+         <callDepth>       _ => 0          </callDepth>
+         <callStack>       _ => .List      </callStack>
+         <callLog>         _ => .Set       </callLog>
+         <program>         _ => .Map       </program>
+         <programBytes>    _ => .WordStack </programBytes>
+         <id>              _ => 0          </id>
+         <caller>          _ => 0          </caller>
+         <callData>        _ => .WordStack </callData>
+         <callValue>       _ => 0          </callValue>
+         <wordStack>       _ => .WordStack </wordStack>
+         <localMem>        _ => .Map       </localMem>
+         <pc>              _ => 0          </pc>
+         <gas>             _ => 0          </gas>
+         <previousGas>     _ => 0          </previousGas>
+         <selfDestruct>    _ => .Set       </selfDestruct>
+         <log>             _ => .List      </log>
+         <refund>          _ => 0          </refund>
+         <gasPrice>        _ => 0          </gasPrice>
+         <origin>          _ => 0          </origin>
+         <touchedAccounts> _ => .Set       </touchedAccounts>
 
     syntax EthreumCommand ::= "clearBLOCK"
  // --------------------------------------

--- a/evm.md
+++ b/evm.md
@@ -41,13 +41,14 @@ In the comments next to each cell, we've marked which component of the YellowPap
                       // Mutable during a single transaction
                       // -----------------------------------
 
-                      <output>        .WordStack </output>              // H_RETURN
-                      <memoryUsed>    0          </memoryUsed>          // \mu_i
-                      <callDepth>     0          </callDepth>
-                      <callStack>     .List      </callStack>
-                      <interimStates> .List      </interimStates>
-                      <substateStack> .List      </substateStack>
-                      <callLog>       .Set       </callLog>
+                      <output>          .WordStack </output>            // H_RETURN
+                      <memoryUsed>      0          </memoryUsed>        // \mu_i
+                      <callDepth>       0          </callDepth>
+                      <callStack>       .List      </callStack>
+                      <interimStates>   .List      </interimStates>
+                      <substateStack>   .List      </substateStack>
+                      <callLog>         .Set       </callLog>
+                      <touchedAccounts> .Set       </touchedAccounts>
 
                       <txExecState>
                         <program>      .Map       </program>            // I_b
@@ -1459,6 +1460,7 @@ The various `CALL*` (and other inter-contract control flow) operations will be d
          <program> _ => CODE </program>
          <programBytes> _ => BYTES </programBytes>
          <static> OLDSTATIC:Bool => OLDSTATIC orBool STATIC </static>
+         <touchedAccounts> ... .Set => SetItem(ACCTFROM) SetItem(ACCTTO) ... </touchedAccounts>
 
     syntax KItem ::= "#initVM"
  // --------------------------
@@ -1631,6 +1633,7 @@ For each `CALL*` operation, we make a corresponding call to `#call` and a state-
            ...
          </account>
          <activeAccounts> ... ACCTTO |-> (EMPTY => #if Gemptyisnonexistent << SCHED >> #then false #else EMPTY #fi) ... </activeAccounts>
+         <touchedAccounts> ... .Set => SetItem(ACCTFROM) SetItem(ACCTTO) ... </touchedAccounts>
 
     syntax KItem ::= "#codeDeposit" Int
                    | "#mkCodeDeposit" Int
@@ -1725,6 +1728,7 @@ Self destructing to yourself, unlike a regular transfer, destroys the balance in
            ...
          </account>
          <output> _ => .WordStack </output>
+         <touchedAccounts> ... .Set => SetItem(ACCT) SetItem(ACCTTO) ... </touchedAccounts>
       requires ACCT =/=Int ACCTTO
 
     rule <k> SELFDESTRUCT ACCT => #end ... </k>
@@ -1741,6 +1745,7 @@ Self destructing to yourself, unlike a regular transfer, destroys the balance in
          </account>
          <activeAccounts> ... ACCT |-> (_ => NONCE ==Int 0 andBool CODE ==K .WordStack) ... </activeAccounts>
          <output> _ => .WordStack </output>
+         <touchedAccounts> ... .Set => SetItem(ACCT) ... </touchedAccounts>
 
 ```
 

--- a/tests/interactive/add0.json.out
+++ b/tests/interactive/add0.json.out
@@ -46,6 +46,9 @@
       <callLog>
         .Set
       </callLog>
+      <touchedAccounts>
+        .Set
+      </touchedAccounts>
       <txExecState>
         <program>
           0 |-> PUSH ( 32 , 115792089237316195423570985008687907853269984665640564039457584007913129639935 )

--- a/tests/interactive/gas-analysis/sumTo10.evm.out
+++ b/tests/interactive/gas-analysis/sumTo10.evm.out
@@ -42,6 +42,9 @@
       <callLog>
         .Set
       </callLog>
+      <touchedAccounts>
+        .Set
+      </touchedAccounts>
       <txExecState>
         <program>
           0 |-> PUSH ( 1 , 0 )

--- a/tests/interactive/log3_MaxTopic_d0g0v0.json.out
+++ b/tests/interactive/log3_MaxTopic_d0g0v0.json.out
@@ -38,6 +38,9 @@
       <callLog>
         .Set
       </callLog>
+      <touchedAccounts>
+        .Set
+      </touchedAccounts>
       <txExecState>
         <program>
           .Map


### PR DESCRIPTION
computes the EIP 161 touched accounts of a transaction as it executes. This does not affect VM execution of a single transaction, but will eventually be necessary if we intend to verify entire blocks in KEVM.