### PR TITLE
data: compare with K instead of Int

### DIFF
--- a/data.md
+++ b/data.md
@@ -250,10 +250,10 @@ The corresponding `<op>Word` operations automatically perform the correct modulu
     rule W0 -Word W1 => chop( W0 -Int W1 ) requires W0 >=Int W1
     rule W0 -Word W1 => chop( (W0 +Int pow256) -Int W1 ) requires W0 <Int W1
     rule W0 *Word W1 => chop( W0 *Int W1 )
-    rule W0 /Word W1 => 0                    requires W1  ==Int 0
-    rule W0 /Word W1 => chop( W0 /Int W1 )   requires W1 =/=Int 0
-    rule W0 %Word W1 => 0                    requires W1  ==Int 0
-    rule W0 %Word W1 => chop( W0 modInt W1 ) requires W1 =/=Int 0
+    rule W0 /Word W1 => 0                    requires W1  ==K 0
+    rule W0 /Word W1 => chop( W0 /Int W1 )   requires W1 =/=K 0
+    rule W0 %Word W1 => 0                    requires W1  ==K 0
+    rule W0 %Word W1 => chop( W0 modInt W1 ) requires W1 =/=K 0
 ```
 
 Care is needed for `^Word` to avoid big exponentiation.


### PR DESCRIPTION
It seems that when terms are sorted with `Int` rather than `K`, the K framework will not simplify expressions before they are sent to z3. This means that expressions like:
`W0 /Word abs(W1)` where we know `W1 ==Int 0` to be true will not simplified in the presence of a lemma `rule abs(B) ==Int 0 => B ==Int 0` if the condition is `requires W1 ==Int 0`, but it will if the condition is `requires W1 ==K 0` with lemma `rule abs(B) ==K 0 => B ==K 0`.

I'm not sure whether you consider this "intended behaviour" of K or not. If this is intended, I would suggest to change side conditions in kevm as suggested by this PR, if it is not intended, I can write some regression tests for this. Ping @daejunpark @dwightguth 