### PR TITLE
Fix master build and add regression testing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,10 @@ RUN    git clone 'https://github.com/z3prover/z3' --branch=z3-4.6.0 \
     && cd ../..                                                     \
     && rm -rf z3
 
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
+RUN apt-get install --yes nodejs
+RUN npm install -g npx
+
 USER user:user
 
 ADD --chown=user:user deps/k/llvm-backend/src/main/native/llvm-backend/install-rust deps/k/llvm-backend/src/main/native/llvm-backend/rust-checksum /home/user/.install-rust/

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -153,6 +153,14 @@ pipeline {
                 '''
               }
             }
+            stage('Firefly') {
+              steps {
+                sh '''
+                  export PATH=$PATH:$(pwd)/.build/defn/vm
+                  make test-interactive-firefly
+                '''
+              }
+            }
           }
         }
       }

--- a/evm-node.md
+++ b/evm-node.md
@@ -226,10 +226,10 @@ Because the same account may be loaded more than once, implementations of this i
 -   `extractConfig` takes a final configuration after rewriting and extracts a `vmResult` from it in order to abstract away configuration structure from the postprocessing done by the blockchain-k-plugin.
 
 ```{.k .node}
-    syntax KItem ::= vmResult ( return: String , gas: Int , refund: Int , status: Int , selfdestruct: List , logs: List , AccountsCell , touched: List , statusCode: String )
+    syntax KItem ::= vmResult ( return: String , gas: Int , refund: Int , status: Int , selfdestruct: Set , logs: List , AccountsCell , touched: Set , statusCode: String )
     syntax KItem ::= extractConfig() [function, symbol]
  // ---------------------------------------------------
-    rule [[ extractConfig() => vmResult(#unparseByteStack(OUT), GAVAIL, REFUND, STATUS, Set2List(SD), LOGS, <accounts> ACCTS </accounts>, Set2List(TOUCHED), StatusCode2String(STATUSCODE)) ]]
+    rule [[ extractConfig() => vmResult(#unparseByteStack(OUT), GAVAIL, REFUND, STATUS, SD, LOGS, <accounts> ACCTS </accounts>, TOUCHED, StatusCode2String(STATUSCODE)) ]]
          <output> OUT </output>
          <gas> GAVAIL </gas>
          <refund> REFUND </refund>


### PR DESCRIPTION
We were out of sync between the version of the plugin and the version of the semantics because we merged a change to the plugin a while back and then updated to the latest plugin without updating the corresponding change to evm-node.md.