### PR TITLE
plugin: update plugin submodule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,9 +161,9 @@ endif
 		&& ocp-ocamlres -format ocaml plugin/plugin/proto/VERSION -o .build/plugin-$*/apiVersion.ml \
 		&& ocaml-protoc plugin/plugin/proto/*.proto -ml_out .build/plugin-$* \
 		&& cd .build/plugin-$* \
-			&& ocamlfind $(OCAMLC) -c -g -I ../$*/driver-kompiled msg_types.mli msg_types.ml msg_pb.mli msg_pb.ml threadLocal.mli threadLocal.ml apiVersion.ml world.mli world.ml caching.mli caching.ml BLOCKCHAIN.ml KRYPTO.ml \
+			&& ocamlfind $(OCAMLC) -c -g -I ../$*/driver-kompiled msg_types.mli msg_types.ml msg_pb.mli msg_pb.ml apiVersion.ml world.mli world.ml caching.mli caching.ml BLOCKCHAIN.ml KRYPTO.ml \
 								   -package cryptokit -package secp256k1 -package bn128 -package ocaml-protoc -safe-string -thread \
-			&& ocamlfind $(OCAMLC) -a -o semantics.$(LIBEXT) KRYPTO.$(EXT) msg_types.$(EXT) msg_pb.$(EXT) threadLocal.$(EXT) apiVersion.$(EXT) world.$(EXT) caching.$(EXT) BLOCKCHAIN.$(EXT) -thread \
+			&& ocamlfind $(OCAMLC) -a -o semantics.$(LIBEXT) KRYPTO.$(EXT) msg_types.$(EXT) msg_pb.$(EXT) apiVersion.$(EXT) world.$(EXT) caching.$(EXT) BLOCKCHAIN.$(EXT) -thread \
 			&& ocamlfind remove ethereum-semantics-plugin-$* \
 			&& ocamlfind install ethereum-semantics-plugin-$* ../../plugin/plugin/META semantics.* *.cmi *.$(EXT)
 


### PR DESCRIPTION
Updates the KEVM submodule for the VM plugin to the latest version, so that we are using processes instead of threads for the server. This should hopefully fix the memory leak that was reported by IOHK.

Ready for review.