### PR TITLE
update ocaml to 4.06.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ ocaml-deps: .build/local/lib/pkgconfig/libsecp256k1.pc
 	opam repository add k "$(K_SUBMODULE)/k-distribution/target/release/k/lib/opam" \
 		|| opam repository set-url k "$(K_SUBMODULE)/k-distribution/target/release/k/lib/opam"
 	opam update
-	opam switch 4.03.0+k
+	opam switch 4.06.1+k
 	eval $$(opam config env) \
 		opam install --yes mlgmp zarith uuidm cryptokit secp256k1.0.3.2 bn128 ocaml-protoc rlp yojson hex ocp-ocamlres
 


### PR DESCRIPTION
When I ran OCaml 4.03.0 on Ubuntu 18.04 I noticed a very serious performance regression in which 99% of the execution time was spent in the kernel doing page faults. I don't really have any idea what caused this, but OCaml 4.03,0 is several years old now and so I upgraded KEVM to OCaml 4.06.1 in make deps. This has been tested and opam builds and installs everything completely fine. This seems to resolve the issue, so I don't see the benefit of investigating any further.