### PR TITLE
Option --no-unparse to kevm script

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -51,7 +51,7 @@ pipeline {
         }
         stage('Test Execution') {
           failFast true
-          options { timeout(time: 15, unit: 'MINUTES') }
+          options { timeout(time: 20, unit: 'MINUTES') }
           parallel {
             stage('Conformance (OCaml)') {
               steps {

--- a/Makefile
+++ b/Makefile
@@ -370,8 +370,9 @@ release.md: INSTALL.md
 TEST_CONCRETE_BACKEND := llvm
 TEST_SYMBOLIC_BACKEND := java
 
-TEST  := ./kevm
-CHECK := git --no-pager diff --no-index --ignore-all-space -R
+TEST         := ./kevm
+TEST_OPTIONS :=
+CHECK        := git --no-pager diff --no-index --ignore-all-space -R
 
 KEVM_MODE     := NORMAL
 KEVM_SCHEDULE := PETERSBURG
@@ -396,17 +397,17 @@ tests/ethereum-tests/VMTests/%: KEVM_MODE=VMTESTS
 tests/ethereum-tests/VMTests/%: KEVM_SCHEDULE=DEFAULT
 
 tests/%.run: tests/%
-	MODE=$(KEVM_MODE) SCHEDULE=$(KEVM_SCHEDULE) $(TEST) interpret --backend $(TEST_CONCRETE_BACKEND) $< > tests/$*.$(TEST_CONCRETE_BACKEND)-out \
+	MODE=$(KEVM_MODE) SCHEDULE=$(KEVM_SCHEDULE) $(TEST) interpret $(TEST_OPTIONS) --backend $(TEST_CONCRETE_BACKEND) $< > tests/$*.$(TEST_CONCRETE_BACKEND)-out \
 	    || $(CHECK) tests/$*.$(TEST_CONCRETE_BACKEND)-out tests/templates/output-success-$(TEST_CONCRETE_BACKEND).json
 	rm -rf tests/$*.$(TEST_CONCRETE_BACKEND)-out
 
 tests/%.run-interactive: tests/%
-	MODE=$(KEVM_MODE) SCHEDULE=$(KEVM_SCHEDULE) $(TEST) run --backend $(TEST_CONCRETE_BACKEND) $< > tests/$*.$(TEST_CONCRETE_BACKEND)-out \
+	MODE=$(KEVM_MODE) SCHEDULE=$(KEVM_SCHEDULE) $(TEST) run $(TEST_OPTIONS) --backend $(TEST_CONCRETE_BACKEND) $< > tests/$*.$(TEST_CONCRETE_BACKEND)-out \
 	    || $(CHECK) tests/$*.$(TEST_CONCRETE_BACKEND)-out tests/templates/output-success-$(TEST_CONCRETE_BACKEND).json
 	rm -rf tests/$*.$(TEST_CONCRETE_BACKEND)-out
 
 tests/%.run-expected: tests/% tests/%.expected
-	MODE=$(KEVM_MODE) SCHEDULE=$(KEVM_SCHEDULE) $(TEST) run --backend $(TEST_CONCRETE_BACKEND) $< > tests/$*.$(TEST_CONCRETE_BACKEND)-out \
+	MODE=$(KEVM_MODE) SCHEDULE=$(KEVM_SCHEDULE) $(TEST) run $(TEST_OPTIONS) --backend $(TEST_CONCRETE_BACKEND) $< > tests/$*.$(TEST_CONCRETE_BACKEND)-out \
 	    || $(CHECK) tests/$*.$(TEST_CONCRETE_BACKEND)-out tests/$*.expected
 	rm -rf tests/$*.$(TEST_CONCRETE_BACKEND)-out
 
@@ -418,7 +419,7 @@ tests/%.run-web3: tests/%.in.json
 	rm -rf tests/$*.out.json
 
 tests/%.parse: tests/%
-	$(TEST) kast --backend $(TEST_CONCRETE_BACKEND) $< kast > $@-out
+	$(TEST) kast $(TEST_OPTIONS) --backend $(TEST_CONCRETE_BACKEND) $< kast > $@-out
 	$(CHECK) $@-out $@-expected
 	rm -rf $@-out
 
@@ -426,15 +427,15 @@ tests/specs/functional/%.prove: TEST_SYMBOLIC_BACKEND=haskell
 tests/specs/functional/storageRoot-spec.k.prove: TEST_SYMBOLIC_BACKEND=java
 
 tests/%.prove: tests/%
-	$(TEST) prove --backend $(TEST_SYMBOLIC_BACKEND) $< --format-failures --def-module $(KPROVE_MODULE) $(KPROVE_OPTIONS)
+	$(TEST) prove $(TEST_OPTIONS) --backend $(TEST_SYMBOLIC_BACKEND) $< --format-failures --def-module $(KPROVE_MODULE) $(KPROVE_OPTIONS)
 
 tests/%.search: tests/%
-	$(TEST) search --backend $(TEST_SYMBOLIC_BACKEND) $< "<statusCode> EVMC_INVALID_INSTRUCTION </statusCode>" > $@-out
+	$(TEST) search $(TEST_OPTIONS) --backend $(TEST_SYMBOLIC_BACKEND) $< "<statusCode> EVMC_INVALID_INSTRUCTION </statusCode>" > $@-out
 	$(CHECK) $@-out $@-expected
 	rm -rf $@-out
 
 tests/%.klab-prove: tests/%
-	$(TEST) klab-prove --backend $(TEST_SYMBOLIC_BACKEND) $< --format-failures --def-module $(KPROVE_MODULE) $(KPROVE_OPTIONS)
+	$(TEST) klab-prove $(TEST_OPTIONS) --backend $(TEST_SYMBOLIC_BACKEND) $< --format-failures --def-module $(KPROVE_MODULE) $(KPROVE_OPTIONS)
 
 # Smoke Tests
 

--- a/kevm
+++ b/kevm
@@ -270,28 +270,14 @@ unparse=true
 [[ ! "$run_command" =~ klab*   ]] || backend='java'
 [[ ! "$run_command" =~ web3*   ]] || backend='llvm'
 while [[ $# -gt 0 ]]; do
-  arg="$1"
-  case $arg in
-    --backend)
-    backend="$2"
-    shift 2
-    ;;
-    --debug)
-    debug=true
-    shift
-    ;;
-    --dump)
-    dump=true
-    shift
-    ;;
-    --no-unparse)
-    unparse=false
-    shift
-    ;;
-    *)
-    break
-    ;;
-  esac
+    arg="$1"
+    case $arg in
+        --backend)    backend="$2"  ; shift 2 ;;
+        --debug)      debug=true    ; shift   ;;
+        --dump)       dump=true     ; shift   ;;
+        --no-unparse) unparse=false ; shift   ;;
+        *)            break                   ;;
+    esac
 done
 backend_dir="$defn_dir/$backend"
 [[ ! "$backend" == "ocaml" ]] || eval $(${OPAM:-opam} config env)

--- a/kevm
+++ b/kevm
@@ -179,21 +179,21 @@ run_interpret() {
                              -c SCHEDULE "$cSCHEDULE" text -c MODE "$cMODE" text --initializer 'initKevmCell' \
                              --output-file "$output" "$@" \
                     || exit_status="$?"
-                if [[ "$exit_status" != '0' ]]; then
+                if [[ "$unparse" == 'true' ]] && [[ "$exit_status" != '0' ]]; then
                     k-bin-to-text "$output" "$output_text"
                     cat "$output_text"
-                    exit "$exit_status"
                 fi
+                exit "$exit_status"
                 ;;
 
         llvm)   run_kast kore > "$kast"
                 if $debug; then debugger="gdb --args"; fi
                 $debugger "$interpreter" "$kast" -1 "$output_text" "$@" \
                     || exit_status="$?"
-                if [[ "$exit_status" != '0' ]]; then
+                if [[ "$unparse" == 'true' ]] && [[ "$exit_status" != '0' ]]; then
                     cat "$output_text" | "$0" kast --backend "$backend" - pretty --input "$output_format" --sort GeneratedTopCell
-                    exit "$exit_status"
                 fi
+                exit "$exit_status"
                 ;;
 
         *)      fatal "Bad backend for interpreter: '$backend'"
@@ -208,17 +208,17 @@ run_command="$1" ; shift
 
 if [[ "$run_command" == 'help' ]] || [[ "$run_command" == '--help' ]] ; then
     echo "
-        usage: $0 run          [--backend (ocaml|java|llvm|haskell)]      <pgm>  <K arg>*
-               $0 interpret    [--backend (ocaml|llvm)] [--debug]         <pgm>  <interpreter arg>*
-               $0 kast         [--backend (ocaml|java|llvm|haskell|web3)] <pgm>  <output format> <K arg>*
-               $0 prove        [--backend (java|haskell)]                 <spec> <K arg>* -m <def_module>
-               $0 search       [--backend (java|haskell)]                 <pgm>  <pattern> <K arg>*
-               $0 web3         [--debug|--dump]                           <port>
-               $0 web3-ganache [--debug|--dump]                           <port>
-               $0 web3-send                                               <port> <web3 method> <web3 params>
-               $0 klab-run                                                <pgm>  <K arg>*
-               $0 klab-prove                                              <spec> <K arg>* -m <def_module>
-               $0 klab-view                                               <spec>
+        usage: $0 run          [--backend (ocaml|java|llvm|haskell)]           <pgm>  <K arg>*
+               $0 interpret    [--backend (ocaml|llvm)] [--debug|--no-unparse] <pgm>  <interpreter arg>*
+               $0 kast         [--backend (ocaml|java|llvm|haskell|web3)]      <pgm>  <output format> <K arg>*
+               $0 prove        [--backend (java|haskell)]                      <spec> <K arg>* -m <def_module>
+               $0 search       [--backend (java|haskell)]                      <pgm>  <pattern> <K arg>*
+               $0 web3         [--debug|--dump]                                <port>
+               $0 web3-ganache [--debug|--dump]                                <port>
+               $0 web3-send                                                    <port> <web3 method> <web3 params>
+               $0 klab-run                                                     <pgm>  <K arg>*
+               $0 klab-prove                                                   <spec> <K arg>* -m <def_module>
+               $0 klab-view                                                    <spec>
 
                $0 [help|--help|version|--version]
 
@@ -265,6 +265,7 @@ fi
 backend="llvm"
 debug=false
 dump=false
+unparse=true
 [[ ! "$run_command" == 'prove' ]] || backend='java'
 [[ ! "$run_command" =~ klab*   ]] || backend='java'
 [[ ! "$run_command" =~ web3*   ]] || backend='llvm'
@@ -281,6 +282,10 @@ while [[ $# -gt 0 ]]; do
     ;;
     --dump)
     dump=true
+    shift
+    ;;
+    --no-unparse)
+    unparse=false
     shift
     ;;
     *)


### PR DESCRIPTION
-   Bumps the timeout on execution tests to 20 minutes to account for the fact that we're running more tests and would like rvwork-0 to keep up.
-   Adds an option `--no-unparse` to `./kevm interpret` command.
-   Allows specifying `TEST_OPTIONS` variable on `make` invocations for calling `kevm` in specific ways.

If you want to completely skip all output-based checking, you can do:

```
make test-conformance TEST_OPTIONS=--no-unparse CHECK=false
```

Setting `TEST_OPTIONS=--no-unparse` skips the unparsing phase of `kevm` script, and setting `CHECK=false` skips calling `git diff` if the test itself returns non-`0` (but still fails the test).