### PR TITLE
Enable haskell prover on storageRoot spec

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,8 +37,8 @@ pipeline {
             timeout(time: 55, unit: 'MINUTES')
           }
           parallel {
-            stage('Java + Haskell')    { steps { sh 'make test-prove -j6'                                                        } }
-            stage('Haskell (dry-run)') { steps { sh 'make test-prove -j2 KPROVE_OPTIONS=--dry-run TEST_SYMBOLIC_BACKEND=haskell' } }
+            stage('Java + Haskell')    { steps { sh 'make test-prove -j6'                                                      } }
+            stage('Haskell (dry-run)') { steps { sh 'make test-prove -j2 KPROVE_OPTIS=--dry-run TEST_SYMBOLIC_BACKEND=haskell' } }
           }
         }
         stage('Test Interactive') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,8 +37,8 @@ pipeline {
             timeout(time: 55, unit: 'MINUTES')
           }
           parallel {
-            stage('Java + Haskell')    { steps { sh 'make test-prove -j6'                                                      } }
-            stage('Haskell (dry-run)') { steps { sh 'make test-prove -j2 KPROVE_OPTIS=--dry-run TEST_SYMBOLIC_BACKEND=haskell' } }
+            stage('Java + Haskell')    { steps { sh 'make test-prove -j6'                                                     } }
+            stage('Haskell (dry-run)') { steps { sh 'make test-prove -j2 KPROVE_OPTS=--dry-run TEST_SYMBOLIC_BACKEND=haskell' } }
           }
         }
         stage('Test Interactive') {

--- a/Makefile
+++ b/Makefile
@@ -342,16 +342,12 @@ tests/specs/functional/lemmas-no-smt-spec.k.prove: KPROVE_OPTS += --haskell-back
 
 tests/%.prove: tests/%
 	$(TEST) prove $(TEST_OPTIONS) --backend $(TEST_SYMBOLIC_BACKEND) $< $(KPROVE_MODULE) --format-failures $(KPROVE_OPTS) \
-	    --concrete-rules $(shell cat $(dir $@)concrete-rules.txt | tr '\n' ',') > $@.out ||                               \
-	    $(CHECK) $@.out $@.expected
-	rm -rf $@.out
+	    --concrete-rules $(shell cat $(dir $@)concrete-rules.txt | tr '\n' ',')
 
 tests/specs/imp-specs/%.prove: tests/specs/imp-specs/%
-	$(TEST) prove $(TEST_OPTIONS) --backend-dir $(specs_dir) \
+	$(TEST) prove $(TEST_OPTIONS) --backend-dir $(specs_dir)                                    \
 		--backend $(TEST_SYMBOLIC_BACKEND) $< $(KPROVE_MODULE) --format-failures $(KPROVE_OPTS) \
-	    --concrete-rules $(shell cat $(dir $@)concrete-rules.txt | tr '\n' ',') > $@.out ||     \
-	    $(CHECK) $@.out $@.expected
-	rm -rf $@.out
+	    --concrete-rules $(shell cat $(dir $@)concrete-rules.txt | tr '\n' ',')
 
 tests/%.search: tests/%
 	$(TEST) search $(TEST_OPTIONS) --backend $(TEST_SYMBOLIC_BACKEND) $< "<statusCode> EVMC_INVALID_INSTRUCTION </statusCode>" > $@-out

--- a/Makefile
+++ b/Makefile
@@ -289,8 +289,8 @@ KEVM_CHAINID  := 1
 
 KEVM_WEB3_ARGS := --shutdownable --respond-to-notifications
 
-KPROVE_MODULE  := VERIFICATION
-KPROVE_OPTIONS :=
+KPROVE_MODULE := VERIFICATION
+KPROVE_OPTS   :=
 
 test-all: test-all-conformance test-prove test-interactive test-parse
 test: test-conformance test-prove test-interactive test-parse
@@ -339,18 +339,18 @@ tests/specs/examples/%.prove:   TEST_SYMBOLIC_BACKEND=haskell
 tests/specs/functional/storageRoot-spec.k.prove: TEST_SYMBOLIC_BACKEND = java
 tests/specs/erc20/hkg/totalSupply-spec.k.prove:  TEST_SYMBOLIC_BACKEND = haskell
 
-tests/specs/functional/lemmas-no-smt-spec.k.prove: KPROVE_OPTIONS += --haskell-backend-command "kore-exec --smt=none"
+tests/specs/functional/lemmas-no-smt-spec.k.prove: KPROVE_OPTS += --haskell-backend-command "kore-exec --smt=none"
 
 tests/%.prove: tests/%
-	$(TEST) prove $(TEST_OPTIONS) --backend $(TEST_SYMBOLIC_BACKEND) $< $(KPROVE_MODULE) --format-failures $(KPROVE_OPTIONS) \
-	    --concrete-rules $(shell cat $(dir $@)concrete-rules.txt | tr '\n' ',') > $@.out ||                                  \
+	$(TEST) prove $(TEST_OPTIONS) --backend $(TEST_SYMBOLIC_BACKEND) $< $(KPROVE_MODULE) --format-failures $(KPROVE_OPTS) \
+	    --concrete-rules $(shell cat $(dir $@)concrete-rules.txt | tr '\n' ',') > $@.out ||                               \
 	    $(CHECK) $@.out $@.expected
 	rm -rf $@.out
 
 tests/specs/imp-specs/%.prove: tests/specs/imp-specs/%
 	$(TEST) prove $(TEST_OPTIONS) --backend-dir $(specs_dir) \
-		--backend $(TEST_SYMBOLIC_BACKEND) $< $(KPROVE_MODULE) --format-failures $(KPROVE_OPTIONS) \
-	    --concrete-rules $(shell cat $(dir $@)concrete-rules.txt | tr '\n' ',') > $@.out ||                                  \
+		--backend $(TEST_SYMBOLIC_BACKEND) $< $(KPROVE_MODULE) --format-failures $(KPROVE_OPTS) \
+	    --concrete-rules $(shell cat $(dir $@)concrete-rules.txt | tr '\n' ',') > $@.out ||     \
 	    $(CHECK) $@.out $@.expected
 	rm -rf $@.out
 
@@ -360,7 +360,7 @@ tests/%.search: tests/%
 	rm -rf $@-out
 
 tests/%.klab-prove: tests/%
-	$(TEST) klab-prove $(TEST_OPTIONS) --backend $(TEST_SYMBOLIC_BACKEND) $< $(KPROVE_MODULE) --format-failures $(KPROVE_OPTIONS) \
+	$(TEST) klab-prove $(TEST_OPTIONS) --backend $(TEST_SYMBOLIC_BACKEND) $< $(KPROVE_MODULE) --format-failures $(KPROVE_OPTS) \
 	    --concrete-rules $(shell cat $(dir $@)concrete-rules.txt | tr '\n' ',')
 
 # Smoke Tests

--- a/Makefile
+++ b/Makefile
@@ -336,8 +336,7 @@ tests/%.parse: tests/%
 tests/specs/functional/%.prove: TEST_SYMBOLIC_BACKEND=haskell
 tests/specs/examples/%.prove:   TEST_SYMBOLIC_BACKEND=haskell
 
-tests/specs/functional/storageRoot-spec.k.prove: TEST_SYMBOLIC_BACKEND = java
-tests/specs/erc20/hkg/totalSupply-spec.k.prove:  TEST_SYMBOLIC_BACKEND = haskell
+tests/specs/erc20/hkg/totalSupply-spec.k.prove: TEST_SYMBOLIC_BACKEND = haskell
 
 tests/specs/functional/lemmas-no-smt-spec.k.prove: KPROVE_OPTS += --haskell-backend-command "kore-exec --smt=none"
 

--- a/Makefile
+++ b/Makefile
@@ -336,9 +336,10 @@ tests/%.parse: tests/%
 tests/specs/functional/%.prove: TEST_SYMBOLIC_BACKEND=haskell
 tests/specs/examples/%.prove:   TEST_SYMBOLIC_BACKEND=haskell
 
-tests/specs/functional/storageRoot-spec.k.prove: TEST_SYMBOLIC_BACKEND=java
-tests/specs/functional/lemmas-no-smt-spec.k.prove: KPROVE_OPTIONS+=--haskell-backend-command "kore-exec --smt=none"
-tests/specs/erc20/hkg/totalSupply-spec.k.prove: TEST_SYMBOLIC_BACKEND=haskell
+tests/specs/functional/storageRoot-spec.k.prove: TEST_SYMBOLIC_BACKEND = java
+tests/specs/erc20/hkg/totalSupply-spec.k.prove:  TEST_SYMBOLIC_BACKEND = haskell
+
+tests/specs/functional/lemmas-no-smt-spec.k.prove: KPROVE_OPTIONS += --haskell-backend-command "kore-exec --smt=none"
 
 tests/%.prove: tests/%
 	$(TEST) prove $(TEST_OPTIONS) --backend $(TEST_SYMBOLIC_BACKEND) $< $(KPROVE_MODULE) --format-failures $(KPROVE_OPTIONS) \

--- a/kast.kscript
+++ b/kast.kscript
@@ -1,0 +1,8 @@
+alias kclaim x   = claim x  | kast -i kore -o pretty -d .build/defn/haskell /dev/stdin
+alias kaxiom x   = axiom x  | kast -i kore -o pretty -d .build/defn/haskell /dev/stdin
+alias konfig     = config   | kast -i kore -o pretty -d .build/defn/haskell /dev/stdin
+alias konfig-n x = config x | kast -i kore -o pretty -d .build/defn/haskell /dev/stdin
+alias ktry x     = try x    | kast -i kore -o pretty -d .build/defn/haskell /dev/stdin
+alias ktryf x    = tryf x   | kast -i kore -o pretty -d .build/defn/haskell /dev/stdin
+alias krule      = rule     | kast -i kore -o pretty -d .build/defn/haskell /dev/stdin
+alias krule-n x  = rule x   | kast -i kore -o pretty -d .build/defn/haskell /dev/stdin

--- a/kevm
+++ b/kevm
@@ -56,7 +56,7 @@ run_kast() {
 }
 
 run_prove() {
-    local def_module smt_prelude_set run_dir smt_file smt_args
+    local def_module smt_prelude_set run_dir smt_file smt_args additional_proof_args
 
     def_module="$1" ; shift
 
@@ -73,8 +73,13 @@ run_prove() {
         set -x
     fi
 
+    additional_proof_args=()
+    if $repl; then
+        additional_proof_args+=(--haskell-backend-command "$k_release_dir/bin/kore-repl --repl-script $kevm_dir/kast.kscript")
+    fi
+
     export K_OPTS=-Xmx8G
-    kprove --directory "$backend_dir" "${smt_args[@]-}" "$run_file" --def-module "$def_module" "$@"
+    kprove --directory "$backend_dir" "${smt_args[@]-}" "$run_file" --def-module "$def_module" "${additional_proof_args[@]}" "$@"
 }
 
 run_search() {
@@ -256,6 +261,7 @@ backend="llvm"
 debug=false
 dump=false
 unparse=true
+repl=false
 [[ ! "$run_command" == 'prove' ]] || backend='java'
 [[ ! "$run_command" =~ klab*   ]] || backend='java'
 [[ ! "$run_command" =~ web3*   ]] || backend='llvm'
@@ -268,6 +274,7 @@ while [[ $# -gt 0 ]]; do
         --debug)              debug=true        ; shift   ;;
         --dump)               dump=true         ; shift   ;;
         --no-unparse)         unparse=false     ; shift   ;;
+        --repl)               repl=true         ; shift   ;;
         --backend)            backend="$2"      ; shift 2 ;;
         --backend-dir)        backend_dir="$2"  ; shift 2 ;;
         -p|--port)            kevm_port="$2"    ; shift 2 ;;
@@ -277,6 +284,8 @@ while [[ $# -gt 0 ]]; do
 done
 set -- "${args[@]}"
 backend_dir="${backend_dir:-$defn_dir/$backend}"
+
+! $repl || [[ "$backend" == haskell ]] || fatal "Option --repl only usable with --backend haskell!"
 
 # get the run file
 if [[ ! "$run_command" =~ web3* ]]; then

--- a/serialization.md
+++ b/serialization.md
@@ -301,8 +301,8 @@ Encoding
     rule #rlpEncodeWordStack(.WordStack) => ""
     rule #rlpEncodeWordStack(W : WS)     => #rlpEncodeWord(W) +String #rlpEncodeWordStack(WS)
 
-    rule #rlpEncodeString(STR) => STR                        requires           lengthString(STR) ==Int 1 andBool ordChar(STR) <Int 128
-    rule #rlpEncodeString(STR) => #rlpEncodeLength(STR, 128) requires notBool ( lengthString(STR) ==Int 1 andBool ordChar(STR) <Int 128 )
+    rule #rlpEncodeString(STR) => STR                        requires           lengthString(STR) ==Int 1 andBool ordChar(substrString(STR, 0, 1)) <Int 128
+    rule #rlpEncodeString(STR) => #rlpEncodeLength(STR, 128) requires notBool ( lengthString(STR) ==Int 1 andBool ordChar(substrString(STR, 0, 1)) <Int 128 )
 
     rule #rlpEncodeAccount(.Account) => "\x80"
     rule #rlpEncodeAccount(ACCT)     => #rlpEncodeBytes(ACCT, 20) requires ACCT =/=K .Account

--- a/serialization.md
+++ b/serialization.md
@@ -302,8 +302,8 @@ Encoding
     rule #rlpEncodeWordStack(W : WS)     => #rlpEncodeWord(W) +String #rlpEncodeWordStack(WS)
 
     rule #rlpEncodeString(STR) => "\x80"                     requires lengthString(STR)  <Int 1
-    rule #rlpEncodeString(STR) => STR                        requires lengthString(STR) ==Int 1 andBool         ordChar(substrString(STR, 0, 1)) <Int 128
-    rule #rlpEncodeString(STR) => #rlpEncodeLength(STR, 128) requires lengthString(STR)  >Int 1  orBool notBool ordChar(substrString(STR, 0, 1)) <Int 128
+    rule #rlpEncodeString(STR) => STR                        requires lengthString(STR) ==Int 1 andBool ordChar(substrString(STR, 0, 1)) <Int 128
+    rule #rlpEncodeString(STR) => #rlpEncodeLength(STR, 128) [owise]
 
     rule #rlpEncodeAccount(.Account) => "\x80"
     rule #rlpEncodeAccount(ACCT)     => #rlpEncodeBytes(ACCT, 20) requires ACCT =/=K .Account

--- a/serialization.md
+++ b/serialization.md
@@ -301,9 +301,9 @@ Encoding
     rule #rlpEncodeWordStack(.WordStack) => ""
     rule #rlpEncodeWordStack(W : WS)     => #rlpEncodeWord(W) +String #rlpEncodeWordStack(WS)
 
-    rule #rlpEncodeString(STR) => "\x80"                     requires           lengthString(STR)  <Int 1
-    rule #rlpEncodeString(STR) => STR                        requires           lengthString(STR) ==Int 1 andBool ordChar(substrString(STR, 0, 1)) <Int 128
-    rule #rlpEncodeString(STR) => #rlpEncodeLength(STR, 128) requires notBool ( lengthString(STR)  >Int 1 andBool ordChar(substrString(STR, 0, 1)) <Int 128 )
+    rule #rlpEncodeString(STR) => "\x80"                     requires lengthString(STR)  <Int 1
+    rule #rlpEncodeString(STR) => STR                        requires lengthString(STR) ==Int 1 andBool         ordChar(substrString(STR, 0, 1)) <Int 128
+    rule #rlpEncodeString(STR) => #rlpEncodeLength(STR, 128) requires lengthString(STR)  >Int 1  orBool notBool ordChar(substrString(STR, 0, 1)) <Int 128
 
     rule #rlpEncodeAccount(.Account) => "\x80"
     rule #rlpEncodeAccount(ACCT)     => #rlpEncodeBytes(ACCT, 20) requires ACCT =/=K .Account

--- a/serialization.md
+++ b/serialization.md
@@ -301,8 +301,9 @@ Encoding
     rule #rlpEncodeWordStack(.WordStack) => ""
     rule #rlpEncodeWordStack(W : WS)     => #rlpEncodeWord(W) +String #rlpEncodeWordStack(WS)
 
+    rule #rlpEncodeString(STR) => "\x80"                     requires           lengthString(STR)  <Int 1
     rule #rlpEncodeString(STR) => STR                        requires           lengthString(STR) ==Int 1 andBool ordChar(substrString(STR, 0, 1)) <Int 128
-    rule #rlpEncodeString(STR) => #rlpEncodeLength(STR, 128) requires notBool ( lengthString(STR) ==Int 1 andBool ordChar(substrString(STR, 0, 1)) <Int 128 )
+    rule #rlpEncodeString(STR) => #rlpEncodeLength(STR, 128) requires notBool ( lengthString(STR)  >Int 1 andBool ordChar(substrString(STR, 0, 1)) <Int 128 )
 
     rule #rlpEncodeAccount(.Account) => "\x80"
     rule #rlpEncodeAccount(ACCT)     => #rlpEncodeBytes(ACCT, 20) requires ACCT =/=K .Account

--- a/tests/failing-symbolic.haskell
+++ b/tests/failing-symbolic.haskell
@@ -23,3 +23,4 @@ tests/specs/benchmarks/storagevar02-nooverflow-spec.k
 tests/specs/benchmarks/storagevar02-overflow-spec.k
 tests/specs/benchmarks/storagevar03-spec.k
 tests/specs/erc20/ds/transferFrom-failure-1-c-spec.k
+tests/specs/functional/merkle-failing-spec.k

--- a/tests/specs/functional/storageRoot-spec.k
+++ b/tests/specs/functional/storageRoot-spec.k
@@ -23,12 +23,7 @@ module STORAGEROOT-SPEC
     // uint pos0;
     //
     // pos0 = 1234;
-    rule <k> runMerkle( Keccak256( #rlpEncodeMerkleTree( #storageRoot(
-              #hashedLocation( "Solidity", 0, .IntList ) |-> 1234
-                                                                     )
-                                                       )
-                                 )
-                      )
+    rule <k> runMerkle( Keccak256( #rlpEncodeMerkleTree( #storageRoot( #hashedLocation( "Solidity", 0, .IntList ) |-> 1234 ) ) ) )
           => doneMerkle( "6ff6cfba457bc662332201b53a8bda503e307197962f2c51e5e2dcc3809e19be" )
          </k>
 
@@ -36,13 +31,7 @@ module STORAGEROOT-SPEC
     //
     // pos0[0] = 100;
     // pos0[1] = 200;
-    rule <k> runMerkle( Keccak256( #rlpEncodeMerkleTree( #storageRoot(
-              #hashedLocation( "Solidity", 0, 0 ) |-> 100
-              #hashedLocation( "Solidity", 0, 1 ) |-> 200
-                                                                     )
-                                                       )
-                                 )
-                      )
+    rule <k> runMerkle( Keccak256( #rlpEncodeMerkleTree( #storageRoot( #hashedLocation( "Solidity", 0, 0 ) |-> 100 #hashedLocation( "Solidity", 0, 1 ) |-> 200 ) ) ) )
           => doneMerkle( "27093708a19995cf73ddd4b27049a7e33fb49e242bde6c1bffbb6596b67b8b3e" )
          </k>
 
@@ -52,14 +41,7 @@ module STORAGEROOT-SPEC
     // pos0    = 600;
     // pos1[0] = 200;
     // pos1[5] = 24;
-    rule <k> runMerkle( Keccak256( #rlpEncodeMerkleTree( #storageRoot(
-              #hashedLocation( "Solidity", 0, .IntList ) |-> 600
-              #hashedLocation( "Solidity", 1, 0 )        |-> 200
-              #hashedLocation( "Solidity", 1, 5 )        |-> 24
-                                                                     )
-                                                       )
-                                 )
-                      )
+    rule <k> runMerkle( Keccak256( #rlpEncodeMerkleTree( #storageRoot( #hashedLocation( "Solidity", 0, .IntList ) |-> 600 #hashedLocation( "Solidity", 1, 0 )        |-> 200 #hashedLocation( "Solidity", 1, 5 )        |-> 24 ) ) ) )
           => doneMerkle( "7df5d7b198240b49434b4e1dbff02fcb0649dd91650ae0fae191b2881cbb009e" )
          </k>
 
@@ -70,15 +52,7 @@ module STORAGEROOT-SPEC
     // pos0[1] = 456;
     // pos1[6] = 56;
     // pos1[9] = 333;
-    rule <k> runMerkle( Keccak256( #rlpEncodeMerkleTree( #storageRoot(
-              #hashedLocation( "Solidity", 0, 0 ) |-> 123
-              #hashedLocation( "Solidity", 0, 1 ) |-> 456
-              #hashedLocation( "Solidity", 1, 6 ) |-> 56
-              #hashedLocation( "Solidity", 1, 9 ) |-> 333
-                                                                     )
-                                                       )
-                                 )
-                      )
+    rule <k> runMerkle( Keccak256( #rlpEncodeMerkleTree( #storageRoot( #hashedLocation( "Solidity", 0, 0 ) |-> 123 #hashedLocation( "Solidity", 0, 1 ) |-> 456 #hashedLocation( "Solidity", 1, 6 ) |-> 56 #hashedLocation( "Solidity", 1, 9 ) |-> 333 ) ) ) )
           => doneMerkle( "e3d130ca69a8d33ad2058d86ba26ec414f6e5639930041d6a266ee88b25ea835" )
          </k>
 
@@ -93,17 +67,7 @@ module STORAGEROOT-SPEC
     // pos2       = 100;
     // pos3[0][0] = 42;
     // pos3[2][1] = 2019;
-    rule <k> runMerkle( Keccak256( #rlpEncodeMerkleTree( #storageRoot(
-              #hashedLocation( "Solidity", 0, .IntList ) |-> 1234
-              #hashedLocation( "Solidity", 1, 0 )        |-> 0
-              #hashedLocation( "Solidity", 1, 1 )        |-> 1
-              #hashedLocation( "Solidity", 2, .IntList ) |-> 100
-              #hashedLocation( "Solidity", 3, 0 0 )      |-> 42
-              #hashedLocation( "Solidity", 3, 2 1 )      |-> 2019
-                                                                     )
-                                                       )
-                                 )
-                      )
+    rule <k> runMerkle( Keccak256( #rlpEncodeMerkleTree( #storageRoot( #hashedLocation( "Solidity", 0, .IntList ) |-> 1234 #hashedLocation( "Solidity", 1, 0 )        |-> 0 #hashedLocation( "Solidity", 1, 1 )        |-> 1 #hashedLocation( "Solidity", 2, .IntList ) |-> 100 #hashedLocation( "Solidity", 3, 0 0 )      |-> 42 #hashedLocation( "Solidity", 3, 2 1 )      |-> 2019 ) ) ) )
           => doneMerkle( "1a40e309e184fb6483112c37def9ed52e5ee36aa4b570a234a962b3a8f186610" )
          </k>
 endmodule

--- a/tests/specs/functional/storageRoot-spec.k
+++ b/tests/specs/functional/storageRoot-spec.k
@@ -11,6 +11,8 @@ module STORAGEROOT-SPEC
 
     rule <k> #storageRoot( .Map ) => .MerkleTree </k>
 
+    rule <k> #rlpEncodeString ( "" ) => "\x80" </k>
+
     rule <k> #rlpEncodeString ( "\x82\x04\xd2" ) => "\x83\x82\x04\xd2" </k>
 
     // uint pos0;

--- a/tests/specs/functional/storageRoot-spec.k
+++ b/tests/specs/functional/storageRoot-spec.k
@@ -4,35 +4,26 @@ requires "edsl.md"
 module VERIFICATION
     imports EVM
     imports EDSL
-
-    syntax StepSort ::= MerkleTree | String
-    syntax    KItem ::= runMerkle ( StepSort )
-                      | doneMerkle( StepSort )
- // ------------------------------------------
-    rule runMerkle( T ) => doneMerkle( T )
-
 endmodule
 
 module STORAGEROOT-SPEC
     imports VERIFICATION
 
-    rule <k> runMerkle( #storageRoot( .Map ) )
-          => doneMerkle( .MerkleTree )
-         </k>
+    rule <k> #storageRoot( .Map ) => .MerkleTree </k>
 
     // uint pos0;
     //
     // pos0 = 1234;
-    rule <k> runMerkle( Keccak256( #rlpEncodeMerkleTree( #storageRoot( #hashedLocation( "Solidity", 0, .IntList ) |-> 1234 ) ) ) )
-          => doneMerkle( "6ff6cfba457bc662332201b53a8bda503e307197962f2c51e5e2dcc3809e19be" )
+    rule <k> Keccak256( #rlpEncodeMerkleTree( #storageRoot( #hashedLocation( "Solidity", 0, .IntList ) |-> 1234 ) ) )
+          => "6ff6cfba457bc662332201b53a8bda503e307197962f2c51e5e2dcc3809e19be"
          </k>
 
     // mapping (uint => uint) pos0;
     //
     // pos0[0] = 100;
     // pos0[1] = 200;
-    rule <k> runMerkle( Keccak256( #rlpEncodeMerkleTree( #storageRoot( #hashedLocation( "Solidity", 0, 0 ) |-> 100 #hashedLocation( "Solidity", 0, 1 ) |-> 200 ) ) ) )
-          => doneMerkle( "27093708a19995cf73ddd4b27049a7e33fb49e242bde6c1bffbb6596b67b8b3e" )
+    rule <k> Keccak256( #rlpEncodeMerkleTree( #storageRoot( #hashedLocation( "Solidity", 0, 0 ) |-> 100 #hashedLocation( "Solidity", 0, 1 ) |-> 200 ) ) )
+          => "27093708a19995cf73ddd4b27049a7e33fb49e242bde6c1bffbb6596b67b8b3e"
          </k>
 
     // uint                   pos0;
@@ -41,8 +32,8 @@ module STORAGEROOT-SPEC
     // pos0    = 600;
     // pos1[0] = 200;
     // pos1[5] = 24;
-    rule <k> runMerkle( Keccak256( #rlpEncodeMerkleTree( #storageRoot( #hashedLocation( "Solidity", 0, .IntList ) |-> 600 #hashedLocation( "Solidity", 1, 0 )        |-> 200 #hashedLocation( "Solidity", 1, 5 )        |-> 24 ) ) ) )
-          => doneMerkle( "7df5d7b198240b49434b4e1dbff02fcb0649dd91650ae0fae191b2881cbb009e" )
+    rule <k> Keccak256( #rlpEncodeMerkleTree( #storageRoot( #hashedLocation( "Solidity", 0, .IntList ) |-> 600 #hashedLocation( "Solidity", 1, 0 ) |-> 200 #hashedLocation( "Solidity", 1, 5 ) |-> 24 ) ) )
+          => "7df5d7b198240b49434b4e1dbff02fcb0649dd91650ae0fae191b2881cbb009e"
          </k>
 
     // mapping (uint => uint) pos0;
@@ -52,8 +43,8 @@ module STORAGEROOT-SPEC
     // pos0[1] = 456;
     // pos1[6] = 56;
     // pos1[9] = 333;
-    rule <k> runMerkle( Keccak256( #rlpEncodeMerkleTree( #storageRoot( #hashedLocation( "Solidity", 0, 0 ) |-> 123 #hashedLocation( "Solidity", 0, 1 ) |-> 456 #hashedLocation( "Solidity", 1, 6 ) |-> 56 #hashedLocation( "Solidity", 1, 9 ) |-> 333 ) ) ) )
-          => doneMerkle( "e3d130ca69a8d33ad2058d86ba26ec414f6e5639930041d6a266ee88b25ea835" )
+    rule <k> Keccak256( #rlpEncodeMerkleTree( #storageRoot( #hashedLocation( "Solidity", 0, 0 ) |-> 123 #hashedLocation( "Solidity", 0, 1 ) |-> 456 #hashedLocation( "Solidity", 1, 6 ) |-> 56 #hashedLocation( "Solidity", 1, 9 ) |-> 333 ) ) )
+          => "e3d130ca69a8d33ad2058d86ba26ec414f6e5639930041d6a266ee88b25ea835"
          </k>
 
     // uint                                     pos0;
@@ -67,7 +58,7 @@ module STORAGEROOT-SPEC
     // pos2       = 100;
     // pos3[0][0] = 42;
     // pos3[2][1] = 2019;
-    rule <k> runMerkle( Keccak256( #rlpEncodeMerkleTree( #storageRoot( #hashedLocation( "Solidity", 0, .IntList ) |-> 1234 #hashedLocation( "Solidity", 1, 0 )        |-> 0 #hashedLocation( "Solidity", 1, 1 )        |-> 1 #hashedLocation( "Solidity", 2, .IntList ) |-> 100 #hashedLocation( "Solidity", 3, 0 0 )      |-> 42 #hashedLocation( "Solidity", 3, 2 1 )      |-> 2019 ) ) ) )
-          => doneMerkle( "1a40e309e184fb6483112c37def9ed52e5ee36aa4b570a234a962b3a8f186610" )
+    rule <k> Keccak256( #rlpEncodeMerkleTree( #storageRoot( #hashedLocation( "Solidity", 0, .IntList ) |-> 1234 #hashedLocation( "Solidity", 1, 0 ) |-> 0 #hashedLocation( "Solidity", 1, 1 ) |-> 1 #hashedLocation( "Solidity", 2, .IntList ) |-> 100 #hashedLocation( "Solidity", 3, 0 0 ) |-> 42 #hashedLocation( "Solidity", 3, 2 1 ) |-> 2019 ) ) )
+          => "1a40e309e184fb6483112c37def9ed52e5ee36aa4b570a234a962b3a8f186610"
          </k>
 endmodule

--- a/tests/specs/functional/storageRoot-spec.k
+++ b/tests/specs/functional/storageRoot-spec.k
@@ -11,6 +11,8 @@ module STORAGEROOT-SPEC
 
     rule <k> #storageRoot( .Map ) => .MerkleTree </k>
 
+    rule <k> #rlpEncodeString ( "\x82\x04\xd2" ) => "\x83\x82\x04\xd2" </k>
+
     // uint pos0;
     //
     // pos0 = 1234;


### PR DESCRIPTION
This makes several changes:

-   Adds the `--repl` option for the Haskell backend for easier debugging of proofs.
-   Fixes the definitions of `#rlpEncodeString` to remove the undefined cases.
-   Enables the `storageRoot` proof on Haskell backend.
-   Renames `KPROVE_OPTIONS` to `KPROVE_OPTS` for consistency with other semantics.
-   Removes the `CHECK` part of running proofs, we weren't using it anyway and it was annoying.