### PR TITLE
Upgrade z3 to version 4.8.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ RUN    apt-get update           \
 ADD deps/k/haskell-backend/src/main/native/haskell-backend/scripts/install-stack.sh /.install-stack/
 RUN /.install-stack/install-stack.sh
 
-RUN    git clone 'https://github.com/z3prover/z3' --branch=z3-4.6.0 \
+RUN    git clone 'https://github.com/z3prover/z3' --branch=z3-4.8.6 \
     && cd z3                                                        \
     && python scripts/mk_make.py                                    \
     && cd build                                                     \


### PR DESCRIPTION
Version 4.7 introduces QF_DT, which makes frontend sort inference/(un)parsing ambiguity much faster.