### PR TITLE
Handle odd-length hex-strings in conformance tests

### DIFF
--- a/data.md
+++ b/data.md
@@ -814,7 +814,11 @@ These parsers can interperet hex-encoded strings as `Int`s, `ByteArray`s, and `M
  // -------------------------------------------------------------
     rule #parseByteStack(S) => #parseHexBytes(replaceAll(S, "0x", ""))
     rule #parseHexBytes("") => .ByteArray
-    rule #parseHexBytes(S)  => Int2Bytes(1, #parseHexWord(substrString(S, 0, 2)), BE) +Bytes #parseHexBytes(substrString(S, 2, lengthString(S))) requires lengthString(S) >=Int 2
+    rule #parseHexBytes(S)  => #parseHexBytes("0" +String S)
+      requires notBool lengthString(S) modInt 2 ==Int 0
+    rule #parseHexBytes(S)  => Int2Bytes(1, #parseHexWord(substrString(S, 0, 2)), BE) +Bytes #parseHexBytes(substrString(S, 2, lengthString(S)))
+      requires lengthString(S) modInt 2 ==Int 0
+       andBool lengthString(S) >Int 0
 
     rule #parseByteStackRaw(S) => String2Bytes(S)
 ```
@@ -826,7 +830,11 @@ These parsers can interperet hex-encoded strings as `Int`s, `ByteArray`s, and `M
  // -------------------------------------------------------------
     rule #parseByteStack(S) => #parseHexBytes(replaceAll(S, "0x", ""))
     rule #parseHexBytes("") => .WordStack
-    rule #parseHexBytes(S)  => #parseHexWord(substrString(S, 0, 2)) : #parseHexBytes(substrString(S, 2, lengthString(S))) requires lengthString(S) >=Int 2
+    rule #parseHexBytes(S)  => #parseHexBytes("0" +String S)
+      requires notBool lengthString(S) modInt 2 ==Int 0
+    rule #parseHexBytes(S)  => #parseHexWord(substrString(S, 0, 2)) : #parseHexBytes(substrString(S, 2, lengthString(S)))
+      requires lengthString(S) modInt 2 ==Int 0
+       andBool lengthString(S) >Int 0
 
     rule #parseByteStackRaw(S) => ordChar(substrString(S, 0, 1)) : #parseByteStackRaw(substrString(S, 1, lengthString(S))) requires lengthString(S) >=Int 1
     rule #parseByteStackRaw("") => .WordStack


### PR DESCRIPTION
I've checked that this does not hurt performance:

```
* 760d5376 - data.md: handle the case where non-even length byte array is passed in           - Everett Hildenbrandt (HEAD -> parseHexBytes-odd-length, upstream/parseHexBytes-odd-length, testing)
| testset: conformance - Wed 04 Dec 2019 12:02:58 AM MST
| 0  193.56s  1959.13s  358.23s  6664276KB  make  test-conformance  TEST_CONCRETE_BACKEND=llvm   -j16
| 0  209.42s  1997.80s  851.45s  3890944KB  make  test-conformance  TEST_CONCRETE_BACKEND=ocaml  -j16
| 
* 1f5e7195 - Update test submodule to post-Istanbul tests (#590)                              - ehildenb (tag: v1.0.0-1f5e719, upstream/master)
| testset: conformance - Tue 03 Dec 2019 11:56:15 PM MST
| 0  194.18s  1961.03s  357.68s  6664436KB  make  test-conformance  TEST_CONCRETE_BACKEND=llvm   -j16
| 0  207.62s  1994.56s  846.41s  3890888KB  make  test-conformance  TEST_CONCRETE_BACKEND=ocaml  -j16
```

Not an appreciable runtime difference, and this makes the new format for tests (which are filled by Geth instead of testeth) not fail when they encounter hex-strings of odd length like `0x20000`.