### PR TITLE
kevm, Makefile, tests/interactive/*.out: default to BYZANTIUM schedule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -234,7 +234,7 @@ test-slow-vm: $(slow_vm_tests:=.test)
 test-vm: $(quick_vm_tests:=.test)
 
 tests/ethereum-tests/VMTests/%.test: tests/ethereum-tests/VMTests/% build-ocaml
-	MODE=VMTESTS $(TEST) $<
+	MODE=VMTESTS SCHEDULE=DEFAULT $(TEST) $<
 
 # BlockchainTests
 

--- a/kevm
+++ b/kevm
@@ -38,7 +38,7 @@ run_env() {
     local release_dir="${K_BIN:-$build_dir/k/k-distribution/target/release/k}"
     local lib_dir="$build_dir/local/lib"
     export cMODE="\`${MODE:-NORMAL}\`(.KList)"
-    export cSCHEDULE="\`${SCHEDULE:-DEFAULT}_EVM\`(.KList)"
+    export cSCHEDULE="\`${SCHEDULE:-BYZANTIUM}_EVM\`(.KList)"
     export PATH="$release_dir/lib/native/linux:$release_dir/lib/native/linux64:$release_dir/bin/:$PATH"
     export LD_LIBRARY_PATH="$release_dir/lib/native/linux64:$lib_dir:${LD_LIBRARY_PATH:-}"
     eval $(opam config env)

--- a/tests/interactive/gas-analysis/sumTo10.evm.out
+++ b/tests/interactive/gas-analysis/sumTo10.evm.out
@@ -9,7 +9,7 @@
     NORMAL
   </mode>
   <schedule>
-    DEFAULT
+    BYZANTIUM
   </schedule>
   <analysis>
     "blocks" |-> ListItem ( { 40 ==> 46 | 20009 | 0 } )


### PR DESCRIPTION
-   VMTESTS run on DEFAULT schedule
-   output of interactive tests is updated

Addresses #174 