### PR TITLE
Empty account defaults to .Account

### DIFF
--- a/driver.md
+++ b/driver.md
@@ -324,8 +324,8 @@ State Manipulation
          <callStack>       _ => .List      </callStack>
          <program>         _ => .ByteArray </program>
          <jumpDests>       _ => .Set       </jumpDests>
-         <id>              _ => 0          </id>
-         <caller>          _ => 0          </caller>
+         <id>              _ => .Account   </id>
+         <caller>          _ => .Account   </caller>
          <callData>        _ => .ByteArray </callData>
          <callValue>       _ => 0          </callValue>
          <wordStack>       _ => .WordStack </wordStack>
@@ -337,7 +337,7 @@ State Manipulation
          <log>             _ => .List      </log>
          <refund>          _ => 0          </refund>
          <gasPrice>        _ => 0          </gasPrice>
-         <origin>          _ => 0          </origin>
+         <origin>          _ => .Account   </origin>
          <touchedAccounts> _ => .Set       </touchedAccounts>
 
     syntax EthereumCommand ::= "clearBLOCK"

--- a/evm.md
+++ b/evm.md
@@ -55,8 +55,8 @@ In the comments next to each cell, we've marked which component of the YellowPap
               <jumpDests> .Set </jumpDests>
 
               // I_*
-              <id>        0          </id>                    // I_a
-              <caller>    0          </caller>                // I_s
+              <id>        .Account   </id>                    // I_a
+              <caller>    .Account   </caller>                // I_s
               <callData>  .ByteArray </callData>              // I_d
               <callValue> 0          </callValue>             // I_v
 
@@ -82,8 +82,8 @@ In the comments next to each cell, we've marked which component of the YellowPap
             // Immutable during a single transaction
             // -------------------------------------
 
-            <gasPrice> 0 </gasPrice>                          // I_p
-            <origin>   0 </origin>                            // I_o
+            <gasPrice> 0        </gasPrice>                   // I_p
+            <origin>   .Account </origin>                     // I_o
 
             // I_H* (block information)
             <blockhashes> .List </blockhashes>
@@ -120,7 +120,7 @@ In the comments next to each cell, we've marked which component of the YellowPap
             <activeAccounts> .Set </activeAccounts>
             <accounts>
               <account multiplicity="*" type="Map">
-                <acctID>      0                      </acctID>
+                <acctID>      .Account               </acctID>
                 <balance>     0                      </balance>
                 <code>        .ByteArray:AccountCode </code>
                 <storage>     .Map                   </storage>

--- a/evm.md
+++ b/evm.md
@@ -120,7 +120,7 @@ In the comments next to each cell, we've marked which component of the YellowPap
             <activeAccounts> .Set </activeAccounts>
             <accounts>
               <account multiplicity="*" type="Map">
-                <acctID>      .Account               </acctID>
+                <acctID>      0                      </acctID>
                 <balance>     0                      </balance>
                 <code>        .ByteArray:AccountCode </code>
                 <storage>     .Map                   </storage>

--- a/tests/failing/ContractCreationSpam_d0g0v0.json.expected
+++ b/tests/failing/ContractCreationSpam_d0g0v0.json.expected
@@ -39,10 +39,10 @@
           .Set
         </jumpDests>
         <id>
-          0
+          .Account
         </id>
         <caller>
-          0
+          .Account
         </caller>
         <callData>
           b""

--- a/tests/failing/static_callcodecallcodecall_110_OOGMAfter_2_d0g0v0.json.expected
+++ b/tests/failing/static_callcodecallcodecall_110_OOGMAfter_2_d0g0v0.json.expected
@@ -39,10 +39,10 @@
           .Set
         </jumpDests>
         <id>
-          0
+          .Account
         </id>
         <caller>
-          0
+          .Account
         </caller>
         <callData>
           b""

--- a/tests/interactive/search/branching-invalid.evm.search-expected
+++ b/tests/interactive/search/branching-invalid.evm.search-expected
@@ -71,10 +71,10 @@
         SetItem ( 12 )
       </jumpDests>
       <id>
-        0
+        .Account
       </id>
       <caller>
-        0
+        .Account
       </caller>
       <callData>
         .WordStack
@@ -137,7 +137,7 @@
     _7
   #Equals
     <origin>
-      0
+      .Account
     </origin>
   }
 #And

--- a/tests/interactive/search/straight-line.evm.search-expected
+++ b/tests/interactive/search/straight-line.evm.search-expected
@@ -71,10 +71,10 @@
         .Set
       </jumpDests>
       <id>
-        0
+        .Account
       </id>
       <caller>
-        0
+        .Account
       </caller>
       <callData>
         .WordStack
@@ -137,7 +137,7 @@
     _7
   #Equals
     <origin>
-      0
+      .Account
     </origin>
   }
 #And

--- a/tests/templates/output-success-haskell.json
+++ b/tests/templates/output-success-haskell.json
@@ -87,7 +87,7 @@
         0
       </gasPrice>
       <origin>
-        0
+        .Account
       </origin>
       <blockhashes>
         .List

--- a/tests/templates/output-success-haskell.json
+++ b/tests/templates/output-success-haskell.json
@@ -36,10 +36,10 @@
           .Set
         </jumpDests>
         <id>
-          0
+          .Account
         </id>
         <caller>
-          0
+          .Account
         </caller>
         <callData>
           .WordStack

--- a/tests/templates/output-success-java.json
+++ b/tests/templates/output-success-java.json
@@ -87,7 +87,7 @@
         0
       </gasPrice>
       <origin>
-        0
+        .Account
       </origin>
       <blockhashes>
         .List

--- a/tests/templates/output-success-java.json
+++ b/tests/templates/output-success-java.json
@@ -36,10 +36,10 @@
           .Set
         </jumpDests>
         <id>
-          0
+          .Account
         </id>
         <caller>
-          0
+          .Account
         </caller>
         <callData>
           .WordStack

--- a/tests/templates/output-success-llvm.json
+++ b/tests/templates/output-success-llvm.json
@@ -87,7 +87,7 @@
         0
       </gasPrice>
       <origin>
-        0
+        .Account
       </origin>
       <blockhashes>
         .List

--- a/tests/templates/output-success-llvm.json
+++ b/tests/templates/output-success-llvm.json
@@ -36,10 +36,10 @@
           .Set
         </jumpDests>
         <id>
-          0
+          .Account
         </id>
         <caller>
-          0
+          .Account
         </caller>
         <callData>
           b""

--- a/tests/templates/output-success-ocaml.json
+++ b/tests/templates/output-success-ocaml.json
@@ -87,7 +87,7 @@
         0
       </gasPrice>
       <origin>
-        0
+        .Account
       </origin>
       <blockhashes>
         .List

--- a/tests/templates/output-success-ocaml.json
+++ b/tests/templates/output-success-ocaml.json
@@ -36,10 +36,10 @@
           .Set
         </jumpDests>
         <id>
-          0
+          .Account
         </id>
         <caller>
-          0
+          .Account
         </caller>
         <callData>
           b""

--- a/web3.md
+++ b/web3.md
@@ -610,8 +610,7 @@ eth_sendTransaction
     rule <k> loadTX _ { ("from": _, REST) => REST } ... </k>
 
     rule <k> loadTX _    { "to": (TO_STRING:String => #parseHexWord(TO_STRING)) , REST } ... </k>
-    rule <k> loadTX _    { "to": .Account   , REST => REST } ... </k>
-    rule <k> loadTX TXID { "to": ACCTTO:Int , REST => REST } ... </k>
+    rule <k> loadTX TXID { "to": ACCTTO:Account , REST => REST } ... </k>
          <message>
            <msgID> TXID </msgID>
            <to> ( _ => ACCTTO ) </to>
@@ -816,7 +815,7 @@ loadCallSettings
     syntax ByteArray ::= #ecrecAddr ( Account ) [function]
  // ------------------------------------------------------
     rule #ecrecAddr(.Account) => .ByteArray
-    rule #ecrecAddr(N:Int) => #padToWidth(20, #asByteStack(N))
+    rule #ecrecAddr(N:Int)    => #padToWidth(20, #asByteStack(N))
 ```
 
 - `#executeTx` takes a transaction, loads it into the current state and executes it.


### PR DESCRIPTION
Fixes: runtimeverification/firefly#170

There are times in `web3.md` where we end up loading a potentially empty account (via `.Account`) into these cells. Instead of having separate rules for either the `Account` or the `Int` sort, it would be nice to have uniform treatment of everything.

One alternative is to remove the `.Account` constructor and always use `0`, since the precompiles start at `1`. I personally prefer not using an `Int` to represent the empty account though.