### PR TITLE
Makefile: parameterize where needed for external builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 
 BUILD_DIR   ?= .build
 DEFN_DIR    := $(BUILD_DIR)/defn
-BUILD_LOCAL := $(CURDIR)/$(BUILD_DIR)/local
+BUILD_LOCAL := $(abspath $(BUILD_DIR)/local)
 
 LIBRARY_PATH       := $(BUILD_LOCAL)/lib
 C_INCLUDE_PATH     += :$(BUILD_LOCAL)/include

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Settings
 # --------
 
-BUILD_DIR   := .build
+BUILD_DIR   ?= .build
 DEFN_DIR    := $(BUILD_DIR)/defn
 BUILD_LOCAL := $(CURDIR)/$(BUILD_DIR)/local
 
@@ -18,9 +18,10 @@ export PKG_CONFIG_PATH
 INSTALL_PREFIX := /usr/local
 INSTALL_DIR    ?= $(DESTDIR)$(INSTALL_PREFIX)/bin
 
-DEPS_DIR         := deps
+DEPS_DIR         ?= deps
 K_SUBMODULE      := $(abspath $(DEPS_DIR)/k)
-export PLUGIN_SUBMODULE := $(abspath $(DEPS_DIR)/plugin)
+PLUGIN_SUBMODULE := $(abspath $(DEPS_DIR)/plugin)
+export PLUGIN_SUBMODULE
 
 K_RELEASE ?= $(K_SUBMODULE)/k-distribution/target/release/k
 K_BIN     := $(K_RELEASE)/bin
@@ -155,8 +156,10 @@ ALL_K_FILES   := $(k_files) $(EXTRA_K_FILES)
 llvm_dir    := $(DEFN_DIR)/llvm
 java_dir    := $(DEFN_DIR)/java
 haskell_dir := $(DEFN_DIR)/haskell
-export node_dir    := $(CURDIR)/$(DEFN_DIR)/node
-export web3_dir    := $(CURDIR)/$(DEFN_DIR)/web3
+node_dir    := $(CURDIR)/$(DEFN_DIR)/node
+web3_dir    := $(CURDIR)/$(DEFN_DIR)/web3
+export node_dir
+export web3_dir
 
 llvm_files    := $(patsubst %, $(llvm_dir)/%, $(ALL_K_FILES))
 java_files    := $(patsubst %, $(java_dir)/%, $(ALL_K_FILES))

--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,7 @@ llvm_dir    := $(DEFN_DIR)/llvm
 java_dir    := $(DEFN_DIR)/java
 haskell_dir := $(DEFN_DIR)/haskell
 node_dir    := $(abspath $(DEFN_DIR)/node)
-web3_dir    ?= $(abspath $(DEFN_DIR)/web3)
+web3_dir    := $(abspath $(DEFN_DIR)/web3)
 export node_dir
 export web3_dir
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@
 # --------
 
 BUILD_DIR   ?= .build
-DEFN_DIR    := $(BUILD_DIR)/defn
+SUBDEFN_DIR ?= .
+DEFN_DIR    := $(BUILD_DIR)/defn/$(SUBDEFN_DIR)
 BUILD_LOCAL := $(abspath $(BUILD_DIR)/local)
 
 LIBRARY_PATH       := $(BUILD_LOCAL)/lib

--- a/Makefile
+++ b/Makefile
@@ -156,8 +156,8 @@ ALL_K_FILES   := $(k_files) $(EXTRA_K_FILES)
 llvm_dir    := $(DEFN_DIR)/llvm
 java_dir    := $(DEFN_DIR)/java
 haskell_dir := $(DEFN_DIR)/haskell
-node_dir    := $(CURDIR)/$(DEFN_DIR)/node
-web3_dir    := $(CURDIR)/$(DEFN_DIR)/web3
+node_dir    := $(abspath $(DEFN_DIR)/node)
+web3_dir    ?= $(abspath $(DEFN_DIR)/web3)
 export node_dir
 export web3_dir
 


### PR DESCRIPTION
This makes it possible to build the Web3 client in a repository which depends on this one by controlling the various Makefile variables.