### PR TITLE
loadTransaction: Ignore fields that aren't part of the web3 spec

### DIFF
--- a/web3.md
+++ b/web3.md
@@ -626,18 +626,18 @@ eth_sendTransaction
     rule <k> _:String ~> #eth_sendTransaction_final => #rpcResponseError(-32000, "VM exception: " +String StatusCode2String( SC )) ... </k>
          <statusCode> SC:ExceptionalStatusCode </statusCode> [owise]
 
-    rule <k> loadTransaction _ { "gas"      : (TG:String => #parseHexWord(TG)), _                 } ... </k>
-    rule <k> loadTransaction _ { "gasPrice" : (TP:String => #parseHexWord(TP)), _                 } ... </k>
-    rule <k> loadTransaction _ { "nonce"    : (TN:String => #parseHexWord(TN)), _                 } ... </k>
-    rule <k> loadTransaction _ { "v"        : (TW:String => #parseHexWord(TW)), _                 } ... </k>
-    rule <k> loadTransaction _ { "value"    : (TV:String => #parseHexWord(TV)), _                 } ... </k>
-    rule <k> loadTransaction _ { "to"       : (TT:String => #parseHexWord(TT)), _                 } ... </k> requires TT =/=String ""
-    rule <k> loadTransaction _ { "to"       : ""                              , REST => REST      } ... </k>
-    rule <k> loadTransaction _ { "data"     : (TI:String => #parseByteStack(TI)), _               } ... </k>
+    rule <k> loadTransaction _ { "gas"      : (TG:String => #parseHexWord(TG)), _                    } ... </k>
+    rule <k> loadTransaction _ { "gasPrice" : (TP:String => #parseHexWord(TP)), _                    } ... </k>
+    rule <k> loadTransaction _ { "nonce"    : (TN:String => #parseHexWord(TN)), _                    } ... </k>
+    rule <k> loadTransaction _ { "v"        : (TW:String => #parseHexWord(TW)), _                    } ... </k>
+    rule <k> loadTransaction _ { "value"    : (TV:String => #parseHexWord(TV)), _                    } ... </k>
+    rule <k> loadTransaction _ { "to"       : (TT:String => #parseHexWord(TT)), _                    } ... </k> requires TT =/=String ""
+    rule <k> loadTransaction _ { "to"       : ""                              , REST => REST         } ... </k>
+    rule <k> loadTransaction _ { "data"     : (TI:String => #parseByteStack(TI)), _                  } ... </k>
     rule <k> loadTransaction _ { "r"        : (TR:String => #padToWidth(32, #parseByteStack(TR))), _ } ... </k>
     rule <k> loadTransaction _ { "s"        : (TS:String => #padToWidth(32, #parseByteStack(TS))), _ } ... </k>
-    rule <k> loadTransaction _ { ("from"    : _, REST => REST) } ... </k>
-    rule <k> loadTransaction _ { (("amount" : TV) => "value": TV), REST                  } ... </k>
+    rule <k> loadTransaction _ { ("from"    : _, REST => REST)                                       } ... </k>
+    rule <k> loadTransaction _ { (("amount" : TV) => "value": TV)             , REST                 } ... </k>
     rule <k> loadTransaction _ { _          : _                               , REST => REST         } ... </k> [owise]
 
     syntax EthereumCommand ::= "makeTX" Int

--- a/web3.md
+++ b/web3.md
@@ -638,6 +638,7 @@ eth_sendTransaction
     rule <k> loadTransaction _ { "s"        : (TS:String => #padToWidth(32, #parseByteStack(TS))), _ } ... </k>
     rule <k> loadTransaction _ { ("from"    : _, REST => REST) } ... </k>
     rule <k> loadTransaction _ { (("amount" : TV) => "value": TV), REST                  } ... </k>
+    rule <k> loadTransaction _ { _          : _                               , REST => REST         } ... </k> [owise]
 
     syntax EthereumCommand ::= "makeTX" Int
  // ---------------------------------------


### PR DESCRIPTION
fixes: https://github.com/runtimeverification/firefly/issues/801

This PR simply adds a rule that drops any fields it doesn't know what to do with when loading in a JSON with transaction parameters.