### PR TITLE
Update coverage collection and calculation

### DIFF
--- a/evm.md
+++ b/evm.md
@@ -1850,7 +1850,7 @@ Overall Gas
 
 ```k
     syntax InternalOp ::= "#gas" "[" OpCode "," OpCode "]"
- // ---------------------------------------------------------------------------
+ // ------------------------------------------------------
     rule <k> #gas [ OP , AOP ]
           => #if #usesMemory(OP) #then #memory [ AOP ] #else .K #fi
           ~> #gas [ AOP ]

--- a/json.md
+++ b/json.md
@@ -19,12 +19,26 @@ module JSON
  // --------------------------------------------------------------------
 ```
 
+-   `reverseJSONs` reverses a JSON list.
+
+```k
+    syntax JSONs ::= reverseJSONs    ( JSONs         ) [function]
+                   | reverseJSONsAux ( JSONs , JSONs ) [function]
+ // -------------------------------------------------------------
+    rule reverseJSONs(JS) => reverseJSONsAux(JS, .JSONs)
+
+    rule reverseJSONsAux(.JSONs, JS') => JS'
+    rule reverseJSONsAux((J, JS:JSONs), JS') => reverseJSONsAux(JS, (J, JS'))
+```
+
 **TODO**: Adding `Int` to `JSONKey` is a hack to make certain parts of semantics easier.
 
 ```k
     syntax JSONKey ::= Int
  // ----------------------
+```
 
+```k
 endmodule
 ```
 

--- a/web3.md
+++ b/web3.md
@@ -1592,8 +1592,12 @@ Collecting Coverage Data
     syntax JSON ::= #makeArgumentList ( List , JSON ) [function]
  // ------------------------------------------------------------
     rule #makeArgumentList(.List, JSON_ARG_LIST) => JSON_ARG_LIST
-    rule #makeArgumentList(((ListItem(#gas[OP, AOP]) => .List) _:List), [ _ , (.JSONs => ArgList2JSONs(#getWSArgs(OP, AOP))) ])
-    rule #makeArgumentList(((ListItem(IOP:InvalidOp) => .List) _:List), [ _ , (.JSONs => [ .JSONs ]) ])
+    rule #makeArgumentList(((ListItem(OP) => .List) _:List), [ _ , (.JSONs => #computeArgList(OP)) ])
+
+    syntax JSONs ::= #computeArgList ( Opcode ) [function]
+ // ------------------------------------------------------
+    rule #computeArgList(IOP:InvalidOp) => [ .JSONs                             ]
+    rule #computeArgList(#gas[OP, AOP]) => [ ArgList2JSONs(#getWSArgs(OP, AOP)) ]
 
     syntax String ::= #getStaticArgs ( ByteArray, Int ) [function]
  // --------------------------------------------------------------

--- a/web3.md
+++ b/web3.md
@@ -1594,10 +1594,10 @@ Collecting Coverage Data
     rule #makeArgumentList(.List, JSON_ARG_LIST) => JSON_ARG_LIST
     rule #makeArgumentList(((ListItem(OP) => .List) _:List), [ _ , (.JSONs => #computeArgList(OP)) ])
 
-    syntax JSONs ::= #computeArgList ( Opcode ) [function]
+    syntax JSONs ::= #computeArgList ( OpCode ) [function]
  // ------------------------------------------------------
-    rule #computeArgList(IOP:InvalidOp) => [ .JSONs                             ]
-    rule #computeArgList(#gas[OP, AOP]) => [ ArgList2JSONs(#getWSArgs(OP, AOP)) ]
+    rule #computeArgList(IOP:InvalidOp) => .JSONs
+    rule #computeArgList(#gas[OP, AOP]) => ArgList2JSONs(#getWSArgs(OP, AOP))
 
     syntax String ::= #getStaticArgs ( ByteArray, Int ) [function]
  // --------------------------------------------------------------

--- a/web3.md
+++ b/web3.md
@@ -19,8 +19,8 @@ module WEB3
         <json-rpc/>
         <coverage>
           <coverageRecorded> true </coverageRecorded>
+          <bytecodeList> .List </bytecodeList>
           <bytecodeCoverages>
-            <bytecodeList> .List </bytecodeList>
             <bytecodeCoverage multiplicity="*" type="Map">
               <bytecode> .ByteArray </bytecode>
               <coverageData> .Map </coverageData>


### PR DESCRIPTION
Fixes runtimeverification/firefly#574.

This revamps the way that coverage data is collected and calculated, so that we calculate the "empty" coverage data ahead of time, and then populate with calls/arguments as we go. This avoids us having separate lists for "covered" opcodes and "all" opcodes, so that calculating >100% coverage is not possible.