### PR TITLE
Add back Jello Paper deploy

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,26 +8,14 @@ pipeline {
     PACKAGE      = 'kevm'
     ROOT_URL     = 'https://github.com/kframework/evm-semantics/releases/download'
   }
-  options {
-    ansiColor('xterm')
-  }
+  options { ansiColor('xterm') }
   stages {
     stage("Init title") {
-      when {
-        changeRequest()
-        beforeAgent true
-      }
-      steps {
-        script {
-          currentBuild.displayName = "PR ${env.CHANGE_ID}: ${env.CHANGE_TITLE}"
-        }
-      }
+      when { changeRequest() }
+      steps { script { currentBuild.displayName = "PR ${env.CHANGE_ID}: ${env.CHANGE_TITLE}" } }
     }
     stage('Build and Test') {
-      when {
-        changeRequest()
-        beforeAgent true
-      }
+      when { changeRequest() }
       agent {
         dockerfile {
           additionalBuildArgs '--build-arg USER_ID=$(id -u) --build-arg GROUP_ID=$(id -g)'
@@ -38,54 +26,18 @@ pipeline {
       stages {
         stage('Dependencies') {
           parallel {
-            stage('K') {
-              steps {
-                sh '''
-                  make deps RELEASE=true
-                '''
-              }
-            }
-            stage('Tests') {
-              steps {
-                sh '''
-                  make split-tests -j3
-                '''
-              }
-            }
+            stage('K')     { steps { sh 'make deps RELEASE=true' } }
+            stage('Tests') { steps { sh 'make split-tests -j3'   } }
           }
         }
-        stage('Build') {
-          steps {
-            sh '''
-              make build -j4
-            '''
-          }
-        }
+        stage('Build') { steps { sh 'make build -j4' } }
         stage('Test Execution') {
           failFast true
           options { timeout(time: 20, unit: 'MINUTES') }
           parallel {
-            stage('Conformance (LLVM)') {
-              steps {
-                sh '''
-                  make test-conformance -j8 TEST_CONCRETE_BACKEND=llvm
-                '''
-              }
-            }
-            stage('VM (Haskell)') {
-              steps {
-                sh '''
-                  make test-vm -j8 TEST_CONCRETE_BACKEND=haskell
-                '''
-              }
-            }
-            stage('Conformance (Web3)') {
-              steps {
-                sh '''
-                  make test-web3 -j8
-                '''
-              }
-            }
+            stage('Conformance (LLVM)') { steps { sh 'make test-conformance -j8 TEST_CONCRETE_BACKEND=llvm' } }
+            stage('VM (Haskell)')       { steps { sh 'make test-vm -j8 TEST_CONCRETE_BACKEND=haskell'       } }
+            stage('Conformance (Web3)') { steps { sh 'make test-web3 -j8'                                   } }
           }
         }
         stage('Proofs') {
@@ -94,82 +46,22 @@ pipeline {
             timeout(time: 55, unit: 'MINUTES')
           }
           parallel {
-            stage('Java + Haskell') {
-              steps {
-                sh '''
-                  make test-prove -j6
-                '''
-              }
-            }
-            stage('Haskell (dry-run)') {
-              steps {
-                sh '''
-                  make test-prove -j2 KPROVE_OPTIONS='--dry-run' TEST_SYMBOLIC_BACKEND='haskell'
-                '''
-              }
-            }
+            stage('Java + Haskell')    { steps { sh 'make test-prove -j6'                                                        } }
+            stage('Haskell (dry-run)') { steps { sh 'make test-prove -j2 KPROVE_OPTIONS=--dry-run TEST_SYMBOLIC_BACKEND=haskell' } }
           }
         }
         stage('Test Interactive') {
           failFast true
           options { timeout(time: 35, unit: 'MINUTES') }
           parallel {
-            stage('LLVM krun') {
-              steps {
-                sh '''
-                  make test-interactive-run TEST_CONCRETE_BACKEND=llvm
-                '''
-              }
-            }
-            stage('Java krun') {
-              steps {
-                sh '''
-                  make test-interactive-run TEST_CONCRETE_BACKEND=java
-                '''
-              }
-            }
-            stage('Haskell krun') {
-              steps {
-                sh '''
-                  make test-interactive-run TEST_CONCRETE_BACKEND=haskell
-                '''
-              }
-            }
-            stage('LLVM Kast') {
-              steps {
-                sh '''
-                  make test-parse TEST_CONCRETE_BACKEND=llvm
-                '''
-              }
-            }
-            stage('Failing tests') {
-              steps {
-                sh '''
-                  make test-failure TEST_CONCRETE_BACKEND=llvm
-                '''
-              }
-            }
-            stage('Java KLab') {
-              steps {
-                sh '''
-                  make test-klab-prove TEST_SYMBOLIC_BACKEND=java
-                '''
-              }
-            }
-            stage('Haskell Search') {
-              steps {
-                sh '''
-                  make test-interactive-search TEST_SYMBOLIC_BACKEND=haskell -j4
-                '''
-              }
-            }
-            stage('KEVM help') {
-              steps {
-                sh '''
-                  ./kevm help
-                '''
-              }
-            }
+            stage('LLVM krun')      { steps { sh 'make test-interactive-run TEST_CONCRETE_BACKEND=llvm'           } }
+            stage('Java krun')      { steps { sh 'make test-interactive-run TEST_CONCRETE_BACKEND=java'           } }
+            stage('Haskell krun')   { steps { sh 'make test-interactive-run TEST_CONCRETE_BACKEND=haskell'        } }
+            stage('LLVM Kast')      { steps { sh 'make test-parse TEST_CONCRETE_BACKEND=llvm'                     } }
+            stage('Failing tests')  { steps { sh 'make test-failure TEST_CONCRETE_BACKEND=llvm'                   } }
+            stage('Java KLab')      { steps { sh 'make test-klab-prove TEST_SYMBOLIC_BACKEND=java'                } }
+            stage('Haskell Search') { steps { sh 'make test-interactive-search TEST_SYMBOLIC_BACKEND=haskell -j4' } }
+            stage('KEVM help')      { steps { sh './kevm help'                                                    } }
           }
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -68,52 +68,54 @@ pipeline {
     }
     stage('Deploy') {
       agent { dockerfile { reuseNode true } }
-        stages {
-          stage('Update Dependents') {
-            when { branch 'master' }
-            steps {
-              build job: 'rv-devops/master', propagate: false, wait: false                                     \
-                  , parameters: [ booleanParam(name: 'UPDATE_DEPS_SUBMODULE', value: true)                     \
-                                , string(name: 'PR_REVIEWER', value: 'ehildenb')                               \
-                                , string(name: 'UPDATE_DEPS_REPOSITORY', value: 'runtimeverification/firefly') \
-                                , string(name: 'UPDATE_DEPS_SUBMODULE_DIR', value: 'deps/evm-semantics')       \
-                                ]
-              build job: 'rv-devops/master', propagate: false, wait: false                                                \
-                  , parameters: [ booleanParam(name: 'UPDATE_DEPS_SUBMODULE', value: true)                                \
-                                , string(name: 'PR_REVIEWER', value: 'ehildenb')                                          \
-                                , string(name: 'UPDATE_DEPS_REPOSITORY', value: 'runtimeverification/erc20-verification') \
-                                , string(name: 'UPDATE_DEPS_SUBMODULE_DIR', value: 'deps/evm-semantics')                  \
-                                ]
-            }
+      stages {
+        stage('Update Dependents') {
+          when { branch 'master' }
+          steps {
+            build job: 'rv-devops/master', propagate: false, wait: false                                     \
+                , parameters: [ booleanParam(name: 'UPDATE_DEPS_SUBMODULE', value: true)                     \
+                              , string(name: 'PR_REVIEWER', value: 'ehildenb')                               \
+                              , string(name: 'UPDATE_DEPS_REPOSITORY', value: 'runtimeverification/firefly') \
+                              , string(name: 'UPDATE_DEPS_SUBMODULE_DIR', value: 'deps/evm-semantics')       \
+                              ]
+            build job: 'rv-devops/master', propagate: false, wait: false                                                \
+                , parameters: [ booleanParam(name: 'UPDATE_DEPS_SUBMODULE', value: true)                                \
+                              , string(name: 'PR_REVIEWER', value: 'ehildenb')                                          \
+                              , string(name: 'UPDATE_DEPS_REPOSITORY', value: 'runtimeverification/erc20-verification') \
+                              , string(name: 'UPDATE_DEPS_SUBMODULE_DIR', value: 'deps/evm-semantics')                  \
+                              ]
           }
-          stage('Deploy Jello Paper') {
-            steps {
-              sshagent(['2b3d8d6b-0855-4b59-864a-6b3ddf9c9d1a']) {
-                dir("kevm-${env.VERSION}-jello-paper") {
-                  checkout scm
-                  sh '''
-                    git config --global user.email "admin@runtimeverification.com"
-                    git config --global user.name  "RV Jenkins"
-                    mkdir -p ~/.ssh
-                    echo 'host github.com'                       > ~/.ssh/config
-                    echo '    hostname github.com'              >> ~/.ssh/config
-                    echo '    user git'                         >> ~/.ssh/config
-                    echo '    identityagent SSH_AUTH_SOCK'      >> ~/.ssh/config
-                    echo '    stricthostkeychecking accept-new' >> ~/.ssh/config
-                    chmod go-rwx -R ~/.ssh
-                    ssh github.com || true
-                    git remote set-url origin 'ssh://github.com/kframework/evm-semantics'
-                    git checkout -B 'gh-pages'
-                    rm -rf .build .gitignore .gitmodules cmake deps Dockerfile Jenkinsfile kast-json.py kevm kore-json.py LICENSE Makefile media package
-                    git add ./
-                    git commit -m 'gh-pages: remove unrelated content'
-                    git fetch origin gh-pages
-                    git merge --strategy ours FETCH_HEAD
-                    git push origin gh-pages
-                  '''
-                }
+        }
+        stage('Deploy Jello Paper') {
+          steps {
+            sshagent(['2b3d8d6b-0855-4b59-864a-6b3ddf9c9d1a']) {
+              dir("kevm-${env.VERSION}-jello-paper") {
+                checkout scm
+                sh '''
+                  git config --global user.email "admin@runtimeverification.com"
+                  git config --global user.name  "RV Jenkins"
+                  mkdir -p ~/.ssh
+                  echo 'host github.com'                       > ~/.ssh/config
+                  echo '    hostname github.com'              >> ~/.ssh/config
+                  echo '    user git'                         >> ~/.ssh/config
+                  echo '    identityagent SSH_AUTH_SOCK'      >> ~/.ssh/config
+                  echo '    stricthostkeychecking accept-new' >> ~/.ssh/config
+                  chmod go-rwx -R ~/.ssh
+                  ssh github.com || true
+                  git remote set-url origin 'ssh://github.com/kframework/evm-semantics'
+                  git checkout -B 'gh-pages'
+                  rm -rf .build .gitignore .gitmodules cmake deps Dockerfile Jenkinsfile kast-json.py kevm kore-json.py LICENSE Makefile media package
+                  git add ./
+                  git commit -m 'gh-pages: remove unrelated content'
+                  git fetch origin gh-pages
+                  git merge --strategy ours FETCH_HEAD
+                  git push origin gh-pages
+                '''
               }
             }
           }
+        }
+      }
+    }
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -86,7 +86,7 @@ pipeline {
                               ]
           }
         }
-        stage('Deploy Jello Paper') {
+        stage('Jello Paper') {
           steps {
             sshagent(['2b3d8d6b-0855-4b59-864a-6b3ddf9c9d1a']) {
               dir("kevm-${env.VERSION}-jello-paper") {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@ pipeline {
       steps { script { currentBuild.displayName = "PR ${env.CHANGE_ID}: ${env.CHANGE_TITLE}" } }
     }
     stage('Build and Test') {
-      when { changeRequest() }
+      when { branch 'master' }
       agent {
         dockerfile {
           additionalBuildArgs '--build-arg USER_ID=$(id -u) --build-arg GROUP_ID=$(id -g)'
@@ -68,9 +68,9 @@ pipeline {
     }
     stage('Deploy') {
       agent { dockerfile { reuseNode true } }
-      when { branch 'master' }
         stages {
           stage('Update Dependents') {
+            when { branch 'master' }
             steps {
               build job: 'rv-devops/master', propagate: false, wait: false                                     \
                   , parameters: [ booleanParam(name: 'UPDATE_DEPS_SUBMODULE', value: true)                     \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -90,7 +90,6 @@ pipeline {
           steps {
             sshagent(['2b3d8d6b-0855-4b59-864a-6b3ddf9c9d1a']) {
               dir("kevm-${env.VERSION}-jello-paper") {
-                checkout scm
                 sh '''
                   git config --global user.email "admin@runtimeverification.com"
                   git config --global user.name  "RV Jenkins"
@@ -102,8 +101,9 @@ pipeline {
                   echo '    stricthostkeychecking accept-new' >> ~/.ssh/config
                   chmod go-rwx -R ~/.ssh
                   ssh github.com || true
-                  git remote set-url origin 'ssh://github.com/kframework/evm-semantics'
-                  git checkout -B 'gh-pages'
+                  git clone 'ssh://github.com/kframework/evm-semantics.git'
+                  cd evm-semantics
+                  git checkout -B gh-pages origin/master
                   rm -rf .build .gitignore .gitmodules cmake deps Dockerfile Jenkinsfile kast-json.py kevm kore-json.py LICENSE Makefile media package
                   git add ./
                   git commit -m 'gh-pages: remove unrelated content'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@ pipeline {
       steps { script { currentBuild.displayName = "PR ${env.CHANGE_ID}: ${env.CHANGE_TITLE}" } }
     }
     stage('Build and Test') {
-      when { branch 'master' }
+      when { changeRequest() }
       agent {
         dockerfile {
           additionalBuildArgs '--build-arg USER_ID=$(id -u) --build-arg GROUP_ID=$(id -g)'
@@ -67,10 +67,10 @@ pipeline {
       }
     }
     stage('Deploy') {
+      when { branch 'master' }
       agent { dockerfile { reuseNode true } }
       stages {
         stage('Update Dependents') {
-          when { branch 'master' }
           steps {
             build job: 'rv-devops/master', propagate: false, wait: false                                     \
                 , parameters: [ booleanParam(name: 'UPDATE_DEPS_SUBMODULE', value: true)                     \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -66,22 +66,54 @@ pipeline {
         }
       }
     }
-    stage('Update Dependents') {
+    stage('Deploy') {
+      agent { dockerfile { reuseNode true } }
       when { branch 'master' }
-      steps {
-        build job: 'rv-devops/master', propagate: false, wait: false                                     \
-            , parameters: [ booleanParam(name: 'UPDATE_DEPS_SUBMODULE', value: true)                     \
-                          , string(name: 'PR_REVIEWER', value: 'ehildenb')                               \
-                          , string(name: 'UPDATE_DEPS_REPOSITORY', value: 'runtimeverification/firefly') \
-                          , string(name: 'UPDATE_DEPS_SUBMODULE_DIR', value: 'deps/evm-semantics')       \
-                          ]
-        build job: 'rv-devops/master', propagate: false, wait: false                                                \
-            , parameters: [ booleanParam(name: 'UPDATE_DEPS_SUBMODULE', value: true)                                \
-                          , string(name: 'PR_REVIEWER', value: 'ehildenb')                                          \
-                          , string(name: 'UPDATE_DEPS_REPOSITORY', value: 'runtimeverification/erc20-verification') \
-                          , string(name: 'UPDATE_DEPS_SUBMODULE_DIR', value: 'deps/evm-semantics')                  \
-                          ]
-      }
-    }
+        stages {
+          stage('Update Dependents') {
+            steps {
+              build job: 'rv-devops/master', propagate: false, wait: false                                     \
+                  , parameters: [ booleanParam(name: 'UPDATE_DEPS_SUBMODULE', value: true)                     \
+                                , string(name: 'PR_REVIEWER', value: 'ehildenb')                               \
+                                , string(name: 'UPDATE_DEPS_REPOSITORY', value: 'runtimeverification/firefly') \
+                                , string(name: 'UPDATE_DEPS_SUBMODULE_DIR', value: 'deps/evm-semantics')       \
+                                ]
+              build job: 'rv-devops/master', propagate: false, wait: false                                                \
+                  , parameters: [ booleanParam(name: 'UPDATE_DEPS_SUBMODULE', value: true)                                \
+                                , string(name: 'PR_REVIEWER', value: 'ehildenb')                                          \
+                                , string(name: 'UPDATE_DEPS_REPOSITORY', value: 'runtimeverification/erc20-verification') \
+                                , string(name: 'UPDATE_DEPS_SUBMODULE_DIR', value: 'deps/evm-semantics')                  \
+                                ]
+            }
+          }
+          stage('Deploy Jello Paper') {
+            steps {
+              sshagent(['2b3d8d6b-0855-4b59-864a-6b3ddf9c9d1a']) {
+                dir("kevm-${env.VERSION}-jello-paper") {
+                  checkout scm
+                  sh '''
+                    git config --global user.email "admin@runtimeverification.com"
+                    git config --global user.name  "RV Jenkins"
+                    mkdir -p ~/.ssh
+                    echo 'host github.com'                       > ~/.ssh/config
+                    echo '    hostname github.com'              >> ~/.ssh/config
+                    echo '    user git'                         >> ~/.ssh/config
+                    echo '    identityagent SSH_AUTH_SOCK'      >> ~/.ssh/config
+                    echo '    stricthostkeychecking accept-new' >> ~/.ssh/config
+                    chmod go-rwx -R ~/.ssh
+                    ssh github.com || true
+                    git remote set-url origin 'ssh://github.com/kframework/evm-semantics'
+                    git checkout -B 'gh-pages'
+                    rm -rf .build .gitignore .gitmodules cmake deps Dockerfile Jenkinsfile kast-json.py kevm kore-json.py LICENSE Makefile media package
+                    git add ./
+                    git commit -m 'gh-pages: remove unrelated content'
+                    git fetch origin gh-pages
+                    git merge --strategy ours FETCH_HEAD
+                    git push origin gh-pages
+                  '''
+                }
+              }
+            }
+          }
   }
 }


### PR DESCRIPTION
It may be good to view the changes of the first commit separately from the remaining commits.

The first commit reformats the Jenkinsfile according to new formatting rules which I'm trying out in Firefly, which I prefer:

-    Any node which only has a single child (and every child also only has a single child) gets a single line.
-    Line up code as much as possible.

This makes the Jenkinsfile a lot more compact/uniform, and thus easier to read.

The remaining commits add back the Jello Paper deploy. The only tricky bit is that we can't use a `checkout scm` step for it because we need to do git operations, and the git reference cache is not available inside the docker container. So instead we just do a fresh clone on the command line.