### PR TITLE
Json Specification conformant with ECMA-404

### DIFF
--- a/json.md
+++ b/json.md
@@ -4,22 +4,76 @@ KJSON
 This is a near-faithful implementation of the [ECMA-404 JSON Data Interchange Format](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
 There are issues with how `JSONNumber` and `JSONString` are specified here, because we use K's `String` and `Int` sort directly, which are not quite correct.
 
-### JSON Syntax
+JSON Specification
+------------------
 
 ```k
 module JSON
     imports INT
     imports STRING
     imports BOOL
+```
 
-    syntax JSONs   ::= List{JSON,","}      [klabel(JSONs)      , symbol]
-    syntax JSONKey ::= String
-    syntax JSON    ::= "null"              [klabel(JSONnull)   , symbol]
-                     | String | Int | Bool
-                     | JSONKey ":" JSON    [klabel(JSONEntry)  , symbol]
-                     | "{" JSONs "}"       [klabel(JSONObject) , symbol]
-                     | "[" JSONs "]"       [klabel(JSONList)   , symbol]
- // --------------------------------------------------------------------
+### JSON Base Types
+
+For now, we use K's `Bool`, `Int`, and `String` types directly for representing JSON base types, even though it's not quite correct.
+
+```k
+    syntax JSONBool   = Bool
+    syntax JSONNumber = Int
+    syntax JSONString = String
+ // --------------------------
+```
+
+### JSON Values
+
+A JSON Value is the top-level data-type exported by the standard.
+
+```k
+    syntax JSONValue ::= JSONObject
+                       | JSONArray
+                       | JSONNumber
+                       | JSONString
+                       | JSONBool
+                       | "null"     [klabel(JSONnull), symbol]
+ // ----------------------------------------------------------
+```
+
+### JSON Objects
+
+JSON Objects are used to implement key-value pairs.
+
+```k
+    syntax JSONObjectEntry  ::= JSONString ":" JSONValue   [klabel(JSONObjectEntry) , symbol]
+    syntax JSONObjectEntrys ::= List{JSONObjectEntry, ","} [klabel(JSONObjectEntrys), symbol]
+ // -----------------------------------------------------------------------------------------
+
+    syntax JSONObject ::= "{" JSONObjectEntrys "}" [klabel(JSONObject), symbol]
+ // ---------------------------------------------------------------------------
+```
+
+### JSON Arrays
+
+JSON Arrays are ordered groupings of JSON Values.
+
+```k
+    syntax JSONArrayEntrys ::= List{JSONValue, ","} [klabel(JSONArrayEntrys), symbol]
+ // ---------------------------------------------------------------------------------
+
+    syntax JSONArray ::= "[" JSONArrayEntrys "]" [klabel(JSONArray), symbol]
+ // ------------------------------------------------------------------------
+```
+
+```k
+endmodule
+```
+
+JSON Extensions and Functions
+-----------------------------
+
+```k
+module JSON-EXT
+    imports JSON
 ```
 
 -   `reverseJSONs` reverses a JSON list.
@@ -47,6 +101,9 @@ endmodule
 
 JSON-RPC
 --------
+
+Many servers export a JSON RPC endpoint to make communicating and controlling them easier.
+This is a simple implementation of a JSON RPC server that other definitions can import for that purpose.
 
 ```k
 module JSON-RPC

--- a/json.md
+++ b/json.md
@@ -1,7 +1,10 @@
-### JSON Formatting
+KJSON
+=====
 
-The JSON format is used extensively for communication in the Ethereum circles.
-Writing a JSON-ish parser in K takes 6 lines.
+This is a near-faithful implementation of the [ECMA-404 JSON Data Interchange Format](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
+There are issues with how `JSONNumber` and `JSONString` are specified here, because we use K's `String` and `Int` sort directly, which are not quite correct.
+
+### JSON Syntax
 
 ```k
 module JSON

--- a/state-loader.md
+++ b/state-loader.md
@@ -1,7 +1,7 @@
 State Manager
 -------------
 
-```{.k}
+```k
 requires "evm.k"
 requires "asm.k"
 
@@ -19,7 +19,7 @@ module STATE-LOADER
 -   `clear` clears all the execution state of the machine.
 -   `clearX` clears the substate `X`, for `TX`, `BLOCK`, and `NETWORK`.
 
-```{.k}
+```k
     syntax EthereumCommand ::= "clear"
  // ----------------------------------
     rule <k> clear => clearTX ~> clearBLOCK ~> clearNETWORK ... </k>
@@ -84,7 +84,7 @@ module STATE-LOADER
 
 -   `mkAcct_` creates an account with the supplied ID (assuming it's already been chopped to 160 bits).
 
-```{.k}
+```k
     syntax EthereumCommand ::= "mkAcct" Int
  // ---------------------------------------
     rule <k> mkAcct ACCT => #newAccount ACCT ... </k>
@@ -92,7 +92,7 @@ module STATE-LOADER
 
 -   `load` loads an account or transaction into the world state.
 
-```{.k}
+```k
     syntax EthereumCommand ::= "load" JSON
  // --------------------------------------
     rule <k> load DATA : { .JSONs }             => .                                                   ... </k>
@@ -105,7 +105,7 @@ module STATE-LOADER
 
 Here we perform pre-proccesing on account data which allows "pretty" specification of input.
 
-```{.k}
+```k
     rule <k> load "pre" : { (ACCTID:String) : ACCT } => mkAcct #parseAddr(ACCTID) ~> loadAccount #parseAddr(ACCTID) ACCT ... </k>
 
     syntax EthereumCommand ::= "loadAccount" Int JSON
@@ -127,7 +127,7 @@ Here we perform pre-proccesing on account data which allows "pretty" specificati
 
 Here we load the environmental information.
 
-```{.k}
+```k
     rule <k> load "env" : { KEY : ((VAL:String) => #parseWord(VAL)) } ... </k>
       requires KEY in (SetItem("currentTimestamp") SetItem("currentGasLimit") SetItem("currentNumber") SetItem("currentDifficulty"))
     rule <k> load "env" : { KEY : ((VAL:String) => #parseHexWord(VAL)) } ... </k>
@@ -158,7 +158,7 @@ Here we load the environmental information.
 
 The `"network"` key allows setting the fee schedule inside the test.
 
-```{.k}
+```k
     rule <k> load "network" : SCHEDSTRING => . ... </k>
          <schedule> _ => #asScheduleString(SCHEDSTRING) </schedule>
 
@@ -176,7 +176,7 @@ The `"network"` key allows setting the fee schedule inside the test.
 
 The `"rlp"` key loads the block information.
 
-```{.k}
+```k
     rule <k> load "rlp"        : (VAL:String => #rlpDecode(#unparseByteStack(#parseByteStack(VAL)))) ... </k>
     rule <k> load "genesisRLP" : (VAL:String => #rlpDecode(#unparseByteStack(#parseByteStack(VAL)))) ... </k>
  // ---------------------------------------------------------------------------------------------------------
@@ -267,7 +267,7 @@ The `"rlp"` key loads the block information.
 
 ### Block Identifiers
 
-```{.k}
+```k
     syntax BlockIdentifier ::= Int
                              | "LATEST"
                              | "PENDING"
@@ -281,6 +281,6 @@ The `"rlp"` key loads the block information.
     rule #parseBlockIdentifier("earliest") => EARLIEST
     rule #parseBlockIdentifier(BLOCKNUM)   => #parseHexWord(BLOCKNUM) requires substrString(BLOCKNUM,0,2) ==String "0x"
 ```
-```{.k}
+```k
 endmodule
 ```


### PR DESCRIPTION
Fixes: runtimeverification/firefly#630

This makes it so that the JSON specification we use is actually the ECMA-404 standard (or much closer, modulo the regexes used for parsing integers and strings).