### PR TITLE
data.md: Remove excess chops for monotonically decreasing word ops

### DIFF
--- a/data.md
+++ b/data.md
@@ -234,7 +234,7 @@ You could alternatively calculate `I1 modInt I2`, then add one to the normal int
 ```
 
 The corresponding `<op>Word` operations automatically perform the correct modulus for EVM words.
-
+Operands are assumed to be within the range of a 256 bit EVM word. 
 ```k
     syntax Int ::= Int "+Word" Int [function]
                  | Int "*Word" Int [function]

--- a/data.md
+++ b/data.md
@@ -234,7 +234,8 @@ You could alternatively calculate `I1 modInt I2`, then add one to the normal int
 ```
 
 The corresponding `<op>Word` operations automatically perform the correct modulus for EVM words.
-Operands are assumed to be within the range of a 256 bit EVM word. 
+Warning: operands are assumed to be within the range of a 256 bit EVM word. Unbound integers may not return the correct result.
+
 ```k
     syntax Int ::= Int "+Word" Int [function]
                  | Int "*Word" Int [function]

--- a/data.md
+++ b/data.md
@@ -243,13 +243,13 @@ The corresponding `<op>Word` operations automatically perform the correct modulu
                  | Int "%Word" Int [function]
  // -----------------------------------------
     rule W0 +Word W1 => chop( W0 +Int W1 )
-    rule W0 -Word W1 => chop( W0 -Int W1 ) requires W0 >=Int W1
+    rule W0 -Word W1 => W0 -Int W1 requires W0 >=Int W1
     rule W0 -Word W1 => chop( (W0 +Int pow256) -Int W1 ) requires W0 <Int W1
     rule W0 *Word W1 => chop( W0 *Int W1 )
-    rule W0 /Word W1 => 0                    requires W1  ==Int 0
-    rule W0 /Word W1 => chop( W0 /Int W1 )   requires W1 =/=Int 0
-    rule W0 %Word W1 => 0                    requires W1  ==Int 0
-    rule W0 %Word W1 => chop( W0 modInt W1 ) requires W1 =/=Int 0
+    rule W0 /Word W1 => 0            requires W1  ==Int 0
+    rule W0 /Word W1 => W0 /Int W1   requires W1 =/=Int 0
+    rule W0 %Word W1 => 0            requires W1  ==Int 0
+    rule W0 %Word W1 => W0 modInt W1 requires W1 =/=Int 0
 ```
 
 Care is needed for `^Word` to avoid big exponentiation.
@@ -324,13 +324,13 @@ Bitwise logical operators are lifted from the integer versions.
                  | Int ">>Word"  Int [function]
                  | Int ">>sWord" Int [function]
  // -------------------------------------------
-    rule ~Word W       => chop( W xorInt (pow256 -Int 1) )
-    rule W0 |Word   W1 => chop( W0 |Int W1 )
-    rule W0 &Word   W1 => chop( W0 &Int W1 )
-    rule W0 xorWord W1 => chop( W0 xorInt W1 )
+    rule ~Word W       => W xorInt maxUInt256
+    rule W0 |Word   W1 => W0 |Int W1
+    rule W0 &Word   W1 => W0 &Int W1
+    rule W0 xorWord W1 => W0 xorInt W1
     rule W0 <<Word  W1 => chop( W0 <<Int W1 ) requires W1 <Int 256
     rule W0 <<Word  W1 => 0 requires W1 >=Int 256
-    rule W0 >>Word  W1 => chop( W0 >>Int W1 )
+    rule W0 >>Word  W1 => W0 >>Int W1
     rule W0 >>sWord W1 => chop( (abs(W0) *Int sgn(W0)) >>Int W1 )
 ```
 


### PR DESCRIPTION
If you agree with the reasoning of https://github.com/kframework/evm-semantics/issues/386