### PR TITLE
Use previousGas cell as callGas cell, calculate all gas/refunds ahead of time

### DIFF
--- a/driver.md
+++ b/driver.md
@@ -140,7 +140,7 @@ To do so, we'll extend sort `JSON` with some EVM specific syntax, and provide a 
          <account>
            <acctID> ACCTFROM </acctID>
            <balance> BAL => BAL -Int (GLIMIT *Int GPRICE) </balance>
-           <nonce> NONCE => NONCE +Int 1 </nonce>
+           <nonce> NONCE </nonce>
            ...
          </account>
          <touchedAccounts> _ => SetItem(MINER) </touchedAccounts>

--- a/driver.md
+++ b/driver.md
@@ -148,12 +148,13 @@ To do so, we'll extend sort `JSON` with some EVM specific syntax, and provide a 
     rule <k> loadTx(ACCTFROM)
           => #loadAccount ACCTTO
           ~> #lookupCode  ACCTTO
-          ~> #call ACCTFROM ACCTTO ACCTTO (GLIMIT -Int G0(SCHED, DATA, false)) VALUE VALUE DATA false
+          ~> #call ACCTFROM ACCTTO ACCTTO VALUE VALUE DATA false
           ~> #finishTx ~> #finalizeTx(false) ~> startTx
          ...
          </k>
          <schedule> SCHED </schedule>
          <gasPrice> _ => GPRICE </gasPrice>
+         <previousGas> _ => GLIMIT -Int G0(SCHED, DATA, false) </previousGas>
          <origin> _ => ACCTFROM </origin>
          <callDepth> _ => -1 </callDepth>
          <txPending> ListItem(TXID:Int) ... </txPending>

--- a/driver.md
+++ b/driver.md
@@ -118,12 +118,13 @@ To do so, we'll extend sort `JSON` with some EVM specific syntax, and provide a 
  // ---------------------------------------------
     rule <k> loadTx(ACCTFROM)
           => #loadAccount #newAddr(ACCTFROM, NONCE)
-          ~> #create ACCTFROM #newAddr(ACCTFROM, NONCE) (GLIMIT -Int G0(SCHED, CODE, true)) VALUE CODE
+          ~> #create ACCTFROM #newAddr(ACCTFROM, NONCE) VALUE CODE
           ~> #finishTx ~> #finalizeTx(false) ~> startTx
          ...
          </k>
          <schedule> SCHED </schedule>
          <gasPrice> _ => GPRICE </gasPrice>
+         <previousGas> _ => GLIMIT -Int G0(SCHED, CODE, true) </previousGas>
          <origin> _ => ACCTFROM </origin>
          <callDepth> _ => -1 </callDepth>
          <txPending> ListItem(TXID:Int) ... </txPending>

--- a/evm-node.md
+++ b/evm-node.md
@@ -141,13 +141,14 @@ Because the same account may be loaded more than once, implementations of this i
 
     rule <k> runVM(true, _, ACCTFROM, _, ARGS, VALUE, GPRICE, GAVAIL, CB, DIFF, NUMB, GLIMIT, TS, _)
           => #loadAccount #newAddr(ACCTFROM, NONCE -Int 1)
-          ~> #create ACCTFROM #newAddr(ACCTFROM, NONCE -Int 1) GAVAIL VALUE #parseByteStackRaw(ARGS)
+          ~> #create ACCTFROM #newAddr(ACCTFROM, NONCE -Int 1) VALUE #parseByteStackRaw(ARGS)
           ~> #codeDeposit #newAddr(ACCTFROM, NONCE -Int 1)
           ~> #endCreate
          ...
          </k>
          <schedule> SCHED </schedule>
          <gasPrice> _ => GPRICE </gasPrice>
+         <previousGas> _ => GAVAIL </previousGas>
          <origin> _ => ACCTFROM </origin>
          <callDepth> _ => -1 </callDepth>
          <coinbase> _ => CB </coinbase>

--- a/evm-node.md
+++ b/evm-node.md
@@ -167,12 +167,13 @@ Because the same account may be loaded more than once, implementations of this i
     rule <k> runVM(false, ACCTTO, ACCTFROM, _, ARGS, VALUE, GPRICE, GAVAIL, CB, DIFF, NUMB, GLIMIT, TS, _)
           => #loadAccount ACCTTO
           ~> #lookupCode ACCTTO
-          ~> #call ACCTFROM ACCTTO ACCTTO GAVAIL VALUE VALUE #parseByteStackRaw(ARGS) false
+          ~> #call ACCTFROM ACCTTO ACCTTO VALUE VALUE #parseByteStackRaw(ARGS) false
           ~> #endVM
          ...
          </k>
          <schedule> SCHED </schedule>
          <gasPrice> _ => GPRICE </gasPrice>
+         <previousGas> _ => GAVAIL </previousGas>
          <origin> _ => ACCTFROM </origin>
          <callDepth> _ => -1 </callDepth>
          <coinbase> _ => CB </coinbase>

--- a/evm.md
+++ b/evm.md
@@ -1291,10 +1291,10 @@ The various `CALL*` (and other inter-contract control flow) operations will be d
 
 ```k
     syntax InternalOp ::= "#checkCall" Int Int
-                        | "#call" Int Int Int Int Int Int WordStack Bool
+                        | "#call"         Int Int Int Int Int Int WordStack Bool
                         | "#callWithCode" Int Int Map WordStack Int Int Int WordStack Bool
-                        | "#mkCall" Int Int Map WordStack Int Int Int WordStack Bool
- // --------------------------------------------------------------------------------
+                        | "#mkCall"       Int Int Map WordStack Int     Int WordStack Bool
+ // --------------------------------------------------------------------------------------
     rule <k> #checkCall ACCT VALUE
           => #refund GCALL ~> #pushCallStack ~> #pushWorldState
           ~> #end #if VALUE >Int BAL #then EVMC_BALANCE_UNDERFLOW #else EVMC_CALL_DEPTH_EXCEEDED #fi
@@ -1349,11 +1349,11 @@ The various `CALL*` (and other inter-contract control flow) operations will be d
     rule <k> #callWithCode ACCTFROM ACCTTO CODE BYTES GLIMIT VALUE APPVALUE ARGS STATIC
           => #pushCallStack ~> #pushWorldState
           ~> #transferFunds ACCTFROM ACCTTO VALUE
-          ~> #mkCall ACCTFROM ACCTTO CODE BYTES GLIMIT VALUE APPVALUE ARGS STATIC
+          ~> #mkCall ACCTFROM ACCTTO CODE BYTES GLIMIT APPVALUE ARGS STATIC
          ...
          </k>
 
-    rule <k> #mkCall ACCTFROM ACCTTO CODE BYTES GLIMIT VALUE APPVALUE ARGS STATIC:Bool
+    rule <k> #mkCall ACCTFROM ACCTTO CODE BYTES GLIMIT APPVALUE ARGS STATIC:Bool
           => #initVM ~> #execute
          ...
          </k>

--- a/evm.md
+++ b/evm.md
@@ -748,7 +748,7 @@ These are just used by the other operators for shuffling local execution state a
            <nonce>  NONCE </nonce>
            ...
          </account>
-      requires CODE =/=K .WordStack orBool NONCE =/=K 0
+      requires CODE =/=K .WordStack orBool NONCE =/=Int 0
 
     rule <k> #newAccount ACCT => . ... </k>
          <account>
@@ -1920,7 +1920,7 @@ The intrinsic gas calculation mirrors the style of the YellowPaper (appendix H).
          <schedule> SCHED </schedule>
 
     rule <k> #gasExec(SCHED, EXP W0 0)  => Gexp < SCHED > ... </k>
-    rule <k> #gasExec(SCHED, EXP W0 W1) => Gexp < SCHED > +Int (Gexpbyte < SCHED > *Int (1 +Int (log256Int(W1)))) ... </k> requires W1 =/=K 0
+    rule <k> #gasExec(SCHED, EXP W0 W1) => Gexp < SCHED > +Int (Gexpbyte < SCHED > *Int (1 +Int (log256Int(W1)))) ... </k> requires W1 =/=Int 0
 
     rule <k> #gasExec(SCHED, CALLDATACOPY    _ _ WIDTH) => Gverylow     < SCHED > +Int (Gcopy < SCHED > *Int (WIDTH up/Int 32)) ... </k>
     rule <k> #gasExec(SCHED, RETURNDATACOPY  _ _ WIDTH) => Gverylow     < SCHED > +Int (Gcopy < SCHED > *Int (WIDTH up/Int 32)) ... </k>
@@ -2149,7 +2149,7 @@ There are several helpers for calculating gas (most of them also specified in th
       => #if ISEMPTY andBool (VALUE =/=Int 0 orBool Gzerovaluenewaccountgas << SCHED >>) #then Gnewaccount < SCHED > #else 0 #fi
 
     rule Cxfer(SCHED, 0) => 0
-    rule Cxfer(SCHED, N) => Gcallvalue < SCHED > requires N =/=K 0
+    rule Cxfer(SCHED, N) => Gcallvalue < SCHED > requires N =/=Int 0
 
     rule Cmem(SCHED, N) => (N *Int Gmemory < SCHED >) +Int ((N *Int N) /Int Gquadcoeff < SCHED >)
 

--- a/evm.md
+++ b/evm.md
@@ -1276,10 +1276,10 @@ The various `CALL*` (and other inter-contract control flow) operations will be d
 
 ```k
     syntax InternalOp ::= "#checkCall" Int Int
-                        | "#call"         Int Int Int Int Int Int WordStack Bool
-                        | "#callWithCode" Int Int Map WordStack Int Int Int WordStack Bool
-                        | "#mkCall"       Int Int Map WordStack Int     Int WordStack Bool
- // --------------------------------------------------------------------------------------
+                        | "#call"         Int Int Int Int Int WordStack Bool
+                        | "#callWithCode" Int Int Map WordStack Int Int WordStack Bool
+                        | "#mkCall"       Int Int Map WordStack     Int WordStack Bool
+ // ----------------------------------------------------------------------------------
     rule <k> #checkCall ACCT VALUE
           => #refund GCALL ~> #pushCallStack ~> #pushWorldState
           ~> #end #if VALUE >Int BAL #then EVMC_BALANCE_UNDERFLOW #else EVMC_CALL_DEPTH_EXCEEDED #fi
@@ -1304,15 +1304,15 @@ The various `CALL*` (and other inter-contract control flow) operations will be d
          </account>
       requires notBool (VALUE >Int BAL orBool CD >=Int 1024)
 
-    rule <k> #call ACCTFROM ACCTTO ACCTCODE GLIMIT VALUE APPVALUE ARGS STATIC
-          => #callWithCode ACCTFROM ACCTTO (0 |-> #precompiled(ACCTCODE)) .WordStack GLIMIT VALUE APPVALUE ARGS STATIC
+    rule <k> #call ACCTFROM ACCTTO ACCTCODE VALUE APPVALUE ARGS STATIC
+          => #callWithCode ACCTFROM ACCTTO (0 |-> #precompiled(ACCTCODE)) .WordStack VALUE APPVALUE ARGS STATIC
          ...
          </k>
          <schedule> SCHED </schedule>
       requires ACCTCODE in #precompiledAccounts(SCHED)
 
-    rule <k> #call ACCTFROM ACCTTO ACCTCODE GLIMIT VALUE APPVALUE ARGS STATIC
-          => #callWithCode ACCTFROM ACCTTO #asMapOpCodes(#dasmOpCodes(CODE, SCHED)) CODE GLIMIT VALUE APPVALUE ARGS STATIC
+    rule <k> #call ACCTFROM ACCTTO ACCTCODE VALUE APPVALUE ARGS STATIC
+          => #callWithCode ACCTFROM ACCTTO #asMapOpCodes(#dasmOpCodes(CODE, SCHED)) CODE VALUE APPVALUE ARGS STATIC
          ...
          </k>
          <schedule> SCHED </schedule>
@@ -1323,22 +1323,22 @@ The various `CALL*` (and other inter-contract control flow) operations will be d
          </account>
       requires notBool ACCTCODE in #precompiledAccounts(SCHED)
 
-    rule <k> #call ACCTFROM ACCTTO ACCTCODE GLIMIT VALUE APPVALUE ARGS STATIC
-          => #callWithCode ACCTFROM ACCTTO .Map .WordStack GLIMIT VALUE APPVALUE ARGS STATIC
+    rule <k> #call ACCTFROM ACCTTO ACCTCODE VALUE APPVALUE ARGS STATIC
+          => #callWithCode ACCTFROM ACCTTO .Map .WordStack VALUE APPVALUE ARGS STATIC
          ...
          </k>
          <activeAccounts> ACCTS </activeAccounts>
          <schedule> SCHED </schedule>
       requires notBool ACCTCODE in #precompiledAccounts(SCHED) andBool notBool ACCTCODE in ACCTS
 
-    rule <k> #callWithCode ACCTFROM ACCTTO CODE BYTES GLIMIT VALUE APPVALUE ARGS STATIC
+    rule <k> #callWithCode ACCTFROM ACCTTO CODE BYTES VALUE APPVALUE ARGS STATIC
           => #pushCallStack ~> #pushWorldState
           ~> #transferFunds ACCTFROM ACCTTO VALUE
-          ~> #mkCall ACCTFROM ACCTTO CODE BYTES GLIMIT APPVALUE ARGS STATIC
+          ~> #mkCall ACCTFROM ACCTTO CODE BYTES APPVALUE ARGS STATIC
          ...
          </k>
 
-    rule <k> #mkCall ACCTFROM ACCTTO CODE BYTES GLIMIT APPVALUE ARGS STATIC:Bool
+    rule <k> #mkCall ACCTFROM ACCTTO CODE BYTES APPVALUE ARGS STATIC:Bool
           => #initVM ~> #execute
          ...
          </k>
@@ -1346,7 +1346,8 @@ The various `CALL*` (and other inter-contract control flow) operations will be d
          <callData> _ => ARGS </callData>
          <callValue> _ => APPVALUE </callValue>
          <id> _ => ACCTTO </id>
-         <gas> _ => GLIMIT </gas>
+         <gas> _ => GCALL </gas>
+         <previousGas> GCALL => 0 </previousGas>
          <caller> _ => ACCTFROM </caller>
          <program> _ => CODE </program>
          <programBytes> _ => BYTES </programBytes>
@@ -1410,33 +1411,31 @@ For each `CALL*` operation, we make a corresponding call to `#call` and a state-
  // ------------------------
     rule <k> CALL GCAP ACCTTO VALUE ARGSTART ARGWIDTH RETSTART RETWIDTH
           => #checkCall ACCTFROM VALUE
-          ~> #call ACCTFROM ACCTTO ACCTTO GCALL VALUE VALUE #range(LM, ARGSTART, ARGWIDTH) false
+          ~> #call ACCTFROM ACCTTO ACCTTO VALUE VALUE #range(LM, ARGSTART, ARGWIDTH) false
           ~> #return RETSTART RETWIDTH
          ...
          </k>
          <schedule> SCHED </schedule>
          <id> ACCTFROM </id>
          <localMem> LM </localMem>
-         <previousGas> GCALL </previousGas>
 
     syntax CallOp ::= "CALLCODE"
  // ----------------------------
     rule <k> CALLCODE GCAP ACCTTO VALUE ARGSTART ARGWIDTH RETSTART RETWIDTH
           => #checkCall ACCTFROM VALUE
-          ~> #call ACCTFROM ACCTFROM ACCTTO GCALL VALUE VALUE #range(LM, ARGSTART, ARGWIDTH) false
+          ~> #call ACCTFROM ACCTFROM ACCTTO VALUE VALUE #range(LM, ARGSTART, ARGWIDTH) false
           ~> #return RETSTART RETWIDTH
          ...
          </k>
          <schedule> SCHED </schedule>
          <id> ACCTFROM </id>
          <localMem> LM </localMem>
-         <previousGas> GCALL </previousGas>
 
     syntax CallSixOp ::= "DELEGATECALL"
  // -----------------------------------
     rule <k> DELEGATECALL GCAP ACCTTO ARGSTART ARGWIDTH RETSTART RETWIDTH
           => #checkCall ACCTFROM 0
-          ~> #call ACCTAPPFROM ACCTFROM ACCTTO GCALL 0 VALUE #range(LM, ARGSTART, ARGWIDTH) false
+          ~> #call ACCTAPPFROM ACCTFROM ACCTTO 0 VALUE #range(LM, ARGSTART, ARGWIDTH) false
           ~> #return RETSTART RETWIDTH
          ...
          </k>
@@ -1445,20 +1444,18 @@ For each `CALL*` operation, we make a corresponding call to `#call` and a state-
          <caller> ACCTAPPFROM </caller>
          <callValue> VALUE </callValue>
          <localMem> LM </localMem>
-         <previousGas> GCALL </previousGas>
 
     syntax CallSixOp ::= "STATICCALL"
  // ---------------------------------
     rule <k> STATICCALL GCAP ACCTTO ARGSTART ARGWIDTH RETSTART RETWIDTH
           => #checkCall ACCTFROM 0
-          ~> #call ACCTFROM ACCTTO ACCTTO GCALL 0 0 #range(LM, ARGSTART, ARGWIDTH) true
+          ~> #call ACCTFROM ACCTTO ACCTTO 0 0 #range(LM, ARGSTART, ARGWIDTH) true
           ~> #return RETSTART RETWIDTH
          ...
          </k>
          <schedule> SCHED </schedule>
          <id> ACCTFROM </id>
          <localMem> LM </localMem>
-         <previousGas> GCALL </previousGas>
 ```
 
 ### Account Creation/Deletion

--- a/evm.md
+++ b/evm.md
@@ -1486,7 +1486,7 @@ For each `CALL*` operation, we make a corresponding call to `#call` and a state-
          </account>
       requires VALUE >Int BAL orBool CD >=Int 1024
 
-    rule <k> #checkCreate ACCT VALUE => #incrementNonce ACCT ... </k>
+    rule <k> #checkCreate ACCT VALUE => . ... </k>
          <callDepth> CD </callDepth>
          <account>
            <acctID> ACCT </acctID>
@@ -1496,7 +1496,8 @@ For each `CALL*` operation, we make a corresponding call to `#call` and a state-
       requires notBool (VALUE >Int BAL orBool CD >=Int 1024)
 
     rule <k> #create ACCTFROM ACCTTO GAVAIL VALUE INITCODE
-          => #pushCallStack ~> #pushWorldState
+          => #incrementNonce ACCTFROM
+          ~> #pushCallStack ~> #pushWorldState
           ~> #newAccount ACCTTO
           ~> #transferFunds ACCTFROM ACCTTO VALUE
           ~> #mkCreate ACCTFROM ACCTTO INITCODE GAVAIL VALUE

--- a/evm.md
+++ b/evm.md
@@ -552,7 +552,7 @@ The `CallOp` opcodes all interperet their second argument as an address.
          <memoryUsed> MU => MU' </memoryUsed> <schedule> SCHED </schedule>
 
     rule <k> G:Int ~> #deductGas => #end EVMC_OUT_OF_GAS ... </k> <gas> GAVAIL                  </gas> requires GAVAIL <Int G
-    rule <k> G:Int ~> #deductGas => .                    ... </k> <gas> GAVAIL => GAVAIL -Int G </gas> <previousGas> _ => GAVAIL </previousGas> requires GAVAIL >=Int G
+    rule <k> G:Int ~> #deductGas => .                    ... </k> <gas> GAVAIL => GAVAIL -Int G </gas> requires GAVAIL >=Int G
 
     syntax Int ::= Cmem ( Schedule , Int ) [function, memo]
  // -------------------------------------------------------
@@ -1950,18 +1950,34 @@ The intrinsic gas calculation mirrors the style of the YellowPaper (appendix H).
 
     rule <k> #gasExec(SCHED, LOG(N) _ WIDTH) => (Glog < SCHED > +Int (Glogdata < SCHED > *Int WIDTH) +Int (N *Int Glogtopic < SCHED >)) ... </k>
 
-    rule <k> #gasExec(SCHED, CALL GCAP ACCTTO VALUE _ _ _ _) => Ccall(SCHED, #accountNonexistent(ACCTTO), GCAP, GAVAIL, VALUE) ... </k>
+    rule <k> #gasExec(SCHED, CALL GCAP ACCTTO VALUE _ _ _ _)
+          => #allocateCallGas
+          ~> Ccall(SCHED, #accountNonexistent(ACCTTO), GCAP, GAVAIL, VALUE)
+         ...
+         </k>
          <gas> GAVAIL </gas>
 
-    rule <k> #gasExec(SCHED, CALLCODE GCAP _ VALUE _ _ _ _) => Ccall(SCHED, #accountNonexistent(ACCTFROM), GCAP, GAVAIL, VALUE) ... </k>
+    rule <k> #gasExec(SCHED, CALLCODE GCAP _ VALUE _ _ _ _)
+          => #allocateCallGas
+          ~> Ccall(SCHED, #accountNonexistent(ACCTFROM), GCAP, GAVAIL, VALUE)
+         ...
+         </k>
          <id> ACCTFROM </id>
          <gas> GAVAIL </gas>
 
-    rule <k> #gasExec(SCHED, DELEGATECALL GCAP _ _ _ _ _) => Ccall(SCHED, #accountNonexistent(ACCTFROM), GCAP, GAVAIL, 0) ... </k>
+    rule <k> #gasExec(SCHED, DELEGATECALL GCAP _ _ _ _ _)
+          => #allocateCallGas
+          ~> Ccall(SCHED, #accountNonexistent(ACCTFROM), GCAP, GAVAIL, 0)
+         ...
+         </k>
          <id> ACCTFROM </id>
          <gas> GAVAIL </gas>
 
-    rule <k> #gasExec(SCHED, STATICCALL GCAP ACCTTO _ _ _ _) => Ccall(SCHED, #accountNonexistent(ACCTTO), GCAP, GAVAIL, 0) ... </k>
+    rule <k> #gasExec(SCHED, STATICCALL GCAP ACCTTO _ _ _ _)
+          => #allocateCallGas
+          ~> Ccall(SCHED, #accountNonexistent(ACCTTO), GCAP, GAVAIL, 0)
+         ...
+         </k>
          <gas> GAVAIL </gas>
 
     rule <k> #gasExec(SCHED, SELFDESTRUCT ACCTTO) => Cselfdestruct(SCHED, #accountNonexistent(ACCTTO), BAL) ... </k>
@@ -2067,6 +2083,12 @@ The intrinsic gas calculation mirrors the style of the YellowPaper (appendix H).
     rule <k> #gasExec(_, ECADD)     => 500   ... </k>
     rule <k> #gasExec(_, ECMUL)     => 40000 ... </k>
     rule <k> #gasExec(_, ECPAIRING) => 100000 +Int (#sizeWordStack(DATA) /Int 192) *Int 80000 ... </k> <callData> DATA </callData>
+
+    syntax InternalOp ::= "#allocateCallGas"
+ // ----------------------------------------
+    rule <k> #allocateCallGas => . ... </k>
+         <gas> GAVAIL </gas>
+         <previousGas> _ => GAVAIL </previousGas>
 ```
 
 There are several helpers for calculating gas (most of them also specified in the YellowPaper).

--- a/evm.md
+++ b/evm.md
@@ -1467,8 +1467,8 @@ For each `CALL*` operation, we make a corresponding call to `#call` and a state-
 -   `#codeDeposit_` checks the result of initialization code and whether the code deposit can be paid, indicating an error if not.
 
 ```k
-    syntax InternalOp ::= "#create" Int Int Int Int WordStack
-                        | "#mkCreate" Int Int WordStack Int Int
+    syntax InternalOp ::= "#create"   Int Int Int Int WordStack
+                        | "#mkCreate" Int Int Int Int WordStack
                         | "#checkCreate" Int Int
                         | "#incrementNonce" Int
  // -------------------------------------------
@@ -1500,11 +1500,11 @@ For each `CALL*` operation, we make a corresponding call to `#call` and a state-
           ~> #pushCallStack ~> #pushWorldState
           ~> #newAccount ACCTTO
           ~> #transferFunds ACCTFROM ACCTTO VALUE
-          ~> #mkCreate ACCTFROM ACCTTO INITCODE GAVAIL VALUE
+          ~> #mkCreate ACCTFROM ACCTTO GAVAIL VALUE INITCODE
          ...
          </k>
 
-    rule <k> #mkCreate ACCTFROM ACCTTO INITCODE GAVAIL VALUE
+    rule <k> #mkCreate ACCTFROM ACCTTO GAVAIL VALUE INITCODE
           => #initVM ~> #execute
          ...
          </k>

--- a/evm.md
+++ b/evm.md
@@ -2079,19 +2079,19 @@ There are several helpers for calculating gas (most of them also specified in th
                  | Cselfdestruct ( Schedule , BExp , Int )             [strict(2)]
  // ------------------------------------------------------------------------------
     rule <k> Ccall(SCHED, ISEMPTY:Bool, GCAP, GAVAIL, VALUE)
-          => Cextra(SCHED, VALUE, ISEMPTY) +Int Cgascap(SCHED, GCAP, GAVAIL, Cextra(SCHED, VALUE, ISEMPTY)) ... </k>
+          => Cextra(SCHED, ISEMPTY, VALUE) +Int Cgascap(SCHED, GCAP, GAVAIL, Cextra(SCHED, ISEMPTY, VALUE)) ... </k>
 
     rule <k> Ccallgas(SCHED, ISEMPTY:Bool, GCAP, GAVAIL, VALUE)
-          => Cgascap(SCHED, GCAP, GAVAIL, Cextra(SCHED, VALUE, ISEMPTY)) +Int #if VALUE ==Int 0 #then 0 #else Gcallstipend < SCHED > #fi ... </k>
+          => Cgascap(SCHED, GCAP, GAVAIL, Cextra(SCHED, ISEMPTY, VALUE)) +Int #if VALUE ==Int 0 #then 0 #else Gcallstipend < SCHED > #fi ... </k>
 
     rule <k> Cselfdestruct(SCHED, ISEMPTY:Bool, BAL)
-          => Gselfdestruct < SCHED > +Int Cnew(SCHED, BAL, ISEMPTY andBool Gselfdestructnewaccount << SCHED >>) ... </k>
+          => Gselfdestruct < SCHED > +Int Cnew(SCHED, ISEMPTY andBool Gselfdestructnewaccount << SCHED >>, BAL) ... </k>
 
     syntax Int ::= Cgascap ( Schedule , Int , Int , Int ) [function]
                  | Csstore ( Schedule , Int , Int , Int ) [function]
                  | Rsstore ( Schedule , Int , Int , Int ) [function]
-                 | Cextra  ( Schedule , Int , Bool )      [function]
-                 | Cnew    ( Schedule , Int , Bool )      [function]
+                 | Cextra  ( Schedule , Bool , Int )      [function]
+                 | Cnew    ( Schedule , Bool , Int )      [function]
                  | Cxfer   ( Schedule , Int )             [function]
  // ----------------------------------------------------------------
     rule Cgascap(SCHED, GCAP, GAVAIL, GEXTRA)
@@ -2125,10 +2125,10 @@ There are several helpers for calculating gas (most of them also specified in th
       => #if CURR =/=Int 0 andBool NEW ==Int 0 #then Rsstoreclear < SCHED > #else 0 #fi
       requires notBool Ghasdirtysstore << SCHED >>
 
-    rule Cextra(SCHED, VALUE, ISEMPTY)
-      => Gcall < SCHED > +Int Cnew(SCHED, VALUE, ISEMPTY) +Int Cxfer(SCHED, VALUE)
+    rule Cextra(SCHED, ISEMPTY, VALUE)
+      => Gcall < SCHED > +Int Cnew(SCHED, ISEMPTY, VALUE) +Int Cxfer(SCHED, VALUE)
 
-    rule Cnew(SCHED, VALUE, ISEMPTY:Bool)
+    rule Cnew(SCHED, ISEMPTY:Bool, VALUE)
       => #if ISEMPTY andBool (VALUE =/=Int 0 orBool Gzerovaluenewaccountgas << SCHED >>) #then Gnewaccount < SCHED > #else 0 #fi
 
     rule Cxfer(SCHED, 0) => 0

--- a/evm.md
+++ b/evm.md
@@ -1295,8 +1295,8 @@ The various `CALL*` (and other inter-contract control flow) operations will be d
                         | "#callWithCode" Int Int Map WordStack Int Int Int WordStack Bool
                         | "#mkCall" Int Int Map WordStack Int Int Int WordStack Bool
  // --------------------------------------------------------------------------------
-    rule <k> #checkCall ACCT VALUE ~> #call _ _ _ GLIMIT _ _ _ _
-          => #refund GLIMIT ~> #pushCallStack ~> #pushWorldState
+    rule <k> #checkCall ACCT VALUE
+          => #refund GCALL ~> #pushCallStack ~> #pushWorldState
           ~> #end #if VALUE >Int BAL #then EVMC_BALANCE_UNDERFLOW #else EVMC_CALL_DEPTH_EXCEEDED #fi
          ...
          </k>
@@ -1307,6 +1307,7 @@ The various `CALL*` (and other inter-contract control flow) operations will be d
            <balance> BAL </balance>
            ...
          </account>
+         <previousGas> GCALL </previousGas>
       requires VALUE >Int BAL orBool CD >=Int 1024
 
      rule <k> #checkCall ACCT VALUE => . ... </k>

--- a/evm.md
+++ b/evm.md
@@ -728,8 +728,7 @@ Operator `#revOps` can be used to reverse a program.
     rule #asMapOpCodes( OPS::OpCodes ) => #asMapOpCodesAux(0, OPS, .Map)
 
     rule #asMapOpCodesAux( N , .OpCodes         , MAP ) => MAP
-    rule #asMapOpCodesAux( N , OP:OpCode  ; OCS , MAP ) => #asMapOpCodesAux(N +Int 1, OCS, MAP [ N <- OP ]) requires notBool isPushOp(OP)
-    rule #asMapOpCodesAux( N , PUSH(M, W) ; OCS , MAP ) => #asMapOpCodesAux(N +Int 1 +Int M, OCS, MAP [ N <- PUSH(M, W) ])
+    rule #asMapOpCodesAux( N , OP:OpCode  ; OCS , MAP ) => #asMapOpCodesAux(N +Int #widthOp(OP), OCS, MAP [ N <- OP ])
 ```
 
 EVM OpCodes

--- a/evm.md
+++ b/evm.md
@@ -1469,33 +1469,8 @@ For each `CALL*` operation, we make a corresponding call to `#call` and a state-
 ```k
     syntax InternalOp ::= "#create"   Int Int Int Int WordStack
                         | "#mkCreate" Int Int Int Int WordStack
-                        | "#checkCreate" Int Int
                         | "#incrementNonce" Int
  // -------------------------------------------
-    rule <k> #checkCreate ACCT VALUE
-          => #refund GCALL ~> #pushCallStack ~> #pushWorldState
-          ~> #end #if VALUE >Int BAL #then EVMC_BALANCE_UNDERFLOW #else EVMC_CALL_DEPTH_EXCEEDED #fi
-         ...
-         </k>
-         <callDepth> CD </callDepth>
-         <output> _ => .WordStack </output>
-         <account>
-           <acctID> ACCT </acctID>
-           <balance> BAL </balance>
-           ...
-         </account>
-         <previousGas> GCALL </previousGas>
-      requires VALUE >Int BAL orBool CD >=Int 1024
-
-    rule <k> #checkCreate ACCT VALUE => . ... </k>
-         <callDepth> CD </callDepth>
-         <account>
-           <acctID> ACCT </acctID>
-           <balance> BAL </balance>
-           ...
-         </account>
-      requires notBool (VALUE >Int BAL orBool CD >=Int 1024)
-
     rule <k> #create ACCTFROM ACCTTO GAVAIL VALUE INITCODE
           => #incrementNonce ACCTFROM
           ~> #pushCallStack ~> #pushWorldState
@@ -1592,7 +1567,7 @@ For each `CALL*` operation, we make a corresponding call to `#call` and a state-
     syntax TernStackOp ::= "CREATE"
  // -------------------------------
     rule <k> CREATE VALUE MEMSTART MEMWIDTH
-          => #checkCreate ACCT VALUE
+          => #checkCall ACCT VALUE
           ~> #create ACCT #newAddr(ACCT, NONCE) GCALL VALUE #range(LM, MEMSTART, MEMWIDTH)
           ~> #codeDeposit #newAddr(ACCT, NONCE)
          ...
@@ -1617,7 +1592,7 @@ have been paid, and it may be to expensive to compute the hash of the init code.
  // --------------------------------
     rule <k> CREATE2 VALUE MEMSTART MEMWIDTH SALT
           => #loadAccount #newAddr(ACCT, SALT, #range(LM, MEMSTART, MEMWIDTH))
-          ~> #checkCreate ACCT VALUE
+          ~> #checkCall ACCT VALUE
           ~> #create ACCT #newAddr(ACCT, SALT, #range(LM, MEMSTART, MEMWIDTH)) GCALL VALUE #range(LM, MEMSTART, MEMWIDTH)
           ~> #codeDeposit #newAddr(ACCT, SALT, #range(LM, MEMSTART, MEMWIDTH))
          ...

--- a/evm.md
+++ b/evm.md
@@ -1271,11 +1271,8 @@ These rules reach into the network state and load/store from account storage:
          <account>
            <acctID> ACCT </acctID>
            <storage> STORAGE => STORAGE [ INDEX <- NEW ] </storage>
-           <origStorage> ORIGSTORAGE </origStorage>
            ...
          </account>
-         <refund> R => R +Int Rsstore(SCHED, NEW, #lookup(STORAGE, INDEX), #lookup(ORIGSTORAGE, INDEX)) </refund>
-         <schedule> SCHED </schedule>
 ```
 
 ### Call Operations
@@ -1933,7 +1930,7 @@ The intrinsic gas calculation mirrors the style of the YellowPaper (appendix H).
 ```k
     syntax InternalOp ::= #gasExec ( Schedule , OpCode )
  // ----------------------------------------------------
-    rule <k> #gasExec(SCHED, SSTORE INDEX VALUE) => Csstore(SCHED, VALUE, #lookup(STORAGE, INDEX), #lookup(ORIGSTORAGE, INDEX)) ... </k>
+    rule <k> #gasExec(SCHED, SSTORE INDEX NEW) => Csstore(SCHED, NEW, #lookup(STORAGE, INDEX), #lookup(ORIGSTORAGE, INDEX)) ... </k>
          <id> ACCT </id>
          <account>
            <acctID> ACCT </acctID>
@@ -1941,6 +1938,8 @@ The intrinsic gas calculation mirrors the style of the YellowPaper (appendix H).
            <origStorage> ORIGSTORAGE </origStorage>
            ...
          </account>
+         <refund> R => R +Int Rsstore(SCHED, NEW, #lookup(STORAGE, INDEX), #lookup(ORIGSTORAGE, INDEX)) </refund>
+         <schedule> SCHED </schedule>
 
     rule <k> #gasExec(SCHED, EXP W0 0)  => Gexp < SCHED > ... </k>
     rule <k> #gasExec(SCHED, EXP W0 W1) => Gexp < SCHED > +Int (Gexpbyte < SCHED > *Int (1 +Int (log256Int(W1)))) ... </k> requires W1 =/=K 0

--- a/evm.md
+++ b/evm.md
@@ -1652,8 +1652,7 @@ Self destructing to yourself, unlike a regular transfer, destroys the balance in
     rule <k> SELFDESTRUCT ACCTTO => #transferFunds ACCT ACCTTO BALFROM ~> #end EVMC_SUCCESS ... </k>
          <schedule> SCHED </schedule>
          <id> ACCT </id>
-         <selfDestruct> SDS (.Set => SetItem(ACCT)) </selfDestruct>
-         <refund> RF => #if ACCT in SDS #then RF #else RF +Word Rselfdestruct < SCHED > #fi </refund>
+         <selfDestruct> ... (.Set => SetItem(ACCT)) ... </selfDestruct>
          <account>
            <acctID> ACCT </acctID>
            <balance> BALFROM </balance>
@@ -1666,8 +1665,7 @@ Self destructing to yourself, unlike a regular transfer, destroys the balance in
     rule <k> SELFDESTRUCT ACCT => #end EVMC_SUCCESS ... </k>
          <schedule> SCHED </schedule>
          <id> ACCT </id>
-         <selfDestruct> SDS (.Set => SetItem(ACCT)) </selfDestruct>
-         <refund> RF => #if ACCT in SDS #then RF #else RF +Word Rselfdestruct < SCHED > #fi </refund>
+         <selfDestruct> ... (.Set => SetItem(ACCT)) ... </selfDestruct>
          <account>
            <acctID> ACCT </acctID>
            <balance> BALFROM => 0 </balance>
@@ -1970,6 +1968,8 @@ The intrinsic gas calculation mirrors the style of the YellowPaper (appendix H).
 
     rule <k> #gasExec(SCHED, SELFDESTRUCT ACCTTO) => Cselfdestruct(SCHED, #accountNonexistent(ACCTTO), BAL) ... </k>
          <id> ACCTFROM </id>
+         <selfDestruct> SDS </selfDestruct>
+         <refund> RF => #if ACCTFROM in SDS #then RF #else RF +Word Rselfdestruct < SCHED > #fi </refund>
          <account>
            <acctID> ACCTFROM </acctID>
            <balance> BAL </balance>

--- a/evm.md
+++ b/evm.md
@@ -721,15 +721,6 @@ Lists of opcodes form programs.
     rule #asMapOpCodes( N , .OpCodes         , MAP ) => MAP
     rule #asMapOpCodes( N , OP:OpCode  ; OCS , MAP ) => #asMapOpCodes(N +Int 1, OCS, MAP [ N <- OP ]) requires notBool isPushOp(OP)
     rule #asMapOpCodes( N , PUSH(M, W) ; OCS , MAP ) => #asMapOpCodes(N +Int 1 +Int M, OCS, MAP [ N <- PUSH(M, W) ])
-
-    syntax OpCodes ::= #asOpCodes ( Map )                 [function]
-                     | #asOpCodes ( Int , Map , OpCodes ) [function, klabel(#asOpCodesAux)]
- // ---------------------------------------------------------------------------------------
-    rule #asOpCodes(M) => #asOpCodes(0, M, .OpCodes)
-
-    rule #asOpCodes(N, .Map,               OPS) => OPS
-    rule #asOpCodes(N, N |-> OP         M, OPS) => #asOpCodes(N +Int 1,        M, OP         ; OPS) requires notBool isPushOp(OP)
-    rule #asOpCodes(N, N |-> PUSH(S, W) M, OPS) => #asOpCodes(N +Int 1 +Int S, M, PUSH(S, W) ; OPS)
 ```
 
 EVM OpCodes

--- a/evm.md
+++ b/evm.md
@@ -1472,8 +1472,8 @@ For each `CALL*` operation, we make a corresponding call to `#call` and a state-
                         | "#checkCreate" Int Int
                         | "#incrementNonce" Int
  // -------------------------------------------
-    rule <k> #checkCreate ACCT VALUE ~> #create _ _ GAVAIL _ _
-          => #refund GAVAIL ~> #pushCallStack ~> #pushWorldState
+    rule <k> #checkCreate ACCT VALUE
+          => #refund GCALL ~> #pushCallStack ~> #pushWorldState
           ~> #end #if VALUE >Int BAL #then EVMC_BALANCE_UNDERFLOW #else EVMC_CALL_DEPTH_EXCEEDED #fi
          ...
          </k>
@@ -1484,6 +1484,7 @@ For each `CALL*` operation, we make a corresponding call to `#call` and a state-
            <balance> BAL </balance>
            ...
          </account>
+         <previousGas> GCALL </previousGas>
       requires VALUE >Int BAL orBool CD >=Int 1024
 
     rule <k> #checkCreate ACCT VALUE => . ... </k>

--- a/evm.md
+++ b/evm.md
@@ -713,14 +713,14 @@ Lists of opcodes form programs.
 ### Converting to/from `Map` Representation
 
 ```k
-    syntax Map ::= #asMapOpCodes ( OpCodes )             [function]
-                 | #asMapOpCodes ( Int , OpCodes , Map ) [function, klabel(#asMapOpCodesAux)]
- // -----------------------------------------------------------------------------------------
-    rule #asMapOpCodes( OPS::OpCodes ) => #asMapOpCodes(0, OPS, .Map)
+    syntax Map ::= #asMapOpCodes    ( OpCodes )             [function]
+                 | #asMapOpCodesAux ( Int , OpCodes , Map ) [function]
+ // ------------------------------------------------------------------
+    rule #asMapOpCodes( OPS::OpCodes ) => #asMapOpCodesAux(0, OPS, .Map)
 
-    rule #asMapOpCodes( N , .OpCodes         , MAP ) => MAP
-    rule #asMapOpCodes( N , OP:OpCode  ; OCS , MAP ) => #asMapOpCodes(N +Int 1, OCS, MAP [ N <- OP ]) requires notBool isPushOp(OP)
-    rule #asMapOpCodes( N , PUSH(M, W) ; OCS , MAP ) => #asMapOpCodes(N +Int 1 +Int M, OCS, MAP [ N <- PUSH(M, W) ])
+    rule #asMapOpCodesAux( N , .OpCodes         , MAP ) => MAP
+    rule #asMapOpCodesAux( N , OP:OpCode  ; OCS , MAP ) => #asMapOpCodesAux(N +Int 1, OCS, MAP [ N <- OP ]) requires notBool isPushOp(OP)
+    rule #asMapOpCodesAux( N , PUSH(M, W) ; OCS , MAP ) => #asMapOpCodesAux(N +Int 1 +Int M, OCS, MAP [ N <- PUSH(M, W) ])
 ```
 
 EVM OpCodes

--- a/tests/interactive/gas-analysis/sumTo10.evm.out
+++ b/tests/interactive/gas-analysis/sumTo10.evm.out
@@ -164,7 +164,7 @@
           2
         </memoryUsed>
         <previousGas>
-          999999991
+          0
         </previousGas>
         <static>
           false


### PR DESCRIPTION
These are simplifications/refactorings of the semantics which achieve a couple things:

-   Try to make the #call and #create machinery look more similar to each other.
-   Calculate all gas needed for CALL when calculating the execution gas (so that the semantics don't deal with gas directly, and we get cleaner separation of the "gas" vs "execution" semantics).
-   Similarly, calculate refunds at the same time as calculating execution gas.