### PR TITLE
Make `#range` and `_[_.._]` total on Bytes builds

### DIFF
--- a/evm-types.md
+++ b/evm-types.md
@@ -590,9 +590,12 @@ The local memory of execution is a byte-array (instead of a word-array).
 
     syntax ByteArray ::= ByteArray "[" Int ".." Int "]" [function, functional]
  // --------------------------------------------------------------------------
-    rule WS [ START .. WIDTH ] => .ByteArray                                                                   requires notBool (WIDTH >=Int 0)
-    rule WS [ START .. WIDTH ] => substrBytes(padRightBytes(WS, START +Int WIDTH, 0), START, START +Int WIDTH) requires          WIDTH >=Int 0 andBool START <Int #sizeByteArray(WS) [concrete]
-    rule WS [ START .. WIDTH ] => padRightBytes(.Bytes, WIDTH, 0)                                                                                                                    [concrete, owise]
+    rule WS [ START .. WIDTH ] => padRightBytes(.Bytes, WIDTH, 0)
+      [concrete, owise]
+    rule WS [ START .. WIDTH ] => .ByteArray
+      requires notBool (WIDTH >=Int 0 andBool START >=Int 0)
+    rule WS [ START .. WIDTH ] => substrBytes(padRightBytes(WS, START +Int WIDTH, 0), START, START +Int WIDTH)
+      requires WIDTH >=Int 0 andBool START >=Int 0 andBool START <Int #sizeByteArray(WS) [concrete]
 
     syntax Int ::= #sizeByteArray ( ByteArray ) [function, functional, klabel(sizeByteArray), smtlib(sizeByteArray)]
  // ----------------------------------------------------------------------------------------------------------------

--- a/evm-types.md
+++ b/evm-types.md
@@ -482,8 +482,8 @@ Most of EVM data is held in local memory.
  // -------------------------------------------------------------------------------------
     rule WS [ START := WS' ] => replaceAtBytes(padRightBytes(WS, START +Int #sizeByteArray(WS'), 0), START, WS')  [concrete]
 
-    syntax ByteArray ::= #range ( Memory , Int , Int ) [function]
- // -------------------------------------------------------------
+    syntax ByteArray ::= #range ( Memory , Int , Int ) [function, functional]
+ // -------------------------------------------------------------------------
     rule #range(LM, START, WIDTH) => LM [ START .. WIDTH ] [concrete]
 
     syntax Memory ::= ".Memory" [function]

--- a/evm-types.md
+++ b/evm-types.md
@@ -590,10 +590,8 @@ The local memory of execution is a byte-array (instead of a word-array).
 
     syntax ByteArray ::= ByteArray "[" Int ".." Int "]" [function, functional]
  // --------------------------------------------------------------------------
-    rule WS [ START .. WIDTH ] => padRightBytes(.Bytes, WIDTH, 0)
-      [concrete, owise]
-    rule WS [ START .. WIDTH ] => .ByteArray
-      requires notBool (WIDTH >=Int 0 andBool START >=Int 0)
+    rule WS [ START .. WIDTH ] => padRightBytes(.Bytes, WIDTH, 0) [concrete, owise]
+    rule WS [ START .. WIDTH ] => .ByteArray                      requires notBool (WIDTH >=Int 0 andBool START >=Int 0)
     rule WS [ START .. WIDTH ] => substrBytes(padRightBytes(WS, START +Int WIDTH, 0), START, START +Int WIDTH)
       requires WIDTH >=Int 0 andBool START >=Int 0 andBool START <Int #sizeByteArray(WS) [concrete]
 

--- a/evm-types.md
+++ b/evm-types.md
@@ -588,10 +588,11 @@ The local memory of execution is a byte-array (instead of a word-array).
  // -------------------------------------------------------------------------------------------------------------
     rule WS ++ WS' => WS +Bytes WS' [concrete]
 
-    syntax ByteArray ::= ByteArray "[" Int ".." Int "]" [function]
- // --------------------------------------------------------------
-    rule WS [ START .. WIDTH ] => substrBytes(padRightBytes(WS, START +Int WIDTH, 0), START, START +Int WIDTH) requires START <Int #sizeByteArray(WS) [concrete]
-    rule WS [ START .. WIDTH ] => padRightBytes(.Bytes, WIDTH, 0)                                              [owise, concrete]
+    syntax ByteArray ::= ByteArray "[" Int ".." Int "]" [function, functional]
+ // --------------------------------------------------------------------------
+    rule WS [ START .. WIDTH ] => .ByteArray                                                                   requires notBool (WIDTH >=Int 0)
+    rule WS [ START .. WIDTH ] => substrBytes(padRightBytes(WS, START +Int WIDTH, 0), START, START +Int WIDTH) requires          WIDTH >=Int 0 andBool START <Int #sizeByteArray(WS) [concrete]
+    rule WS [ START .. WIDTH ] => padRightBytes(.Bytes, WIDTH, 0)                                                                                                                    [concrete, owise]
 
     syntax Int ::= #sizeByteArray ( ByteArray ) [function, functional, klabel(sizeByteArray), smtlib(sizeByteArray)]
  // ----------------------------------------------------------------------------------------------------------------

--- a/tests/specs/functional/lemmas-spec.k
+++ b/tests/specs/functional/lemmas-spec.k
@@ -32,7 +32,7 @@ module LEMMAS-SPEC
 
     // Range outside of previous buffer write
     rule <k> runLemma ( #range(M [ 32 := BUF:ByteArray ], 20, 4) ) => doneLemma ( #range(M, 20, 4) ) ... </k>
-    // rule <k> runLemma ( #range(M [ 32 := BUF:ByteArray ], 48, 4) ) => doneLemma ( #range(M, 48, 4) ) ... </k> requires #sizeByteArray(BUF) <=Int 12
+    rule <k> runLemma ( #range(M [ 32 := BUF:ByteArray ], 48, 4) ) => doneLemma ( #range(M, 48, 4) ) ... </k> requires #sizeByteArray(BUF) <=Int 12
     rule <k> runLemma ( #range(M [ 32 := BUF:ByteArray ], 31, 1) ) => doneLemma ( #range(M, 31, 1) ) ... </k>
     rule <k> runLemma ( #range(M [ 32 := #buf(1, BUF) ], 33, 1) )  => doneLemma ( #range(M, 33, 1) ) ... </k>
 


### PR DESCRIPTION
Currently both `#range` and `_[_.._]` are marked as partial, because there were some cases that were undefined.

I've added a case to `_[_.._]` to make it total, so that we don't produce definedness conditions for this symbol.