### PR TITLE
Simplify branching structure of KEVM, less intermediate steps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -257,6 +257,7 @@ endif
 
 TEST_CONCRETE_BACKEND:=ocaml
 TEST_SYMBOLIC_BACKEND:=java
+TEST:=./kevm
 CHECK:=git --no-pager diff --no-index --ignore-all-space
 
 KEVM_MODE:=NORMAL
@@ -278,22 +279,22 @@ tests/ethereum-tests/VMTests/%: KEVM_MODE=VMTESTS
 tests/ethereum-tests/VMTests/%: KEVM_SCHEDULE=DEFAULT
 
 tests/%.run: tests/%
-	MODE=$(KEVM_MODE) SCHEDULE=$(KEVM_SCHEDULE) ./kevm interpret --backend $(TEST_CONCRETE_BACKEND) $< > tests/$*.$(TEST_CONCRETE_BACKEND)-out \
+	MODE=$(KEVM_MODE) SCHEDULE=$(KEVM_SCHEDULE) $(TEST) interpret --backend $(TEST_CONCRETE_BACKEND) $< > tests/$*.$(TEST_CONCRETE_BACKEND)-out \
 	    || $(CHECK) tests/templates/output-success-$(TEST_CONCRETE_BACKEND).json tests/$*.$(TEST_CONCRETE_BACKEND)-out
 	rm -rf tests/$*.$(TEST_CONCRETE_BACKEND)-out
 
 tests/%.run-interactive: tests/%
-	MODE=$(KEVM_MODE) SCHEDULE=$(KEVM_SCHEDULE) ./kevm run --backend $(TEST_CONCRETE_BACKEND) $< > tests/$*.$(TEST_CONCRETE_BACKEND)-out \
+	MODE=$(KEVM_MODE) SCHEDULE=$(KEVM_SCHEDULE) $(TEST) run --backend $(TEST_CONCRETE_BACKEND) $< > tests/$*.$(TEST_CONCRETE_BACKEND)-out \
 	    || $(CHECK) tests/templates/output-success-$(TEST_CONCRETE_BACKEND).json tests/$*.$(TEST_CONCRETE_BACKEND)-out
 	rm -rf tests/$*.$(TEST_CONCRETE_BACKEND)-out
 
 tests/%.parse: tests/%
-	./kevm kast --backend $(TEST_CONCRETE_BACKEND) $< > $@-out
+	$(TEST) kast --backend $(TEST_CONCRETE_BACKEND) $< > $@-out
 	$(CHECK) $@-expected $@-out
 	rm -rf $@-out
 
 tests/%.prove: tests/%
-	./kevm prove --backend $(TEST_SYMBOLIC_BACKEND) $< --format-failures
+	$(TEST) prove --backend $(TEST_SYMBOLIC_BACKEND) $< --format-failures
 
 # Smoke Tests
 

--- a/evm.md
+++ b/evm.md
@@ -1783,6 +1783,8 @@ In the YellowPaper, each opcode is defined to consume zero gas unless specified 
     rule #memory ( COP:CallOp     _ _ _ ARGSTART ARGWIDTH RETSTART RETWIDTH , MU ) => #memoryUsageUpdate(#memoryUsageUpdate(MU, ARGSTART, ARGWIDTH), RETSTART, RETWIDTH)
     rule #memory ( CSOP:CallSixOp _ _   ARGSTART ARGWIDTH RETSTART RETWIDTH , MU ) => #memoryUsageUpdate(#memoryUsageUpdate(MU, ARGSTART, ARGWIDTH), RETSTART, RETWIDTH)
 
+    rule #memory ( _ , MU ) => MU [owise]
+
     syntax Bool ::= #usesMemory ( OpCode ) [function]
  // -------------------------------------------------
     rule #usesMemory(OP) => isLogOp(OP)
@@ -1800,77 +1802,6 @@ In the YellowPaper, each opcode is defined to consume zero gas unless specified 
                      orBool OP ==K CREATE2
                      orBool OP ==K RETURN
                      orBool OP ==K REVERT
-```
-
-Grumble grumble, K sucks at `owise`.
-
-```k
-    rule #memory(JUMP _,    MU) => MU
-    rule #memory(JUMPI _ _, MU) => MU
-    rule #memory(JUMPDEST,  MU) => MU
-
-    rule #memory(SSTORE _ _,   MU) => MU
-    rule #memory(SLOAD _,      MU) => MU
-
-    rule #memory(ADD _ _,        MU) => MU
-    rule #memory(SUB _ _,        MU) => MU
-    rule #memory(MUL _ _,        MU) => MU
-    rule #memory(DIV _ _,        MU) => MU
-    rule #memory(EXP _ _,        MU) => MU
-    rule #memory(MOD _ _,        MU) => MU
-    rule #memory(SDIV _ _,       MU) => MU
-    rule #memory(SMOD _ _,       MU) => MU
-    rule #memory(SIGNEXTEND _ _, MU) => MU
-    rule #memory(ADDMOD _ _ _,   MU) => MU
-    rule #memory(MULMOD _ _ _,   MU) => MU
-
-    rule #memory(NOT _,     MU) => MU
-    rule #memory(AND _ _,   MU) => MU
-    rule #memory(EVMOR _ _, MU) => MU
-    rule #memory(XOR _ _,   MU) => MU
-    rule #memory(BYTE _ _,  MU) => MU
-    rule #memory(SHL _ _,   MU) => MU
-    rule #memory(SHR _ _,   MU) => MU
-    rule #memory(SAR _ _,   MU) => MU
-    rule #memory(ISZERO _,  MU) => MU
-
-    rule #memory(LT _ _,         MU) => MU
-    rule #memory(GT _ _,         MU) => MU
-    rule #memory(SLT _ _,        MU) => MU
-    rule #memory(SGT _ _,        MU) => MU
-    rule #memory(EQ _ _,         MU) => MU
-
-    rule #memory(POP _,      MU) => MU
-    rule #memory(PUSH(_, _), MU) => MU
-    rule #memory(DUP(_) _,   MU) => MU
-    rule #memory(SWAP(_) _,  MU) => MU
-
-    rule #memory(STOP,           MU) => MU
-    rule #memory(ADDRESS,        MU) => MU
-    rule #memory(ORIGIN,         MU) => MU
-    rule #memory(CALLER,         MU) => MU
-    rule #memory(CALLVALUE,      MU) => MU
-    rule #memory(CALLDATASIZE,   MU) => MU
-    rule #memory(RETURNDATASIZE, MU) => MU
-    rule #memory(CODESIZE,       MU) => MU
-    rule #memory(GASPRICE,       MU) => MU
-    rule #memory(COINBASE,       MU) => MU
-    rule #memory(TIMESTAMP,      MU) => MU
-    rule #memory(NUMBER,         MU) => MU
-    rule #memory(DIFFICULTY,     MU) => MU
-    rule #memory(GASLIMIT,       MU) => MU
-    rule #memory(PC,             MU) => MU
-    rule #memory(MSIZE,          MU) => MU
-    rule #memory(GAS,            MU) => MU
-
-    rule #memory(SELFDESTRUCT _, MU) => MU
-    rule #memory(CALLDATALOAD _, MU) => MU
-    rule #memory(EXTCODESIZE _,  MU) => MU
-    rule #memory(EXTCODEHASH _,  MU) => MU
-    rule #memory(BALANCE _,      MU) => MU
-    rule #memory(BLOCKHASH _,    MU) => MU
-
-    rule #memory(_:PrecompiledOp, MU) => MU
 
     syntax Int ::= #memoryUsageUpdate ( Int , Int , Int ) [function]
  // ----------------------------------------------------------------

--- a/evm.md
+++ b/evm.md
@@ -401,7 +401,7 @@ The `#next [_]` operator initiates execution by:
  // --------------------------------------------
     rule <k> #exec [ IOP:InvalidOp ] => IOP ... </k>
 
-    rule <k> #exec [ OP ] => #gas [ OP ] ~> OP ... </k> requires isInternalOp(OP) orBool isNullStackOp(OP) orBool isPushOp(OP)
+    rule <k> #exec [ OP ] => #gas [ OP ] ~> OP ... </k> requires isNullStackOp(OP) orBool isPushOp(OP)
 ```
 
 Here we load the correct number of arguments from the `wordStack` based on the sort of the opcode.
@@ -418,10 +418,10 @@ Some of them require an argument to be interpereted as an address (modulo 160 bi
                         | TernStackOp Int Int Int
                         | QuadStackOp Int Int Int Int
  // -------------------------------------------------
-    rule <k> #exec [ UOP:UnStackOp   => UOP W0          ] ... </k> <wordStack> W0 : WS                => WS </wordStack>
-    rule <k> #exec [ BOP:BinStackOp  => BOP W0 W1       ] ... </k> <wordStack> W0 : W1 : WS           => WS </wordStack>
-    rule <k> #exec [ TOP:TernStackOp => TOP W0 W1 W2    ] ... </k> <wordStack> W0 : W1 : W2 : WS      => WS </wordStack>
-    rule <k> #exec [ QOP:QuadStackOp => QOP W0 W1 W2 W3 ] ... </k> <wordStack> W0 : W1 : W2 : W3 : WS => WS </wordStack>
+    rule <k> #exec [ UOP:UnStackOp   ] => #gas [ UOP W0          ] ~> UOP W0          ... </k> <wordStack> W0 : WS                => WS </wordStack>
+    rule <k> #exec [ BOP:BinStackOp  ] => #gas [ BOP W0 W1       ] ~> BOP W0 W1       ... </k> <wordStack> W0 : W1 : WS           => WS </wordStack>
+    rule <k> #exec [ TOP:TernStackOp ] => #gas [ TOP W0 W1 W2    ] ~> TOP W0 W1 W2    ... </k> <wordStack> W0 : W1 : W2 : WS      => WS </wordStack>
+    rule <k> #exec [ QOP:QuadStackOp ] => #gas [ QOP W0 W1 W2 W3 ] ~> QOP W0 W1 W2 W3 ... </k> <wordStack> W0 : W1 : W2 : W3 : WS => WS </wordStack>
 ```
 
 `StackOp` is used for opcodes which require a large portion of the stack.
@@ -429,7 +429,7 @@ Some of them require an argument to be interpereted as an address (modulo 160 bi
 ```k
     syntax InternalOp ::= StackOp WordStack
  // ---------------------------------------
-    rule <k> #exec [ SO:StackOp => SO WS ] ... </k> <wordStack> WS </wordStack>
+    rule <k> #exec [ SO:StackOp ] => #gas [ SO WS ] ~> SO WS ... </k> <wordStack> WS </wordStack>
 ```
 
 The `CallOp` opcodes all interperet their second argument as an address.
@@ -438,8 +438,8 @@ The `CallOp` opcodes all interperet their second argument as an address.
     syntax InternalOp ::= CallSixOp Int Int     Int Int Int Int
                         | CallOp    Int Int Int Int Int Int Int
  // -----------------------------------------------------------
-    rule <k> #exec [ CSO:CallSixOp => CSO W0 W1    W2 W3 W4 W5 ] ... </k> <wordStack> W0 : W1 : W2 : W3 : W4 : W5 : WS      => WS </wordStack>
-    rule <k> #exec [ CO:CallOp     => CO  W0 W1 W2 W3 W4 W5 W6 ] ... </k> <wordStack> W0 : W1 : W2 : W3 : W4 : W5 : W6 : WS => WS </wordStack>
+    rule <k> #exec [ CSO:CallSixOp ] => #gas [ CSO W0 W1    W2 W3 W4 W5 ] ~> CSO W0 W1    W2 W3 W4 W5 ... </k> <wordStack> W0 : W1 : W2 : W3 : W4 : W5 : WS      => WS </wordStack>
+    rule <k> #exec [ CO:CallOp     ] => #gas [ CO  W0 W1 W2 W3 W4 W5 W6 ] ~> CO  W0 W1 W2 W3 W4 W5 W6 ... </k> <wordStack> W0 : W1 : W2 : W3 : W4 : W5 : W6 : WS => WS </wordStack>
 ```
 
 ### Helpers
@@ -1843,7 +1843,7 @@ Grumble grumble, K sucks at `owise`.
     syntax Int ::= #memoryUsageUpdate ( Int , Int , Int ) [function]
  // ----------------------------------------------------------------
     rule #memoryUsageUpdate(MU, START, WIDTH) => MU                                       requires WIDTH ==Int 0
-    rule #memoryUsageUpdate(MU, START, WIDTH) => maxInt(MU, (START +Int WIDTH) up/Int 32) requires WIDTH >Int 0  [concrete]
+    rule #memoryUsageUpdate(MU, START, WIDTH) => maxInt(MU, (START +Int WIDTH) up/Int 32) requires WIDTH  >Int 0 [concrete]
 ```
 
 Execution Gas

--- a/evm.md
+++ b/evm.md
@@ -265,24 +265,21 @@ OpCode Execution
 
 ### Execution Macros
 
--   `#execute` calls `#next` repeatedly until it receives an `#end`.
+-   `#execute` loads the next opcode (or halts with `EVMC_SUCCESS` if there is no next opcode).
 
 ```k
     syntax KItem ::= "#execute"
  // ---------------------------
-    rule [step]: <mode> EXECMODE </mode>
-                 <k> (. => #next [ OP ]) ~> #execute ... </k>
+    rule [halt]: <k> #halt ~> (#execute => .) ... </k>
+    rule [step]: <k> (. => #next [ OP ]) ~> #execute ... </k>
                  <pc> PCOUNT </pc>
                  <program> ... PCOUNT |-> OP ... </program>
-              requires EXECMODE in (SetItem(NORMAL) SetItem(VMTESTS))
 
-    rule <k> #execute => #end EVMC_SUCCESS ... </k>
+    rule <k> (. => #end EVMC_SUCCESS) ~> #execute ... </k>
          <pc> PCOUNT </pc>
          <program> PGM </program>
          <output> _ => .WordStack </output>
       requires notBool (PCOUNT in_keys(PGM))
-
-    rule [halt]: <k> #halt ~> (#execute => .) ... </k>
 ```
 
 ### Single Step

--- a/evm.md
+++ b/evm.md
@@ -1738,7 +1738,6 @@ Overall Gas
          <schedule> SCHED </schedule>
 
     rule <k> #memory [ OP ] => #memory(OP, MU) ~> #deductMemory ... </k>
-         <schedule> SCHED </schedule>
          <memoryUsed> MU </memoryUsed>
 
     syntax InternalOp ::= "#gas"    "[" OpCode "]" | "#deductGas"

--- a/evm.md
+++ b/evm.md
@@ -317,7 +317,8 @@ The `#next [_]` operator initiates execution by:
     rule <k> #next [ OP ] => #end EVMC_STATIC_MODE_VIOLATION ... </k>
          <wordStack> WS </wordStack>
          <static> STATIC:Bool </static>
-      requires STATIC andBool #changesState(OP, WS)
+      requires notBool ( #stackUnderflow(WS, OP) orBool #stackOverflow(WS, OP) )
+       andBool STATIC andBool #changesState(OP, WS)
 ```
 
 ### Exceptional Checks

--- a/evm.md
+++ b/evm.md
@@ -386,9 +386,15 @@ The `#next` operator executes a single step by:
 ```k
     syntax InternalOp ::= "#static?" "[" OpCode "]"
  // -----------------------------------------------
-    rule <k> #static? [ OP ] => .                               ... </k>                             <static> false </static>
-    rule <k> #static? [ OP ] => .                               ... </k> <wordStack> WS </wordStack> <static> true  </static> requires notBool #changesState(OP, WS)
-    rule <k> #static? [ OP ] => #end EVMC_STATIC_MODE_VIOLATION ... </k> <wordStack> WS </wordStack> <static> true  </static> requires         #changesState(OP, WS)
+    rule <k> #static? [ OP ] => . ... </k>
+         <wordStack> WS </wordStack>
+         <static> STATIC:Bool </static>
+      requires notBool (STATIC andBool #changesState(OP, WS))
+
+    rule <k> #static? [ OP ] => #end EVMC_STATIC_MODE_VIOLATION ... </k>
+         <wordStack> WS </wordStack>
+         <static> STATIC:Bool </static>
+      requires STATIC andBool #changesState(OP, WS)
 ```
 
 **TODO**: Investigate why using `[owise]` here for the `false` cases breaks the proofs.

--- a/evm.md
+++ b/evm.md
@@ -1009,13 +1009,9 @@ The `JUMP*` family of operations affect the current program counter.
 
     syntax UnStackOp ::= "JUMP"
  // ---------------------------
-    rule <k> JUMP DEST => . ... </k>
+    rule <k> JUMP DEST => #if OP ==K JUMPDEST #then . #else #end EVMC_BAD_JUMP_DESTINATION #fi ... </k>
          <pc> _ => DEST </pc>
-         <program> ... DEST |-> JUMPDEST ... </program>
-
-    rule <k> JUMP DEST => #end EVMC_BAD_JUMP_DESTINATION ... </k>
          <program> ... DEST |-> OP ... </program>
-      requires OP =/=K JUMPDEST
 
     rule <k> JUMP DEST => #end EVMC_BAD_JUMP_DESTINATION ... </k>
          <program> PGM </program>

--- a/evm.md
+++ b/evm.md
@@ -270,21 +270,19 @@ OpCode Execution
 ```k
     syntax KItem ::= "#execute"
  // ---------------------------
-    rule [step]: <k> (. => #next) ~> #execute ... </k>
-    rule [halt]: <k> #halt ~> (#execute => .) ... </k>
-```
+    rule [step]: <mode> EXECMODE </mode>
+                 <k> (. => #next [ OP ]) ~> #execute ... </k>
+                 <pc> PCOUNT </pc>
+                 <program> ... PCOUNT |-> OP ... </program>
+              requires EXECMODE in (SetItem(NORMAL) SetItem(VMTESTS))
 
-Execution follows a simple cycle where first the state is checked for exceptions, then if no exceptions will be thrown the opcode is run.
-When the `#next` operator cannot lookup the next opcode, it assumes that the end of execution has been reached.
-
-```k
-    syntax InternalOp ::= "#next"
- // -----------------------------
-    rule <k> #next => #end EVMC_SUCCESS ... </k>
+    rule <k> #execute => #end EVMC_SUCCESS ... </k>
          <pc> PCOUNT </pc>
          <program> PGM </program>
          <output> _ => .WordStack </output>
       requires notBool (PCOUNT in_keys(PGM))
+
+    rule [halt]: <k> #halt ~> (#execute => .) ... </k>
 ```
 
 ### Single Step
@@ -300,12 +298,6 @@ The `#next [_]` operator initiates execution by:
 ```k
     syntax InternalOp ::= "#next" "[" OpCode "]"
  // --------------------------------------------
-    rule <mode> EXECMODE </mode>
-         <k> #next => #next [ OP ] ... </k>
-         <pc> PCOUNT </pc>
-         <program> ... PCOUNT |-> OP ... </program>
-      requires EXECMODE in (SetItem(NORMAL) SetItem(VMTESTS))
-
     rule <k> #next [ OP ]
           => #load [ OP ]
           ~> #exec [ OP ]


### PR DESCRIPTION
These refactors lead up to loading entire basic blocks at a time, which is not quite working yet.

It may be easier to review this commit-by-commit.