### PR TITLE
evm-types.md: simplify sizeWordStack

### DIFF
--- a/evm-types.md
+++ b/evm-types.md
@@ -434,11 +434,9 @@ A cons-list is used for the EVM wordstack.
 
 ```k
     syntax Int ::= #sizeWordStack ( WordStack )       [function, functional, smtlib(sizeWordStack)]
-                 | #sizeWordStack ( WordStack , Int ) [function, functional, klabel(sizeWordStackAux), smtlib(sizeWordStackAux)]
  // ----------------------------------------------------------------------------------------------------------------------------
-    rule #sizeWordStack ( WS ) => #sizeWordStack(WS, 0)
-    rule #sizeWordStack ( .WordStack, SIZE ) => SIZE
-    rule #sizeWordStack ( W : WS, SIZE )     => #sizeWordStack(WS, SIZE +Int 1)
+    rule #sizeWordStack ( .WordStack ) => 0
+    rule #sizeWordStack ( W : WS )     => #sizeWordStack(WS) +Int 1
 
     syntax Bool ::= Int "in" WordStack [function]
  // ---------------------------------------------


### PR DESCRIPTION
There's plenty of instances employing a pattern like this, where an `*aux` version of a production is used with an extra accumulating argument. These constructions seem to introduce unnecessary complexity and complicate symbolic execution to the point where [additional rules](https://github.com/kframework/evm-semantics/blob/master/tests/specs/lemmas.k#L13) need to be introduced, which would seem redundant if the rules were just written in a straight forward manner in the first place. 

Is there any reasoning to keeping rules on this form that I'm unaware about? If there is no good reason, there are several [function] productions that can be simplified