### PR TITLE
evm: no need to push/pop callstack on every opcode

### DIFF
--- a/evm.md
+++ b/evm.md
@@ -328,11 +328,10 @@ The `#next` operator executes a single step by:
 ```k
     rule <mode> EXECMODE </mode>
          <k> #next
-          => #pushCallStack ~> #exceptional? [ OP ]
-                            ~> #load         [ OP ]
-                            ~> #exec         [ OP ]
-                            ~> #pc           [ OP ]
-          ~> #? #dropCallStack : #popCallStack ?#
+          => #exceptional? [ OP ]
+          ~> #load         [ OP ]
+          ~> #exec         [ OP ]
+          ~> #pc           [ OP ]
          ...
          </k>
          <pc> PCOUNT </pc>


### PR DESCRIPTION
Seemed to pass conformance tests for me, should speed up execution a bit. Did not notice much speedup for the conformance tests locally, but perhaps the proofs will benefit.