### PR TITLE
Several changes to improve rebuildability/readability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,12 @@
 /.build/*
-/pkg
-/src
+.kompile*
+.kprove*
+.krun*
+/media/*.pdf
 /package/pkg
 /package/src
-/media/*.pdf
+/pkg
+/src
 /tests/specs/**/*.prove.out
-/tests/web3/*.out.json
 /tests/web3/*/*.out.json
+/tests/web3/*.out.json

--- a/Makefile
+++ b/Makefile
@@ -120,10 +120,6 @@ $(K_JAR):
 # Building
 # --------
 
-MAIN_MODULE    := ETHEREUM-SIMULATION
-SYNTAX_MODULE  := $(MAIN_MODULE)
-MAIN_DEFN_FILE := driver
-
 SOURCE_FILES       := asm           \
                       data          \
                       driver        \
@@ -140,12 +136,29 @@ SOURCE_FILES       := asm           \
 EXTRA_SOURCE_FILES :=
 ALL_FILES          := $(patsubst %, %.k, $(SOURCE_FILES) $(EXTRA_SOURCE_FILES))
 
+llvm_main_module    := ETHEREUM-SIMULATION
+java_main_module    := ETHEREUM-SIMULATION
+specs_main_module   := EVM-IMP-SPECS
+haskell_main_module := ETHEREUM-SIMULATION
+web3_main_module    := WEB3
+
+llvm_syntax_module    := $(llvm_main_module)
+java_syntax_module    := $(java_main_module)
+specs_syntax_module   := $(specs_main_module)
+haskell_syntax_module := $(haskell_main_module)
+web3_syntax_module    := $(web3_main_module)
+
+llvm_main_file    := driver
+java_main_file    := driver
+specs_main_file   := evm-imp-specs
+haskell_main_file := driver
+web3_main_file    := web3
+
 llvm_dir    := $(DEFN_DIR)/llvm
 java_dir    := $(DEFN_DIR)/java
 specs_dir   := $(DEFN_DIR)/specs
 haskell_dir := $(DEFN_DIR)/haskell
 web3_dir    := $(abspath $(DEFN_DIR)/web3)
-export web3_dir
 
 llvm_files    := $(patsubst %, $(llvm_dir)/%, $(ALL_FILES))
 java_files    := $(patsubst %, $(java_dir)/%, $(ALL_FILES))
@@ -154,19 +167,13 @@ haskell_files := $(patsubst %, $(haskell_dir)/%, $(ALL_FILES))
 web3_files    := $(patsubst %, $(web3_dir)/%, $(ALL_FILES))
 defn_files    := $(llvm_files) $(java_files) $(specs_files) $(haskell_files) $(web3_files)
 
-java_kompiled    := $(java_dir)/$(MAIN_DEFN_FILE)-kompiled/timestamp
-specs_kompiled   := $(specs_dir)/specs-kompiled/timestamp
+java_kompiled    := $(java_dir)/$(java_main_file)-kompiled/timestamp
+specs_kompiled   := $(specs_dir)/$(specs_main_file)-kompiled/timestamp
 web3_kompiled    := $(web3_dir)/build/kevm-client
-haskell_kompiled := $(haskell_dir)/$(MAIN_DEFN_FILE)-kompiled/definition.kore
-llvm_kompiled    := $(llvm_dir)/$(MAIN_DEFN_FILE)-kompiled/interpreter
+haskell_kompiled := $(haskell_dir)/$(haskell_main_file)-kompiled/definition.kore
+llvm_kompiled    := $(llvm_dir)/$(llvm_main_file)-kompiled/interpreter
 
-web3_kore := $(web3_dir)/$(MAIN_DEFN_FILE)-kompiled/definition.kore
-$(web3_kompiled): MAIN_DEFN_FILE := web3
-$(web3_kompiled): MAIN_MODULE    := WEB3
-$(web3_kompiled): SYNTAX_MODULE  := WEB3
-$(web3_kompiled): web3_kore      := $(web3_dir)/$(MAIN_DEFN_FILE)-kompiled/definition.kore
-
-export MAIN_DEFN_FILE
+web3_kore := $(web3_dir)/$(web3_main_file)-kompiled/definition.kore
 
 # Tangle definition from *.md files
 
@@ -213,40 +220,39 @@ build-llvm:    $(llvm_kompiled)
 # Java
 
 $(java_kompiled): $(java_files)
-	kompile --debug --main-module $(MAIN_MODULE) --backend java              \
-	        --syntax-module $(SYNTAX_MODULE) $(java_dir)/$(MAIN_DEFN_FILE).k \
-	        --directory $(java_dir) -I $(java_dir)                           \
+	kompile --debug --main-module $(java_main_module) --backend java              \
+	        --syntax-module $(java_syntax_module) $(java_dir)/$(java_main_file).k \
+	        --directory $(java_dir) -I $(java_dir)                                \
 	        $(KOMPILE_OPTS)
 
 # Imperative Specs
 
-$(specs_kompiled): MAIN_DEFN_FILE=evm-imp-specs
-$(specs_kompiled): MAIN_MODULE=EVM-IMP-SPECS
-$(specs_kompiled): SYNTAX_MODULE=EVM-IMP-SPECS
-
 $(specs_kompiled): $(specs_files)
-	kompile --debug --main-module $(MAIN_MODULE) --backend java \
-	        --syntax-module $(SYNTAX_MODULE) $(specs_dir)/$(MAIN_DEFN_FILE).k \
-	        --directory $(specs_dir) -I $(specs_dir) \
+	kompile --debug --main-module $(specs_main_module) --backend java                \
+	        --syntax-module $(specs_syntax_module) $(specs_dir)/$(specs_main_file).k \
+	        --directory $(specs_dir) -I $(specs_dir)                                 \
 	        $(KOMPILE_OPTS)
 
 # Haskell
 
 $(haskell_kompiled): $(haskell_files)
-	kompile --debug --main-module $(MAIN_MODULE) --backend haskell --hook-namespaces KRYPTO \
-	        --syntax-module $(SYNTAX_MODULE) $(haskell_dir)/$(MAIN_DEFN_FILE).k             \
-	        --directory $(haskell_dir) -I $(haskell_dir)                                    \
+	kompile --debug --main-module $(haskell_main_module) --backend haskell --hook-namespaces KRYPTO \
+	        --syntax-module $(haskell_syntax_module) $(haskell_dir)/$(haskell_main_file).k          \
+	        --directory $(haskell_dir) -I $(haskell_dir)                                            \
 	        $(KOMPILE_OPTS)
 
 # Web3
 
 $(web3_kore): $(web3_files)
-	kompile --debug --main-module $(MAIN_MODULE) --backend llvm              \
-	        --syntax-module $(SYNTAX_MODULE) $(web3_dir)/$(MAIN_DEFN_FILE).k \
-	        --directory $(web3_dir) -I $(web3_dir)                           \
-	        --hook-namespaces "KRYPTO JSON"                                  \
-	        --no-llvm-kompile                                                \
+	kompile --debug --main-module $(web3_main_module) --backend llvm              \
+	        --syntax-module $(web3_syntax_module) $(web3_dir)/$(web3_main_file).k \
+	        --directory $(web3_dir) -I $(web3_dir)                                \
+	        --hook-namespaces "KRYPTO JSON"                                       \
+	        --no-llvm-kompile                                                     \
 	        $(KOMPILE_OPTS)
+
+export web3_main_file
+export web3_dir
 
 $(web3_kompiled): $(web3_kore) $(libff_out)
 	@mkdir -p $(web3_dir)/build
@@ -264,11 +270,11 @@ ifeq ($(UNAME_S),Linux)
 endif
 
 $(llvm_kompiled): $(llvm_files) $(libff_out)
-	kompile --debug --main-module $(MAIN_MODULE) --backend llvm                                  \
-	        --syntax-module $(SYNTAX_MODULE) $(llvm_dir)/$(MAIN_DEFN_FILE).k                     \
-	        --directory $(llvm_dir) -I $(llvm_dir)                                               \
-	        --hook-namespaces KRYPTO                                                             \
-	        $(KOMPILE_OPTS)                                                                      \
+	kompile --debug --main-module $(llvm_main_module) --backend llvm              \
+	        --syntax-module $(llvm_syntax_module) $(llvm_dir)/$(llvm_main_file).k \
+	        --directory $(llvm_dir) -I $(llvm_dir)                                \
+	        --hook-namespaces KRYPTO                                              \
+	        $(KOMPILE_OPTS)                                                       \
 	        $(addprefix -ccopt ,$(STANDALONE_KOMPILE_OPTS))
 
 # Installing

--- a/Makefile
+++ b/Makefile
@@ -38,11 +38,12 @@ TANGLER                 := $(PANDOC_TANGLE_SUBMODULE)/tangle.lua
 LUA_PATH                := $(PANDOC_TANGLE_SUBMODULE)/?.lua;;
 export TANGLER
 export LUA_PATH
+defn-java defn-specs defn-haskell defn-web3 defn-llvm
 
 .PHONY: all clean distclean                                                                                                      \
         deps all-deps llvm-deps haskell-deps repo-deps k-deps plugin-deps libsecp256k1 libff                                     \
-        build build-java build-specs build-haskell build-llvm build-web3                                                         \
-        defn defn-java defn-specs defn-web3 defn-haskell defn-llvm                                                               \
+        defn defn-java defn-specs defn-haskell defn-web3 defn-llvm                                                               \
+        build build-java build-specs build-haskell build-web3 build-llvm                                                         \
         test test-all test-conformance test-rest-conformance test-all-conformance test-slow-conformance test-failing-conformance \
         test-vm test-rest-vm test-all-vm test-bchain test-rest-bchain test-all-bchain                                            \
         test-web3 test-all-web3 test-failing-web3                                                                                \
@@ -140,8 +141,8 @@ concrete_tangle := .k:not(.symbolic):not(.nobytes):not(.memmap),.concrete,.bytes
 java_tangle     := .k:not(.concrete):not(.bytes):not(.memmap):not(.membytes),.symbolic,.nobytes
 haskell_tangle  := .k:not(.concrete):not(.nobytes):not(.memmap),.symbolic,.bytes,.membytes
 
-defn:  defn-llvm defn-java defn-specs defn-haskell defn-web3
-build: build-llvm build-haskell build-java build-specs build-web3
+defn:  defn-java defn-specs defn-haskell defn-web3 defn-llvm
+build: build-java build-specs build-haskell build-web3 build-llvm
 
 # Java
 

--- a/Makefile
+++ b/Makefile
@@ -136,44 +136,42 @@ SOURCE_FILES       := asm           \
 EXTRA_SOURCE_FILES :=
 ALL_FILES          := $(patsubst %, %.k, $(SOURCE_FILES) $(EXTRA_SOURCE_FILES))
 
-llvm_main_module    := ETHEREUM-SIMULATION
-java_main_module    := ETHEREUM-SIMULATION
+llvm_dir           := $(DEFN_DIR)/llvm
+llvm_kompiled      := $(llvm_dir)/$(llvm_main_file)-kompiled/interpreter
+llvm_main_module   := ETHEREUM-SIMULATION
+llvm_syntax_module := $(llvm_main_module)
+llvm_main_file     := driver
+
+java_dir           := $(DEFN_DIR)/java
+java_kompiled      := $(java_dir)/$(java_main_file)-kompiled/timestamp
+java_files         := $(patsubst %, $(java_dir)/%, $(ALL_FILES))
+java_main_module   := ETHEREUM-SIMULATION
+java_syntax_module := $(java_main_module)
+java_main_file     := driver
+
+specs_dir           := $(DEFN_DIR)/specs
+specs_kompiled      := $(specs_dir)/$(specs_main_file)-kompiled/timestamp
+specs_files         := $(patsubst %, $(specs_dir)/%, $(ALL_FILES))
 specs_main_module   := EVM-IMP-SPECS
-haskell_main_module := ETHEREUM-SIMULATION
-web3_main_module    := WEB3
+specs_syntax_module := $(specs_main_module)
+specs_main_file     := evm-imp-specs
 
-llvm_syntax_module    := $(llvm_main_module)
-java_syntax_module    := $(java_main_module)
-specs_syntax_module   := $(specs_main_module)
-haskell_syntax_module := $(haskell_main_module)
-web3_syntax_module    := $(web3_main_module)
+haskell_dir            := $(DEFN_DIR)/haskell
+haskell_kompiled       := $(haskell_dir)/$(haskell_main_file)-kompiled/definition.kore
+haskell_files          := $(patsubst %, $(haskell_dir)/%, $(ALL_FILES))
+haskell_main_module    := ETHEREUM-SIMULATION
+haskell_syntax_module  := $(haskell_main_module)
+haskell_main_file      := driver
 
-llvm_main_file    := driver
-java_main_file    := driver
-specs_main_file   := evm-imp-specs
-haskell_main_file := driver
-web3_main_file    := web3
-
-llvm_dir    := $(DEFN_DIR)/llvm
-java_dir    := $(DEFN_DIR)/java
-specs_dir   := $(DEFN_DIR)/specs
-haskell_dir := $(DEFN_DIR)/haskell
-web3_dir    := $(abspath $(DEFN_DIR)/web3)
-
-llvm_files    := $(patsubst %, $(llvm_dir)/%, $(ALL_FILES))
-java_files    := $(patsubst %, $(java_dir)/%, $(ALL_FILES))
-specs_files   := $(patsubst %, $(specs_dir)/%, $(ALL_FILES))
-haskell_files := $(patsubst %, $(haskell_dir)/%, $(ALL_FILES))
-web3_files    := $(patsubst %, $(web3_dir)/%, $(ALL_FILES))
-defn_files    := $(llvm_files) $(java_files) $(specs_files) $(haskell_files) $(web3_files)
-
-java_kompiled    := $(java_dir)/$(java_main_file)-kompiled/timestamp
-specs_kompiled   := $(specs_dir)/$(specs_main_file)-kompiled/timestamp
-web3_kompiled    := $(web3_dir)/build/kevm-client
-haskell_kompiled := $(haskell_dir)/$(haskell_main_file)-kompiled/definition.kore
-llvm_kompiled    := $(llvm_dir)/$(llvm_main_file)-kompiled/interpreter
-
-web3_kore := $(web3_dir)/$(web3_main_file)-kompiled/definition.kore
+web3_dir           := $(abspath $(DEFN_DIR)/web3)
+web3_kompiled      := $(web3_dir)/build/kevm-client
+web3_files         := $(patsubst %, $(web3_dir)/%, $(ALL_FILES))
+web3_main_module   := WEB3
+web3_syntax_module := $(web3_main_module)
+web3_main_file     := web3
+web3_kore          := $(web3_dir)/$(web3_main_file)-kompiled/definition.kore
+export web3_main_file
+export web3_dir
 
 # Tangle definition from *.md files
 
@@ -181,7 +179,7 @@ concrete_tangle := .k:not(.symbolic):not(.nobytes):not(.memmap),.concrete,.bytes
 java_tangle     := .k:not(.concrete):not(.bytes):not(.memmap):not(.membytes),.symbolic,.nobytes
 haskell_tangle  := .k:not(.concrete):not(.nobytes):not(.memmap),.symbolic,.bytes,.membytes
 
-defn: $(defn_files)
+defn: llvm-defn java-defn specs-defn haskell-defn web3-defn
 llvm-defn:    $(llvm_files)
 java-defn:    $(java_files)
 specs-defn:   $(specs_files)
@@ -250,9 +248,6 @@ $(web3_kore): $(web3_files)
 	        --hook-namespaces "KRYPTO JSON"                                       \
 	        --no-llvm-kompile                                                     \
 	        $(KOMPILE_OPTS)
-
-export web3_main_file
-export web3_dir
 
 $(web3_kompiled): $(web3_kore) $(libff_out)
 	@mkdir -p $(web3_dir)/build

--- a/Makefile
+++ b/Makefile
@@ -160,9 +160,10 @@ $(java_dir)/%.k: %.md $(TANGLER)
 	pandoc --from markdown --to "$(TANGLER)" --metadata=code:"$(java_tangle)" $< > $@
 
 $(java_kompiled): $(java_files)
-	kompile --debug --main-module $(java_main_module) --backend java              \
-	        --syntax-module $(java_syntax_module) $(java_dir)/$(java_main_file).k \
-	        --directory $(java_dir) -I $(java_dir)                                \
+	kompile --debug --backend java                                                  \
+	        --directory $(java_dir) -I $(java_dir)                                  \
+	        --main-module $(java_main_module) --syntax-module $(java_syntax_module) \
+	        $(java_dir)/$(java_main_file).k                                         \
 	        $(KOMPILE_OPTS)
 
 # Imperative Specs
@@ -182,9 +183,10 @@ $(specs_dir)/%.k: %.md $(TANGLER)
 	pandoc --from markdown --to "$(TANGLER)" --metadata=code:"$(java_tangle)" $< > $@
 
 $(specs_kompiled): $(specs_files)
-	kompile --debug --main-module $(specs_main_module) --backend java                \
-	        --syntax-module $(specs_syntax_module) $(specs_dir)/$(specs_main_file).k \
-	        --directory $(specs_dir) -I $(specs_dir)                                 \
+	kompile --debug --backend java                                                    \
+	        --directory $(specs_dir) -I $(specs_dir)                                  \
+	        --main-module $(specs_main_module) --syntax-module $(specs_syntax_module) \
+	        $(specs_dir)/$(specs_main_file).k                                         \
 	        $(KOMPILE_OPTS)
 
 # Haskell
@@ -204,9 +206,11 @@ $(haskell_dir)/%.k: %.md $(TANGLER)
 	pandoc --from markdown --to "$(TANGLER)" --metadata=code:"$(haskell_tangle)" $< > $@
 
 $(haskell_kompiled): $(haskell_files)
-	kompile --debug --main-module $(haskell_main_module) --backend haskell --hook-namespaces KRYPTO \
-	        --syntax-module $(haskell_syntax_module) $(haskell_dir)/$(haskell_main_file).k          \
-	        --directory $(haskell_dir) -I $(haskell_dir)                                            \
+	kompile --debug --backend haskell                                                     \
+	        --directory $(haskell_dir) -I $(haskell_dir)                                  \
+	        --main-module $(haskell_main_module) --syntax-module $(haskell_syntax_module) \
+	        $(haskell_dir)/$(haskell_main_file).k                                         \
+	        --hook-namespaces KRYPTO                                                      \
 	        $(KOMPILE_OPTS)
 
 # Web3
@@ -229,11 +233,12 @@ $(web3_dir)/%.k: %.md $(TANGLER)
 	pandoc --from markdown --to "$(TANGLER)" --metadata=code:"$(concrete_tangle)" $< > $@
 
 $(web3_kore): $(web3_files)
-	kompile --debug --main-module $(web3_main_module) --backend llvm              \
-	        --syntax-module $(web3_syntax_module) $(web3_dir)/$(web3_main_file).k \
-	        --directory $(web3_dir) -I $(web3_dir)                                \
-	        --hook-namespaces "KRYPTO JSON"                                       \
-	        --no-llvm-kompile                                                     \
+	kompile --debug --backend llvm                                                  \
+	        --directory $(web3_dir) -I $(web3_dir)                                  \
+	        --main-module $(web3_main_module) --syntax-module $(web3_syntax_module) \
+	        $(web3_dir)/$(web3_main_file).k                                         \
+	        --hook-namespaces "KRYPTO JSON"                                         \
+	        --no-llvm-kompile                                                       \
 	        $(KOMPILE_OPTS)
 
 $(web3_kompiled): $(web3_kore) $(libff_out)
@@ -265,11 +270,12 @@ ifeq ($(UNAME_S),Linux)
 endif
 
 $(llvm_kompiled): $(llvm_files) $(libff_out)
-	kompile --debug --main-module $(llvm_main_module) --backend llvm              \
-	        --syntax-module $(llvm_syntax_module) $(llvm_dir)/$(llvm_main_file).k \
-	        --directory $(llvm_dir) -I $(llvm_dir)                                \
-	        --hook-namespaces KRYPTO                                              \
-	        $(KOMPILE_OPTS)                                                       \
+	kompile --debug --backend llvm                                                  \
+	        --directory $(llvm_dir) -I $(llvm_dir)                                  \
+	        --main-module $(llvm_main_module) --syntax-module $(llvm_syntax_module) \
+	        $(llvm_dir)/$(llvm_main_file).k                                         \
+	        --hook-namespaces KRYPTO                                                \
+	        $(KOMPILE_OPTS)                                                         \
 	        $(addprefix -ccopt ,$(STANDALONE_KOMPILE_OPTS))
 
 # Installing

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,6 @@ TANGLER                 := $(PANDOC_TANGLE_SUBMODULE)/tangle.lua
 LUA_PATH                := $(PANDOC_TANGLE_SUBMODULE)/?.lua;;
 export TANGLER
 export LUA_PATH
-defn-java defn-specs defn-haskell defn-web3 defn-llvm
 
 .PHONY: all clean distclean                                                                                                      \
         deps all-deps llvm-deps haskell-deps repo-deps k-deps plugin-deps libsecp256k1 libff                                     \

--- a/Makefile
+++ b/Makefile
@@ -248,6 +248,7 @@ $(web3_kompiled): $(web3_kore) $(libff_out)
 # Standalone
 
 llvm_dir           := $(DEFN_DIR)/llvm
+llvm_files         := $(patsubst %, $(llvm_dir)/%, $(ALL_FILES))
 llvm_main_module   := ETHEREUM-SIMULATION
 llvm_syntax_module := $(llvm_main_module)
 llvm_main_file     := driver

--- a/Makefile
+++ b/Makefile
@@ -146,11 +146,11 @@ build: build-llvm build-haskell build-java build-specs build-web3
 # Java
 
 java_dir           := $(DEFN_DIR)/java
-java_kompiled      := $(java_dir)/$(java_main_file)-kompiled/timestamp
 java_files         := $(patsubst %, $(java_dir)/%, $(ALL_FILES))
 java_main_module   := ETHEREUM-SIMULATION
 java_syntax_module := $(java_main_module)
 java_main_file     := driver
+java_kompiled      := $(java_dir)/$(java_main_file)-kompiled/timestamp
 
 java-defn:  $(java_files)
 build-java: $(java_kompiled)
@@ -168,11 +168,11 @@ $(java_kompiled): $(java_files)
 # Imperative Specs
 
 specs_dir           := $(DEFN_DIR)/specs
-specs_kompiled      := $(specs_dir)/$(specs_main_file)-kompiled/timestamp
 specs_files         := $(patsubst %, $(specs_dir)/%, $(ALL_FILES))
 specs_main_module   := EVM-IMP-SPECS
 specs_syntax_module := $(specs_main_module)
 specs_main_file     := evm-imp-specs
+specs_kompiled      := $(specs_dir)/$(specs_main_file)-kompiled/timestamp
 
 specs-defn:  $(specs_files)
 build-specs: $(specs_kompiled)
@@ -190,11 +190,11 @@ $(specs_kompiled): $(specs_files)
 # Haskell
 
 haskell_dir            := $(DEFN_DIR)/haskell
-haskell_kompiled       := $(haskell_dir)/$(haskell_main_file)-kompiled/definition.kore
 haskell_files          := $(patsubst %, $(haskell_dir)/%, $(ALL_FILES))
 haskell_main_module    := ETHEREUM-SIMULATION
 haskell_syntax_module  := $(haskell_main_module)
 haskell_main_file      := driver
+haskell_kompiled       := $(haskell_dir)/$(haskell_main_file)-kompiled/definition.kore
 
 haskell-defn:  $(haskell_files)
 build-haskell: $(haskell_kompiled)
@@ -212,11 +212,11 @@ $(haskell_kompiled): $(haskell_files)
 # Web3
 
 web3_dir           := $(abspath $(DEFN_DIR)/web3)
-web3_kompiled      := $(web3_dir)/build/kevm-client
 web3_files         := $(patsubst %, $(web3_dir)/%, $(ALL_FILES))
 web3_main_module   := WEB3
 web3_syntax_module := $(web3_main_module)
 web3_main_file     := web3
+web3_kompiled      := $(web3_dir)/build/kevm-client
 web3_kore          := $(web3_dir)/$(web3_main_file)-kompiled/definition.kore
 export web3_main_file
 export web3_dir
@@ -243,10 +243,10 @@ $(web3_kompiled): $(web3_kore) $(libff_out)
 # Standalone
 
 llvm_dir           := $(DEFN_DIR)/llvm
-llvm_kompiled      := $(llvm_dir)/$(llvm_main_file)-kompiled/interpreter
 llvm_main_module   := ETHEREUM-SIMULATION
 llvm_syntax_module := $(llvm_main_module)
 llvm_main_file     := driver
+llvm_kompiled      := $(llvm_dir)/$(llvm_main_file)-kompiled/interpreter
 
 STANDALONE_KOMPILE_OPTS := -L$(LOCAL_LIB) -I$(K_RELEASE)/include/kllvm \
                            $(PLUGIN_SUBMODULE)/plugin-c/crypto.cpp     \

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ export LUA_PATH
 .PHONY: all clean distclean                                                                                                      \
         deps all-deps llvm-deps haskell-deps repo-deps k-deps plugin-deps libsecp256k1 libff                                     \
         build build-java build-specs build-haskell build-llvm build-web3                                                         \
-        defn java-defn specs-defn web3-defn haskell-defn llvm-defn                                                               \
+        defn defn-java defn-specs defn-web3 defn-haskell defn-llvm                                                               \
         test test-all test-conformance test-rest-conformance test-all-conformance test-slow-conformance test-failing-conformance \
         test-vm test-rest-vm test-all-vm test-bchain test-rest-bchain test-all-bchain                                            \
         test-web3 test-all-web3 test-failing-web3                                                                                \
@@ -140,7 +140,7 @@ concrete_tangle := .k:not(.symbolic):not(.nobytes):not(.memmap),.concrete,.bytes
 java_tangle     := .k:not(.concrete):not(.bytes):not(.memmap):not(.membytes),.symbolic,.nobytes
 haskell_tangle  := .k:not(.concrete):not(.nobytes):not(.memmap),.symbolic,.bytes,.membytes
 
-defn: llvm-defn java-defn specs-defn haskell-defn web3-defn
+defn:  defn-llvm defn-java defn-specs defn-haskell defn-web3
 build: build-llvm build-haskell build-java build-specs build-web3
 
 # Java
@@ -152,7 +152,7 @@ java_syntax_module := $(java_main_module)
 java_main_file     := driver
 java_kompiled      := $(java_dir)/$(java_main_file)-kompiled/timestamp
 
-java-defn:  $(java_files)
+defn-java:  $(java_files)
 build-java: $(java_kompiled)
 
 $(java_dir)/%.k: %.md $(TANGLER)
@@ -174,7 +174,7 @@ specs_syntax_module := $(specs_main_module)
 specs_main_file     := evm-imp-specs
 specs_kompiled      := $(specs_dir)/$(specs_main_file)-kompiled/timestamp
 
-specs-defn:  $(specs_files)
+defn-specs:  $(specs_files)
 build-specs: $(specs_kompiled)
 
 $(specs_dir)/%.k: %.md $(TANGLER)
@@ -196,7 +196,7 @@ haskell_syntax_module  := $(haskell_main_module)
 haskell_main_file      := driver
 haskell_kompiled       := $(haskell_dir)/$(haskell_main_file)-kompiled/definition.kore
 
-haskell-defn:  $(haskell_files)
+defn-haskell:  $(haskell_files)
 build-haskell: $(haskell_kompiled)
 
 $(haskell_dir)/%.k: %.md $(TANGLER)
@@ -221,7 +221,7 @@ web3_kore          := $(web3_dir)/$(web3_main_file)-kompiled/definition.kore
 export web3_main_file
 export web3_dir
 
-web3-defn:  $(web3_files)
+defn-web3:  $(web3_files)
 build-web3: $(web3_kompiled)
 
 $(web3_dir)/%.k: %.md $(TANGLER)
@@ -253,7 +253,7 @@ STANDALONE_KOMPILE_OPTS := -L$(LOCAL_LIB) -I$(K_RELEASE)/include/kllvm \
                            $(PLUGIN_SUBMODULE)/plugin-c/blake2.cpp     \
                            -g -std=c++14 -lff -lcryptopp -lsecp256k1
 
-llvm-defn:  $(llvm_files)
+defn-llvm:  $(llvm_files)
 build-llvm: $(llvm_kompiled)
 
 $(llvm_dir)/%.k: %.md $(TANGLER)

--- a/Makefile
+++ b/Makefile
@@ -124,9 +124,21 @@ MAIN_MODULE    := ETHEREUM-SIMULATION
 SYNTAX_MODULE  := $(MAIN_MODULE)
 MAIN_DEFN_FILE := driver
 
-k_files       := driver.k data.k network.k evm.k evm-types.k json.k krypto.k edsl.k web3.k asm.k state-loader.k serialization.k evm-imp-specs.k
-EXTRA_K_FILES += $(MAIN_DEFN_FILE).k
-ALL_K_FILES   := $(k_files) $(EXTRA_K_FILES)
+SOURCE_FILES       := asm           \
+                      data          \
+                      driver        \
+                      edsl          \
+                      evm           \
+                      evm-imp-specs \
+                      evm-types     \
+                      json          \
+                      krypto        \
+                      network       \
+                      serialization \
+                      state-loader  \
+                      web3
+EXTRA_SOURCE_FILES :=
+ALL_FILES          := $(patsubst %, %.k, $(SOURCE_FILES) $(EXTRA_SOURCE_FILES))
 
 llvm_dir    := $(DEFN_DIR)/llvm
 java_dir    := $(DEFN_DIR)/java
@@ -135,11 +147,11 @@ haskell_dir := $(DEFN_DIR)/haskell
 web3_dir    := $(abspath $(DEFN_DIR)/web3)
 export web3_dir
 
-llvm_files    := $(patsubst %, $(llvm_dir)/%, $(ALL_K_FILES))
-java_files    := $(patsubst %, $(java_dir)/%, $(ALL_K_FILES))
-specs_files   := $(patsubst %, $(specs_dir)/%, $(ALL_K_FILES))
-haskell_files := $(patsubst %, $(haskell_dir)/%, $(ALL_K_FILES))
-web3_files    := $(patsubst %, $(web3_dir)/%, $(ALL_K_FILES))
+llvm_files    := $(patsubst %, $(llvm_dir)/%, $(ALL_FILES))
+java_files    := $(patsubst %, $(java_dir)/%, $(ALL_FILES))
+specs_files   := $(patsubst %, $(specs_dir)/%, $(ALL_FILES))
+haskell_files := $(patsubst %, $(haskell_dir)/%, $(ALL_FILES))
+web3_files    := $(patsubst %, $(web3_dir)/%, $(ALL_FILES))
 defn_files    := $(llvm_files) $(java_files) $(specs_files) $(haskell_files) $(web3_files)
 
 java_kompiled    := $(java_dir)/$(MAIN_DEFN_FILE)-kompiled/timestamp

--- a/cmake/client/CMakeLists.txt
+++ b/cmake/client/CMakeLists.txt
@@ -5,7 +5,7 @@ list(APPEND CMAKE_MODULE_PATH "$ENV{K_RELEASE}/lib/cmake/kframework")
 include(LLVMKompilePrelude)
 project (KevmClient CXX)
 
-set(KOMPILED_DIR $ENV{web3_dir}/$ENV{MAIN_DEFN_FILE}-kompiled)
+set(KOMPILED_DIR $ENV{web3_dir}/$ENV{web3_main_file}-kompiled)
 set(KOMPILE_USE_MAIN "library")
 set(TARGET_NAME "kevm-client")
 


### PR DESCRIPTION
This PR may be easier to review 1 commit at a time. It does several refactors to the `Makefile` to improve the rebuildability of targets:

-    No longer a single `MAIN_DEFN_FILE`, `MAIN_MODULE`, `MAIN_SYNTAX_MODULE` per build type. Instead each build gets its own.
-    Organize the `Makefile` a bit.
-    Ignore some more files.

This makes my next PR for switching to direct K support for Markdown files simpler.