### PR TITLE
Replace #sizeWordStack(_, _) helper with direct recursion

### DIFF
--- a/data.md
+++ b/data.md
@@ -451,14 +451,23 @@ A cons-list is used for the EVM wordstack.
 -   `#sizeWordStack` calculates the size of a `WordStack`.
 -   `_in_` determines if a `Int` occurs in a `WordStack`.
 
-```k
+```{.k .symbolic}
+    syntax Int ::= #sizeWordStack ( WordStack )       [function, functional, memo, smtlib(sizeWordStack)]
+ // -----------------------------------------------------------------------------------------------------
+    rule #sizeWordStack ( .WordStack ) => 0
+    rule #sizeWordStack ( W : WS     ) => 1 +Int #sizeWordStack(WS)
+```
+
+```{.k .concrete}
     syntax Int ::= #sizeWordStack ( WordStack )       [function, functional, smtlib(sizeWordStack)]
                  | #sizeWordStack ( WordStack , Int ) [function, functional, klabel(sizeWordStackAux), smtlib(sizeWordStackAux)]
  // ----------------------------------------------------------------------------------------------------------------------------
     rule #sizeWordStack ( WS ) => #sizeWordStack(WS, 0)
     rule #sizeWordStack ( .WordStack, SIZE ) => SIZE
     rule #sizeWordStack ( W : WS, SIZE )     => #sizeWordStack(WS, SIZE +Int 1)
+```
 
+```k
     syntax Bool ::= Int "in" WordStack [function]
  // ---------------------------------------------
     rule W in .WordStack => false

--- a/tests/specs/bihu/verification.k
+++ b/tests/specs/bihu/verification.k
@@ -9,11 +9,6 @@ module VERIFICATION
     imports EDSL
     imports LEMMAS
 
-    rule #sizeWordStack ( WS , N:Int )
-      => N +Int #sizeWordStack ( WS , 0 )
-      requires N =/=K 0
-      [lemma]
-
     //Rules for #padToWidth with non-regular symbolic arguments.
     rule #padToWidth(32, #asByteStack(V)) => #asByteStackInWidth(V, 32)
       requires 0 <=Int V andBool V <Int pow256 andBool #notKLabel(V, "#asWord")

--- a/tests/specs/ds-token-erc20/verification.k
+++ b/tests/specs/ds-token-erc20/verification.k
@@ -9,11 +9,6 @@ module VERIFICATION
     imports EDSL
     imports LEMMAS
 
-    rule #sizeWordStack ( WS , N:Int )
-      => N +Int #sizeWordStack ( WS , 0 )
-      requires N =/=K 0
-      [lemma]
-
     //Rules for #padToWidth with non-regular symbolic arguments.
     rule #padToWidth(32, #asByteStack(V)) => #asByteStackInWidth(V, 32)
       requires 0 <=Int V andBool V <Int pow256 andBool #notKLabel(V, "#asWord")

--- a/tests/specs/examples/sum-to-n-spec.k
+++ b/tests/specs/examples/sum-to-n-spec.k
@@ -7,11 +7,6 @@ module VERIFICATION
     imports LEMMAS
     imports EVM-ASSEMBLY
 
-    rule #sizeWordStack ( WS , N:Int )
-      => N +Int #sizeWordStack ( WS , 0 )
-      requires N =/=K 0
-      [lemma]
-
     syntax ByteArray ::= "sumToN" [function]
  // ----------------------------------------
     rule sumToN

--- a/tests/specs/hkg-erc20/verification.k
+++ b/tests/specs/hkg-erc20/verification.k
@@ -9,11 +9,6 @@ module VERIFICATION
     imports EDSL
     imports LEMMAS
 
-    rule #sizeWordStack ( WS , N:Int )
-      => N +Int #sizeWordStack ( WS , 0 )
-      requires N =/=K 0
-      [lemma]
-
     //Rules for #padToWidth with non-regular symbolic arguments.
     rule #padToWidth(32, #asByteStack(V)) => #asByteStackInWidth(V, 32)
       requires 0 <=Int V andBool V <Int pow256 andBool #notKLabel(V, "#asWord")

--- a/tests/specs/hobby-erc20/verification.k
+++ b/tests/specs/hobby-erc20/verification.k
@@ -9,11 +9,6 @@ module VERIFICATION
     imports EDSL
     imports LEMMAS
 
-    rule #sizeWordStack ( WS , N:Int )
-      => N +Int #sizeWordStack ( WS , 0 )
-      requires N =/=K 0
-      [lemma]
-
     //Rules for #padToWidth with non-regular symbolic arguments.
     rule #padToWidth(32, #asByteStack(V)) => #asByteStackInWidth(V, 32)
       requires 0 <=Int V andBool V <Int pow256 andBool #notKLabel(V, "#asWord")


### PR DESCRIPTION
The change is only applied to the symbolic backends; the tail-recursive helper
is retained for concrete backends. The change allows using the `memo` attribute
with the Haskell backend, reducing runtime of the sum-to-n spec by over 50%. We
are also able to remove lemmas from several specs.