### PR TITLE
.build/k: update k submodule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ $(K_SUBMODULE)/make.timestamp:
 	@echo "== submodule: $@"
 	git submodule update --init -- $(K_SUBMODULE)
 	cd $(K_SUBMODULE) \
-	    && mvn package -q -DskipTests -U
+	    && mvn package -q -DskipTests -U -Dllvm.backend.skip
 	touch $(K_SUBMODULE)/make.timestamp
 
 $(PANDOC_TANGLE_SUBMODULE)/make.timestamp:


### PR DESCRIPTION
This should fix builds of evm to use the new s3 endpoint, so it should be merged as soon as it passes.