### PR TITLE
edsl.md: add uint16 ABI calldata type

### DIFF
--- a/data.md
+++ b/data.md
@@ -57,6 +57,8 @@ These can be used for pattern-matching on the LHS of rules as well (`macro` attr
                  | "maxSInt128"
                  | "minUInt8"
                  | "maxUInt8"
+                 | "minUInt16"
+                 | "maxUInt16"
                  | "minUInt48"
                  | "maxUInt48"
                  | "minUInt128"
@@ -81,6 +83,8 @@ These can be used for pattern-matching on the LHS of rules as well (`macro` attr
 
     rule minUInt8        =>  0                                                                              [macro]
     rule maxUInt8        =>  255                                                                            [macro]
+    rule minUInt16       =>  0                                                                              [macro]
+    rule maxUInt16       =>  65535                                                                          [macro]  /*   2^16 -  1  */
     rule minUInt48       =>  0                                                                              [macro]
     rule maxUInt48       =>  281474976710655                                                                [macro]  /*   2^48 -  1  */
     rule minUInt128      =>  0                                                                              [macro]
@@ -110,6 +114,7 @@ These can be used for pattern-matching on the LHS of rules as well (`macro` attr
     rule #rangeSInt    ( 128 ,      X ) => #range ( minSInt128      <= X <= maxSInt128      ) [macro]
     rule #rangeSInt    ( 256 ,      X ) => #range ( minSInt256      <= X <= maxSInt256      ) [macro]
     rule #rangeUInt    (   8 ,      X ) => #range ( minUInt8        <= X <= maxUInt8        ) [macro]
+    rule #rangeUInt    (  16 ,      X ) => #range ( minUInt16       <= X <= maxUInt16       ) [macro]
     rule #rangeUInt    (  48 ,      X ) => #range ( minUInt48       <= X <= maxUInt48       ) [macro]
     rule #rangeUInt    ( 128 ,      X ) => #range ( minUInt128      <= X <= maxUInt128      ) [macro]
     rule #rangeUInt    ( 256 ,      X ) => #range ( minUInt256      <= X <= maxUInt256      ) [macro]

--- a/edsl.md
+++ b/edsl.md
@@ -38,6 +38,7 @@ where `F1 : F2 : F3 : F4` is the (two's complement) byte-array representation of
                       | #address ( Int )
                       | #uint256 ( Int )
                       | #uint48  ( Int )
+                      | #uint16  ( Int )
                       | #uint8   ( Int )
                       | #int256  ( Int )
                       | #int128  ( Int )
@@ -72,6 +73,7 @@ where `F1 : F2 : F3 : F4` is the (two's complement) byte-array representation of
     rule #typeName(   #address( _ )) => "address"
     rule #typeName(   #uint256( _ )) => "uint256"
     rule #typeName(    #uint48( _ )) => "uint48"
+    rule #typeName(    #uint16( _ )) => "uint16"
     rule #typeName(     #uint8( _ )) => "uint8"
     rule #typeName(    #int256( _ )) => "int256"
     rule #typeName(    #int128( _ )) => "int128"
@@ -107,6 +109,7 @@ where `F1 : F2 : F3 : F4` is the (two's complement) byte-array representation of
     rule #lenOfHead(  #address( _ )) => 32
     rule #lenOfHead(  #uint256( _ )) => 32
     rule #lenOfHead(   #uint48( _ )) => 32
+    rule #lenOfHead(   #uint16( _ )) => 32
     rule #lenOfHead(    #uint8( _ )) => 32
     rule #lenOfHead(   #int256( _ )) => 32
     rule #lenOfHead(   #int128( _ )) => 32
@@ -122,6 +125,7 @@ where `F1 : F2 : F3 : F4` is the (two's complement) byte-array representation of
     rule #isStaticType(  #address( _ )) => true
     rule #isStaticType(  #uint256( _ )) => true
     rule #isStaticType(   #uint48( _ )) => true
+    rule #isStaticType(   #uint16( _ )) => true
     rule #isStaticType(    #uint8( _ )) => true
     rule #isStaticType(   #int256( _ )) => true
     rule #isStaticType(   #int128( _ )) => true
@@ -155,6 +159,7 @@ where `F1 : F2 : F3 : F4` is the (two's complement) byte-array representation of
     rule #enc(#address( DATA )) => #buf(32, #getValue(#address( DATA )))
     rule #enc(#uint256( DATA )) => #buf(32, #getValue(#uint256( DATA )))
     rule #enc( #uint48( DATA )) => #buf(32, #getValue( #uint48( DATA )))
+    rule #enc( #uint16( DATA )) => #buf(32, #getValue( #uint16( DATA )))    
     rule #enc(  #uint8( DATA )) => #buf(32, #getValue(  #uint8( DATA )))
     rule #enc( #int256( DATA )) => #buf(32, #getValue( #int256( DATA )))
     rule #enc( #int128( DATA )) => #buf(32, #getValue( #int128( DATA )))
@@ -188,6 +193,9 @@ where `F1 : F2 : F3 : F4` is the (two's complement) byte-array representation of
 
     rule #getValue(  #uint48( DATA )) => DATA
       requires minUInt48 <=Int DATA andBool DATA <=Int maxUInt48
+
+    rule #getValue(  #uint16( DATA )) => DATA
+      requires minUInt16 <=Int DATA andBool DATA <=Int maxUInt16
 
     rule #getValue(  #uint8( DATA )) => DATA
       requires minUInt8 <=Int DATA andBool DATA <=Int maxUInt8


### PR DESCRIPTION
Not sure what the policy on ABI type inclusion is, but this is a solidity type that came up in a spec we are working on.