### PR TITLE
use fastbuild for K since there is a bug with lto and tailcallopt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,7 @@ tangle-deps: $(TANGLER)
 plugin-deps: $(PLUGIN_SUBMODULE)/make.timestamp
 
 ifneq ($(RELEASE),)
-K_BUILD_TYPE         := Release
+K_BUILD_TYPE         := FastBuild
 SEMANTICS_BUILD_TYPE := Release
 KOMPILE_OPTS         += -O3
 else


### PR DESCRIPTION
Fixes runtimeverification/firefly#374

There is some kind of bug in the llvm backend surrounding -tailcallopt and lto builds. I'm not sure exactly what is causing it because it has worked in the past. The best solution at this point is to wait for the soon-to-be-released LLVM 10 and rely on it in cases where we want to enable LTO, as LLVM 10 contains a code change I wrote which should significantly decrease the messiness of getting lto and tail calls to play nicely together on all platforms.