### PR TITLE
data: improve element access to have constant amortized cost

### DIFF
--- a/data.md
+++ b/data.md
@@ -421,13 +421,6 @@ A cons-list is used for the EVM wordstack.
  // ---------------------------------------------------------------------
     rule #drop(N, WS)         => WS                  requires notBool N >Int 0
     rule #drop(N, .WordStack) => .WordStack
-```
-
-```{.k .concrete}
-    rule #drop(N, (W : WS))   => #drop(N -Int 1, WS) requires N >Int 0
-```
-
-```{.k .symbolic}
     rule #drop(N, (W : WS))   => #drop(1, #drop(N -Int 1, (W : WS))) requires N >Int 1
     rule #drop(1, (_ : WS))   => WS
 ```

--- a/data.md
+++ b/data.md
@@ -421,7 +421,15 @@ A cons-list is used for the EVM wordstack.
  // ---------------------------------------------------------------------
     rule #drop(N, WS)         => WS                  requires notBool N >Int 0
     rule #drop(N, .WordStack) => .WordStack
+```
+
+```{.k .concrete}
     rule #drop(N, (W : WS))   => #drop(N -Int 1, WS) requires N >Int 0
+```
+
+```{.k .symbolic}
+    rule #drop(N, (W : WS))   => #drop(1, #drop(N -Int 1, (W : WS))) requires N >Int 1
+    rule #drop(1, (_ : WS))   => WS
 ```
 
 ### Element Access
@@ -432,8 +440,8 @@ A cons-list is used for the EVM wordstack.
 ```k
     syntax Int ::= WordStack "[" Int "]" [function]
  // -----------------------------------------------
-    rule (W0 : WS)   [N] => W0           requires N ==Int 0
-    rule (W0 : WS)   [N] => WS[N -Int 1] requires N >Int 0
+    rule (W : _) [ N ] => W                  requires N ==Int 0
+    rule WS      [ N ] => #drop(N, WS) [ 0 ] requires N >Int 0
 
     syntax WordStack ::= WordStack "[" Int ":=" Int "]" [function]
  // --------------------------------------------------------------


### PR DESCRIPTION
Now `#drop` is defined in a way that utilizes the function evaluation cache, thus the amortized  complexity of `PGM [ PCOUNT ]` becomes constant.

The disadvantage of this new `#drop` is that it is not tail-recursive. But its overhead is relatively small and acceptable for the symbolic execution.  For the concrete execution, `#drop` is only used for `LOG(N)` where `N <= 4`, so it should be fine.