### PR TITLE
kevm: allow extra options passed on command line for prover

### DIFF
--- a/kevm
+++ b/kevm
@@ -169,32 +169,47 @@ case "$run_command" in
     get-failing)  run_get_failing  "$@" ;;
 
     *) echo "
-    usage: $0 <cmd> <file> <K args>*
+    normal usage
+    ============
 
-       # Running
-       # -------
-       $0 run    <pgm>   Run a single EVM program
-       $0 debug  <pgm>   Run a single EVM program in the debugger
-       $0 search <pgm>   Run a program searching for all execution paths
-       $0 prove  <spec>  Attempt to prove the specification using K's RL prover
+        $0 [run|debug|search] <pgm>  <K args>*
+        $0 prove              <spec> <K args>*
 
-       Note: <pgm> and <spec> here are paths to files.
-       These files should be Ethereum programs/specifications.
+    -   run       Run a single EVM program
+    -   debug     Run a single EVM program in the debugger
+    -   search    Run a program searching for all execution paths
+    -   prove     Attempt to prove the specification using K's RL prover
 
-       Examples:
-       $ $0 run   tests/ethereum-tests/VMTests/vmArithmeticTest/add0.json
-       $ $0 debug tests/interactive/gas-analysis/sumTo10.evm
-       $ $0 prove tests/proofs/specs/examples/sum-to-n-spec.k
+    Note: <pgm> and <spec> here are paths to files.
+    These files should be Ethereum programs/specifications.
 
-       # Testing
-       # -------
-       $0 interpret    <pgm>           Run a single EVM program (in JSON testing format) using fast interpreter
-       $0 test         <pgm> <output>  Run a single EVM program like it's a test
-       $0 test-profile <pgm> <output>  Same as test, but generate list of failing tests and dump timing information
-       $0 sort-logs                    Normalize the test logs for CI servers to use
-       $0 get-failing  [<count>]       Return a list of failing tests, at most <count>.
+    <K args> are any options you want to pass directly to K.
+    Useful <K args> are:
 
-       Note: <output> is the expected output of the given test.
-             These commands are more for devs and CI servers.
+    -   --debug: output more debugging information when running/proving.
+
+    Examples:
+
+        $ $0 run   tests/ethereum-tests/VMTests/vmArithmeticTest/add0.json
+        $ $0 debug tests/interactive/gas-analysis/sumTo10.evm
+        $ $0 prove tests/proofs/specs/examples/sum-to-n-spec.k
+
+    ci usage
+    ========
+
+    These commands are more for devs and CI servers.
+
+        $0 interpret           <pgm>
+        $0 [test|test-profile] <pgm> <output>
+        $0 sort-logs
+        $0 get-failing [<count>]
+
+    -   interpret      Run a single EVM program (in JSON testing format) using fast interpreter
+    -   test           Run a single EVM program like it's a test
+    -   test-profile   Same as test, but generate list of failing tests and dump timing information
+    -   sort-logs      Normalize the test logs for CI servers to use
+    -   get-failing    Return a list of failing tests, at most <count>.
+
+    Note: <output> is the expected output of the given test.
 " ; exit ;;
 esac

--- a/kevm
+++ b/kevm
@@ -72,7 +72,7 @@ run_proof() {
     [[ -f "$proof_file" ]] || die "$proof_file does not exist"
     run_env "$proof_file"
     export K_OPTS=-Xmx5G
-    kprove --directory "$build_dir/java/" --z3-executable "$proof_file" --def-module VERIFICATION
+    kprove --directory "$build_dir/java/" --z3-executable "$proof_file" --def-module VERIFICATION "$@"
 }
 
 # Dev Commands


### PR DESCRIPTION
Passes options through to `./kevm prove`.