### PR TITLE
.gitmodules: switch to new K submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,7 +5,7 @@
 	ignore = untracked
 [submodule ".build/k"]
 	path = .build/k
-	url = https://github.com/runtimeverification/k
+	url = https://github.com/kframework/k
 	ignore = untracked
 [submodule ".build/secp256k1"]
 	path = .build/secp256k1


### PR DESCRIPTION
Simple change, switches to https://github.com/kframework/k from https://github.com/runtimeverification/k for the K submodule.