### PR TITLE
evm: remove vestigial Gsstorestipend

### DIFF
--- a/evm.md
+++ b/evm.md
@@ -2261,11 +2261,11 @@ A `ScheduleFlag` is a boolean determined by the fee schedule; applying a `Schedu
     syntax Bool ::= ScheduleFlag "<<" Schedule ">>" [function, functional]
  // ----------------------------------------------------------------------
 
-    syntax ScheduleFlag ::= "Gselfdestructnewaccount" | "Gstaticcalldepth"  | "Gemptyisnonexistent" | "Gzerovaluenewaccountgas"
-                          | "Ghasrevert"              | "Ghasreturndata"    | "Ghasstaticcall"      | "Ghasshift"
-                          | "Ghasdirtysstore"         | "Ghascreate2"       | "Ghasextcodehash"     | "Ghasselfbalance"
-                          | "Gsstorestipend"          | "Ghassstorestipend"
- // -----------------------------------------------------------------------
+    syntax ScheduleFlag ::= "Gselfdestructnewaccount" | "Gstaticcalldepth" | "Gemptyisnonexistent" | "Gzerovaluenewaccountgas"
+                          | "Ghasrevert"              | "Ghasreturndata"   | "Ghasstaticcall"      | "Ghasshift"
+                          | "Ghasdirtysstore"         | "Ghascreate2"      | "Ghasextcodehash"     | "Ghasselfbalance"
+                          | "Ghassstorestipend"
+ // -------------------------------------------
 ```
 
 ### Schedule Constants


### PR DESCRIPTION
Accidentally forgot to remove `Gsstorestipend` from a former PR, so it's removed here.