### PR TITLE
data.md: add rules reducing IMaps with provably equal key entries

### DIFF
--- a/data.md
+++ b/data.md
@@ -960,5 +960,24 @@ module EVM-DATA-SYMBOLIC [symbolic]
 
 //  syntax IMap ::= ".IMap" [function, smtlib(emptyIMap), smt-prelude] // (define-fun emptyIMap () IMap ((as const IMap) 0))
 //  rule select(.IMap, _) => 0
+
+
+    syntax Bool ::= "#inKeys" "(" IMap "," Int ")" [function]
+
+    rule #inKeys(.IMap, A) => false
+    rule #inKeys(store(M, K, V), K0) => #inKeys(M, K0)
+        requires K =/=Int K0
+
+    rule #inKeys(store(M, K, V), K0) => true
+        requires K ==Int K0
+
+    //Reduces IMaps where multiple entries share the same key
+    rule store(store(M, K0, V0), K1, V1) => store(M, K0, V1)
+        requires K0 ==Int K1
+
+    rule store(store(M, K0, V0), K1, V1) => store(store(M, K1, V1), K0, V0)
+        requires K0 =/=Int K1
+        andBool #inKeys(M, K1)
+
 endmodule
 ```


### PR DESCRIPTION
Curious what you think about this @daejunpark . Without this, a simple token examples' storage ends up looking like:
```
store 
    (store 
         ( store 
                ( store ( M , keccakIntList ( ABI_To  0  .IntList ) , ToBal )
         , keccakIntList ( CALLER_ID  0  .IntList), FromBal)
   , keccakIntList ( CALLER_ID  0  .IntList), FromBal -Int ABI_Value )
, keccakIntList ( ABI_To  0  .IntList ) , ToBal +Int ABI_Value)"
```
while with it, it looks nice and tidy like:
```
store(store(M, keccakIntList ( ABI_To  0  .IntList ) , ToBal +Int ABI_Value), keccakIntList ( CALLER_ID  0  .IntList), FromBal -Int ABI_Value )
```