### PR TITLE
Add functional attribute to total functions for Haskell backend

### DIFF
--- a/evm.md
+++ b/evm.md
@@ -2133,8 +2133,8 @@ Specify which profile by passing in the argument `-cSCHEDULE=<FEE_SCHEDULE>` whe
 A `ScheduleFlag` is a boolean determined by the fee schedule; applying a `ScheduleFlag` to a `Schedule` yields whether the flag is set or not.
 
 ```k
-    syntax Bool ::= ScheduleFlag "<<" Schedule ">>" [function]
- // ----------------------------------------------------------
+    syntax Bool ::= ScheduleFlag "<<" Schedule ">>" [function, functional]
+ // ----------------------------------------------------------------------
 
     syntax ScheduleFlag ::= "Gselfdestructnewaccount" | "Gstaticcalldepth" | "Gemptyisnonexistent" | "Gzerovaluenewaccountgas"
                           | "Ghasrevert"              | "Ghasreturndata"   | "Ghasstaticcall"      | "Ghasshift"

--- a/evm.md
+++ b/evm.md
@@ -2147,8 +2147,8 @@ A `ScheduleFlag` is a boolean determined by the fee schedule; applying a `Schedu
 A `ScheduleConst` is a constant determined by the fee schedule.
 
 ```k
-    syntax Int ::= ScheduleConst "<" Schedule ">" [function]
- // --------------------------------------------------------
+    syntax Int ::= ScheduleConst "<" Schedule ">" [function, functional]
+ // --------------------------------------------------------------------
 
     syntax ScheduleConst ::= "Gzero"        | "Gbase"          | "Gverylow"      | "Glow"          | "Gmid"        | "Ghigh"
                            | "Gextcodesize" | "Gextcodecopy"   | "Gbalance"      | "Gsload"        | "Gjumpdest"   | "Gsstoreset"


### PR DESCRIPTION
The `functional` attribute informs the Haskell backend that these function symbols should be total. This is necessary for some proofs to go through.