### PR TITLE
ABI formalization for more types

### DIFF
--- a/data.md
+++ b/data.md
@@ -110,6 +110,27 @@ Primitives provide the basic conversion from K's sorts `Int` and `Bool` to EVM's
     rule abs(I) => I         requires sgn(I) ==K 1
 ```
 
+-   #signed : uInt256 -> sInt256  (i.e., [minUInt256..maxUInt256] -> [minSInt256..maxSInt256])
+- #unsigned : sInt256 -> uInt256  (i.e., [minSInt256..maxSInt256] -> [minUInt256..maxUInt256])
+
+```k
+    syntax Int ::= #signed ( Int ) [function]
+ // -----------------------------------------
+    rule #signed(DATA) => DATA
+      requires 0 <=Int DATA andBool DATA <=Int maxSInt256
+
+    rule #signed(DATA) => DATA -Int pow256
+      requires maxSInt256 <Int DATA andBool DATA <=Int maxUInt256
+
+    syntax Int ::= #unsigned ( Int ) [function]
+ // -----------------------------------------
+    rule #unsigned(DATA) => DATA
+      requires 0 <=Int DATA andBool DATA <=Int maxSInt256
+
+    rule #unsigned(DATA) => pow256 +Int DATA
+      requires minSInt256 <=Int DATA andBool DATA <Int 0
+```
+
 ### Empty Account
 
 -   `.Account` represents the case when an account ID is referenced in the yellowpaper, but

--- a/data.md
+++ b/data.md
@@ -49,6 +49,24 @@ These can be used for pattern-matching on the LHS of rules as well (`macro` attr
     rule pow256 => 115792089237316195423570985008687907853269984665640564039457584007913129639936 [macro]
     rule pow255 => 57896044618658097711785492504343953926634992332820282019728792003956564819968  [macro]
     rule pow16  => 65536 [macro]
+
+    syntax Int ::= "minSInt128" [function]
+                 | "maxSInt128" [function]
+                 | "minUInt160" [function]
+                 | "maxUInt160" [function]
+                 | "minUInt256" [function]
+                 | "maxUInt256" [function]
+                 | "minSInt256" [funciton]
+                 | "maxSInt256" [function]
+ // ---------------------------------------
+    rule minSInt128 => -170141183460469231731687303715884105728  [macro]  /* -2^127     */
+    rule maxSInt128 =>  170141183460469231731687303715884105727  [macro]  /*  2^127 - 1 */
+    rule minUInt160 => 0  [macro]
+    rule maxUInt160 => 1461501637330902918203684832716283019655932542975  [macro]  /* 2^160 - 1 */
+    rule minUInt256 => 0  [macro]
+    rule maxUInt256 => 115792089237316195423570985008687907853269984665640564039457584007913129639935  [macro]  /*  2^256 - 1 */
+    rule minSInt256 => -57896044618658097711785492504343953926634992332820282019728792003956564819968  [macro]  /* -2^255     */
+    rule maxSInt256 =>  57896044618658097711785492504343953926634992332820282019728792003956564819967  [macro]  /*  2^255 - 1 */
 ```
 
 -   `chop` interperets an integer modulo $2^256$.

--- a/edsl.md
+++ b/edsl.md
@@ -39,6 +39,7 @@ where `F1 : F2 : F3 : F4` is the (two's complement) byte-array representation of
                       | #uint256 ( Int )
                       | #int128  ( Int )
                       | #bytes32 ( Int )
+                      | #bool    ( Int )
  // ------------------------------------
 
     syntax TypedArgs ::= List{TypedArg, ","} [klabel(typedArgs)]
@@ -66,6 +67,7 @@ where `F1 : F2 : F3 : F4` is the (two's complement) byte-array representation of
     rule #typeName(#uint256( _ )) => "uint256"
     rule #typeName( #int128( _ )) => "int128"
     rule #typeName(#bytes32( _ )) => "bytes32"
+    rule #typeName(   #bool( _ )) => "bool"
 
     syntax WordStack ::= #encodeArgs ( TypedArgs ) [function]
  // ---------------------------------------------------------
@@ -88,6 +90,9 @@ where `F1 : F2 : F3 : F4` is the (two's complement) byte-array representation of
 
     rule #getData(#bytes32( DATA )) => #padToWidth(32, #asByteStack(DATA))
       requires 0 <=Int DATA andBool DATA <=Int maxUInt256
+
+    rule #getData(   #bool( DATA )) => #padToWidth(32, #asByteStack(DATA))
+      requires 0 <=Int DATA andBool DATA <=Int 1
 
     syntax Int ::= "minInt128"  [function]
                  | "maxInt128"  [function]

--- a/edsl.md
+++ b/edsl.md
@@ -139,7 +139,7 @@ where `F1 : F2 : F3 : F4` is the (two's complement) byte-array representation of
     rule #getValue(#uint256( DATA )) => DATA
       requires minUInt256 <=Int DATA andBool DATA <=Int maxUInt256
 
-    rule #getValue( #int128( DATA )) => #signed(DATA)
+    rule #getValue( #int128( DATA )) => #unsigned(DATA)
       requires minSInt128 <=Int DATA andBool DATA <=Int maxSInt128
 
     rule #getValue(#bytes32( DATA )) => DATA
@@ -147,14 +147,6 @@ where `F1 : F2 : F3 : F4` is the (two's complement) byte-array representation of
 
     rule #getValue(   #bool( DATA )) => DATA
       requires 0 <=Int DATA andBool DATA <=Int 1
-
-    syntax Int ::= #signed ( Int ) [function]
- // -----------------------------------------
-    rule #signed(DATA) => DATA
-      requires 0 <=Int DATA andBool DATA <=Int maxSInt256
-
-    rule #signed(DATA) => pow256 +Int DATA
-      requires minSInt256 <=Int DATA andBool DATA <Int 0
 
     syntax Int ::= #ceil32 ( Int ) [function]
  // -----------------------------------------

--- a/edsl.md
+++ b/edsl.md
@@ -159,24 +159,6 @@ where `F1 : F2 : F3 : F4` is the (two's complement) byte-array representation of
     syntax Int ::= #ceil32 ( Int ) [function]
  // -----------------------------------------
     rule #ceil32(N) => ((N +Int 31) /Int 32) *Int 32
-
-    syntax Int ::= "minSInt128" [function]
-                 | "maxSInt128" [function]
-                 | "minUInt160" [function]
-                 | "maxUInt160" [function]
-                 | "minUInt256" [function]
-                 | "maxUInt256" [function]
-                 | "minSInt256" [funciton]
-                 | "maxSInt256" [function]
- // ---------------------------------------
-    rule minSInt128 => -170141183460469231731687303715884105728  [macro]  /* -2^127     */
-    rule maxSInt128 =>  170141183460469231731687303715884105727  [macro]  /*  2^127 - 1 */
-    rule minUInt160 => 0  [macro]
-    rule maxUInt160 => 1461501637330902918203684832716283019655932542975  [macro]  /* 2^160 - 1 */
-    rule minUInt256 => 0  [macro]
-    rule maxUInt256 => 115792089237316195423570985008687907853269984665640564039457584007913129639935  [macro]  /*  2^256 - 1 */
-    rule minSInt256 => -57896044618658097711785492504343953926634992332820282019728792003956564819968  [macro]  /* -2^255     */
-    rule maxSInt256 =>  57896044618658097711785492504343953926634992332820282019728792003956564819967  [macro]  /*  2^255 - 1 */
 ```
 
 ### ABI Event Logs

--- a/edsl.md
+++ b/edsl.md
@@ -74,47 +74,55 @@ where `F1 : F2 : F3 : F4` is the (two's complement) byte-array representation of
     rule #encodeArgs(ARG, ARGS)  => #getData(ARG) ++ #encodeArgs(ARGS)
     rule #encodeArgs(.TypedArgs) => .WordStack
 
-    syntax WordStack ::= #getData ( TypedArg ) [function]
- // -----------------------------------------------------
-    rule #getData(#uint160( DATA )) => #padToWidth(32, #asByteStack(DATA))
-      requires 0 <=Int DATA andBool DATA <=Int maxUInt160
+    syntax Int ::= #getValue ( TypedArg ) [function]
+ // ------------------------------------------------
+    rule #getValue(#uint160( DATA )) => DATA
+      requires minUInt160 <=Int DATA andBool DATA <=Int maxUInt160
 
-    rule #getData(#address( DATA )) => #padToWidth(32, #asByteStack(DATA))
-      requires 0 <=Int DATA andBool DATA <=Int maxUInt160
+    rule #getValue(#address( DATA )) => DATA
+      requires minUInt160 <=Int DATA andBool DATA <=Int maxUInt160
 
-    rule #getData(#uint256( DATA )) => #padToWidth(32, #asByteStack(DATA))
-      requires 0 <=Int DATA andBool DATA <=Int maxUInt256
+    rule #getValue(#uint256( DATA )) => DATA
+      requires minUInt256 <=Int DATA andBool DATA <=Int maxUInt256
 
-    rule #getData( #int128( DATA )) => #padToWidth(32, #asByteStack(#signed(DATA)))
-      requires minInt128 <=Int DATA andBool DATA <=Int maxInt128
+    rule #getValue( #int128( DATA )) => #signed(DATA)
+      requires minSInt128 <=Int DATA andBool DATA <=Int maxSInt128
 
-    rule #getData(#bytes32( DATA )) => #padToWidth(32, #asByteStack(DATA))
-      requires 0 <=Int DATA andBool DATA <=Int maxUInt256
+    rule #getValue(#bytes32( DATA )) => DATA
+      requires minUInt256 <=Int DATA andBool DATA <=Int maxUInt256
 
-    rule #getData(   #bool( DATA )) => #padToWidth(32, #asByteStack(DATA))
+    rule #getValue(   #bool( DATA )) => DATA
       requires 0 <=Int DATA andBool DATA <=Int 1
-
-    syntax Int ::= "minInt128"  [function]
-                 | "maxInt128"  [function]
-                 | "maxUInt160" [function]
-                 | "maxUInt256" [function]
-                 | "minInt256"  [funciton]
-                 | "maxInt256"  [function]
- // ---------------------------------------
-    rule minInt128  => -170141183460469231731687303715884105728                                        [macro]  /* -2^127     */
-    rule maxInt128  =>  170141183460469231731687303715884105727                                        [macro]  /*  2^127 - 1 */
-    rule maxUInt160 =>  1461501637330902918203684832716283019655932542975                              [macro]  /*  2^160 - 1 */
-    rule maxUInt256 =>  115792089237316195423570985008687907853269984665640564039457584007913129639935 [macro]  /*  2^256 - 1 */
-    rule minInt256  => -57896044618658097711785492504343953926634992332820282019728792003956564819968  [macro]  /* -2^255     */
-    rule maxInt256  =>  57896044618658097711785492504343953926634992332820282019728792003956564819967  [macro]  /*  2^255 - 1 */
 
     syntax Int ::= #signed ( Int ) [function]
  // -----------------------------------------
     rule #signed(DATA) => DATA
-      requires 0 <=Int DATA andBool DATA <=Int maxInt256
+      requires 0 <=Int DATA andBool DATA <=Int maxSInt256
 
     rule #signed(DATA) => pow256 +Int DATA
-      requires minInt256 <=Int DATA andBool DATA <Int 0
+      requires minSInt256 <=Int DATA andBool DATA <Int 0
+
+    syntax WordStack ::= #getData ( TypedArg ) [function]
+ // -----------------------------------------------------
+    rule #getData(X) => #padToWidth(32, #asByteStack(#getValue(X)))
+
+    syntax Int ::= "minSInt128" [function]
+                 | "maxSInt128" [function]
+                 | "minUInt160" [function]
+                 | "maxUInt160" [function]
+                 | "minUInt256" [function]
+                 | "maxUInt256" [function]
+                 | "minSInt256" [funciton]
+                 | "maxSInt256" [function]
+ // ---------------------------------------
+    rule minSInt128 => -170141183460469231731687303715884105728  [macro]  /* -2^127     */
+    rule maxSInt128 =>  170141183460469231731687303715884105727  [macro]  /*  2^127 - 1 */
+    rule minUInt160 => 0  [macro]
+    rule maxUInt160 => 1461501637330902918203684832716283019655932542975  [macro]  /* 2^160 - 1 */
+    rule minUInt256 => 0  [macro]
+    rule maxUInt256 => 115792089237316195423570985008687907853269984665640564039457584007913129639935  [macro]  /*  2^256 - 1 */
+    rule minSInt256 => -57896044618658097711785492504343953926634992332820282019728792003956564819968  [macro]  /* -2^255     */
+    rule maxSInt256 =>  57896044618658097711785492504343953926634992332820282019728792003956564819967  [macro]  /*  2^255 - 1 */
 ```
 
 ### ABI Event Logs
@@ -184,11 +192,6 @@ where `1003892871367861763272476045097431689001461395759728643661426852242313133
     rule #getEventData(E:TypedArg,  ES) => #getData(E) ++ #getEventData(ES)
     rule #getEventData(.EventArgs)      => .WordStack
 
-    syntax Int ::= #getValue ( TypedArg ) [function]
- // ------------------------------------------------
-    rule #getValue(#uint160(V)) => V
-    rule #getValue(#address(V)) => V
-    rule #getValue(#uint256(V)) => V
 ```
 
 ### Hashed Location for Storage


### PR DESCRIPTION
ABI support for `bool`, `int128`, `bytes32`, and `bytes`.

Encoding  for `bytes` is not trivial.

Also, the casper proof is included.