### PR TITLE
Simplification rules for bool2Word

### DIFF
--- a/tests/specs/examples/sum-to-n-spec.k
+++ b/tests/specs/examples/sum-to-n-spec.k
@@ -1,7 +1,9 @@
 requires "asm.k"
+requires "../lemmas.k"
 
 module VERIFICATION
     imports EVM-ASSEMBLY
+    imports LEMMAS
 
     rule #sizeWordStack ( WS , N:Int )
       => N +Int #sizeWordStack ( WS , 0 )

--- a/tests/specs/lemmas.k
+++ b/tests/specs/lemmas.k
@@ -274,4 +274,7 @@ module LEMMAS-HASKELL [symbolic, kore]
     // Defineness axiom for #buf
     rule #Ceil(#buf(@SIZE, @DATA)) => {(@SIZE >=Int 0) #Equals true} #And #Ceil(@SIZE) #And #Ceil(@DATA) [anywhere]
 
+    rule bool2Word( B:Bool ) ==Int 1 => B         [simplification]
+    rule bool2Word( B:Bool ) ==Int 0 => notBool B [simplification]
+
 endmodule


### PR DESCRIPTION
The Haskell backend will use these simplification rules to simplify the common
patterns `bool2Word(B) ==Int 0` and `bool2Word(B) ==Int 1` to fix a performance
regression. Previously, the frontend emitted rules that generalized `==Int` to
`==K`. Then, the backend would branch on `==K`. However, branching causes other
performance problems, so the simplification rules seem like a good compromise.

Fixes kframework/kore#1686