### PR TITLE
Consistent integer comparisons

### DIFF
--- a/edsl.md
+++ b/edsl.md
@@ -363,7 +363,7 @@ Specifically, `#hashedLocation` is defined as follows, capturing the storage lay
     // #sizeWordStack(WS) is not necessarily a multiple of 32.
     rule byteStack2IntList ( WS , N )
          => #asWord ( WS [ 0 .. bytesInNextInt(WS, N) ] ) byteStack2IntList ( #drop(bytesInNextInt(WS, N), WS) , N -Int 1 )
-         requires N >Int 0
+         requires 0 <Int N
 
     rule byteStack2IntList ( WS , 0 ) => .IntList
 

--- a/evm.md
+++ b/evm.md
@@ -292,7 +292,7 @@ OpCode Execution
          <pc> PCOUNT </pc>
          <program> PGM </program>
          <output> _ => .ByteArray </output>
-      requires PCOUNT >=Int #sizeByteArray(PGM)
+      requires #sizeByteArray(PGM) <=Int PCOUNT
 ```
 
 ### Single Step
@@ -1113,7 +1113,7 @@ These operators query about the current return data buffer.
          <wordStack> WS => #drop(N, WS) </wordStack>
          <localMem> LM </localMem>
          <log> ... (.List => ListItem({ ACCT | WordStack2List(#take(N, WS)) | #range(LM, MEMSTART, MEMWIDTH) })) </log>
-      requires #sizeWordStack(WS) >=Int N
+      requires N <=Int #sizeWordStack(WS)
 ```
 
 Ethereum Network OpCodes
@@ -1344,7 +1344,7 @@ The various `CALL*` (and other inter-contract control flow) operations will be d
 ```{.k .bytes}
     syntax Set ::= #computeValidJumpDestsWithinBound(ByteArray, Int, List) [function]
  // ---------------------------------------------------------------------------------
-    rule #computeValidJumpDests(PGM, I, RESULT) => List2Set(RESULT) requires I >=Int #sizeByteArray(PGM)
+    rule #computeValidJumpDests(PGM, I, RESULT) => List2Set(RESULT) requires #sizeByteArray(PGM) <=Int I
     rule #computeValidJumpDests(PGM, I, RESULT) => #computeValidJumpDestsWithinBound(PGM, I, RESULT) requires I <Int #sizeByteArray(PGM)
 
     rule #computeValidJumpDestsWithinBound(PGM, I, RESULT) => #computeValidJumpDests(PGM, I +Int 1, RESULT ListItem(I)) requires PGM [ I ] ==Int 91
@@ -1354,7 +1354,7 @@ The various `CALL*` (and other inter-contract control flow) operations will be d
 ```k
     syntax Int ::= #widthOpCode(Int) [function]
  // -------------------------------------------
-    rule #widthOpCode(W) => W -Int 94 requires W >=Int 96 andBool W <=Int 127
+    rule #widthOpCode(W) => W -Int 94 requires 96 <=Int W andBool W <=Int 127
     rule #widthOpCode(_) => 1 [owise]
 
     syntax KItem ::= "#return" Int Int
@@ -1810,8 +1810,8 @@ Overall Gas
          <memoryUsed> MU => MU' </memoryUsed> <schedule> SCHED </schedule>
 
     rule <k> G:Int ~> (#deductMemoryGas => #deductGas)   ... </k> //Required for verification
-    rule <k> G:Int ~> #deductGas => #end EVMC_OUT_OF_GAS ... </k> <gas> GAVAIL                  </gas> requires GAVAIL <Int G
-    rule <k> G:Int ~> #deductGas => .                    ... </k> <gas> GAVAIL => GAVAIL -Int G </gas> requires GAVAIL >=Int G
+    rule <k> G:Int ~> #deductGas => #end EVMC_OUT_OF_GAS ... </k> <gas> GAVAIL                  </gas> requires GAVAIL  <Int G
+    rule <k> G:Int ~> #deductGas => .                    ... </k> <gas> GAVAIL => GAVAIL -Int G </gas> requires G      <=Int GAVAIL
 ```
 
 Memory Consumption

--- a/serialization.md
+++ b/serialization.md
@@ -293,7 +293,7 @@ Encoding
                     | #rlpEncodeAccount ( Account )     [function]
  // --------------------------------------------------------------
     rule #rlpEncodeWord(0) => "\x80"
-    rule #rlpEncodeWord(WORD) => chrChar(WORD) requires WORD >Int 0 andBool WORD <Int 128
+    rule #rlpEncodeWord(WORD) => chrChar(WORD) requires 0 <Int WORD andBool WORD <Int 128
     rule #rlpEncodeWord(WORD) => #rlpEncodeLength(#unparseByteStack(#asByteStack(WORD)), 128) requires WORD >=Int 128
 
     rule #rlpEncodeBytes(WORD, LEN) => #rlpEncodeString(#unparseByteStack(#padToWidth(LEN, #asByteStack(WORD))))
@@ -486,15 +486,15 @@ Merkle Patricia Tree
 
     rule MerklePut ( MerkleLeaf ( LEAFPATH, LEAFVALUE ), PATH, VALUE )
       => MerklePut ( MerklePut ( MerkleBranch( .Map, "" ), LEAFPATH, LEAFVALUE ), PATH, VALUE )
-      requires #sizeByteArray( LEAFPATH ) >Int 0
-       andBool #sizeByteArray( PATH ) >Int 0
+      requires 0 <Int #sizeByteArray( LEAFPATH )
+       andBool 0 <Int #sizeByteArray( PATH )
        andBool LEAFPATH[0] =/=Int PATH[0]
 
     rule MerklePut ( MerkleLeaf ( LEAFPATH, LEAFVALUE ), PATH, VALUE )
       => #merkleExtensionBuilder( .ByteArray, LEAFPATH, LEAFVALUE, PATH, VALUE )
       requires #unparseByteStack( LEAFPATH ) =/=String #unparseByteStack( PATH )
-       andBool #sizeByteArray( LEAFPATH ) >Int 0
-       andBool #sizeByteArray( PATH )     >Int 0
+       andBool 0 <Int #sizeByteArray( LEAFPATH )
+       andBool 0 <Int #sizeByteArray( PATH )
        andBool LEAFPATH[0] ==Int PATH[0]
 
     rule MerklePut ( MerkleExtension ( EXTPATH, EXTTREE ), PATH, VALUE )
@@ -503,13 +503,13 @@ Merkle Patricia Tree
 
     rule MerklePut ( MerkleExtension ( EXTPATH, EXTTREE ), PATH, VALUE )
       => #merkleExtensionBrancher( MerklePut( MerkleBranch( .Map, "" ), PATH, VALUE ), EXTPATH, EXTTREE )
-      requires #sizeByteArray( PATH ) >Int 0
+      requires 0 <Int #sizeByteArray( PATH )
        andBool EXTPATH[0] =/=Int PATH[0]
 
     rule MerklePut ( MerkleExtension ( EXTPATH, EXTTREE ), PATH, VALUE )
       => #merkleExtensionSplitter( .ByteArray, EXTPATH, EXTTREE, PATH, VALUE )
       requires #unparseByteStack( EXTPATH ) =/=String #unparseByteStack( PATH )
-       andBool #sizeByteArray( PATH ) >Int 0
+       andBool 0 <Int #sizeByteArray( PATH )
        andBool EXTPATH[0] ==Int PATH[0]
 
     rule MerklePut ( MerkleBranch( M, _ ), PATH, VALUE )
@@ -518,7 +518,7 @@ Merkle Patricia Tree
 
     rule MerklePut ( MerkleBranch( M, BRANCHVALUE ), PATH, VALUE )
       => #merkleUpdateBranch ( M, BRANCHVALUE, PATH[0], PATH[1 .. #sizeByteArray(PATH) -Int 1], VALUE )
-      requires #sizeByteArray( PATH ) >Int 0
+      requires 0 <Int #sizeByteArray( PATH )
 
     rule MerkleDelete( .MerkleTree, _ ) => .MerkleTree
 
@@ -531,10 +531,10 @@ Merkle Patricia Tree
       requires #sizeByteArray(EXTPATH) <=Int #sizeByteArray(PATH) andBool PATH[0 .. #sizeByteArray(EXTPATH)] ==K EXTPATH
 
     rule MerkleDelete( MerkleBranch( M, V ), PATH ) => MerkleCheck( MerkleBranch( M, "" ) ) requires #sizeByteArray(PATH) ==Int 0
-    rule MerkleDelete( MerkleBranch( M, V ), PATH ) => MerkleBranch( M, V )                 requires #sizeByteArray(PATH) >Int 0 andBool notBool PATH[0] in_keys(M)
+    rule MerkleDelete( MerkleBranch( M, V ), PATH ) => MerkleBranch( M, V )                 requires 0 <Int #sizeByteArray(PATH) andBool notBool PATH[0] in_keys(M)
     rule MerkleDelete( MerkleBranch( M, V ), PATH )
       => MerkleCheck( MerkleBranch( M[PATH[0] <- MerkleDelete( {M[PATH[0]]}:>MerkleTree, PATH[1 .. #sizeByteArray(PATH) -Int 1] )], V ) )
-      requires #sizeByteArray(PATH) >Int 0 andBool PATH[0] in_keys(M)
+      requires 0 <Int #sizeByteArray(PATH) andBool PATH[0] in_keys(M)
 
     syntax MerkleTree ::= MerkleCheck( MerkleTree ) [function]
  // ----------------------------------------------------------
@@ -574,17 +574,17 @@ Merkle Tree Aux Functions
     rule #nibbleize ( B ) => (      #asByteStack ( B [ 0 ] /Int 16 )[0 .. 1]
                                ++ ( #asByteStack ( B [ 0 ] %Int 16 )[0 .. 1] )
                              ) ++ #nibbleize ( B[1 .. #sizeByteArray(B) -Int 1] )
-      requires #sizeByteArray(B) >Int 0
+      requires 0 <Int #sizeByteArray(B)
 
     rule #nibbleize ( B ) => .ByteArray
-      requires notBool #sizeByteArray(B) >Int 0
+      requires notBool 0 <Int #sizeByteArray(B)
 
     rule #byteify ( B ) =>    #asByteStack ( B[0] *Int 16 +Int B[1] )[0 .. 1]
                            ++ #byteify ( B[2 .. #sizeByteArray(B) -Int 2] )
-      requires #sizeByteArray(B) >Int 0
+      requires 0 <Int #sizeByteArray(B)
 
     rule #byteify ( B ) => .ByteArray
-      requires notBool #sizeByteArray(B) >Int 0
+      requires notBool 0 <Int #sizeByteArray(B)
 
     syntax ByteArray ::= #HPEncode ( ByteArray, Int ) [function]
  // ------------------------------------------------------------
@@ -623,21 +623,21 @@ Merkle Tree Aux Functions
                                 , P1[1 .. #sizeByteArray(P1) -Int 1], V1
                                 , P2[1 .. #sizeByteArray(P2) -Int 1], V2
                                 )
-      requires #sizeByteArray(P1) >Int 0
-       andBool #sizeByteArray(P2) >Int 0
+      requires 0 <Int #sizeByteArray(P1)
+       andBool 0 <Int #sizeByteArray(P2)
        andBool P1[0] ==Int P2[0]
 
     rule #merkleExtensionBuilder( PATH, P1, V1, P2, V2 )
       => MerkleExtension( PATH, MerklePut( MerklePut( MerkleBranch( .Map, "" ), P1, V1 ), P2, V2 ) )
-      requires notBool ( #sizeByteArray(P1) >Int 0
-               andBool   #sizeByteArray(P2) >Int 0
+      requires notBool ( 0 <Int #sizeByteArray(P1)
+               andBool   0 <Int #sizeByteArray(P2)
                andBool   P1[0] ==Int P2[0] )
 
     syntax MerkleTree ::= #merkleExtensionBrancher ( MerkleTree, ByteArray, MerkleTree ) [function]
  // -----------------------------------------------------------------------------------------------
     rule #merkleExtensionBrancher( MerkleBranch(M, VALUE), PATH, EXTTREE )
       => MerkleBranch( M[PATH[0] <- MerkleExtension( PATH[1 .. #sizeByteArray(PATH) -Int 1], EXTTREE )], VALUE )
-      requires #sizeByteArray(PATH) >Int 1
+      requires 1 <Int #sizeByteArray(PATH)
 
     rule #merkleExtensionBrancher( MerkleBranch(M, VALUE), PATH, EXTTREE )
       => MerkleBranch( M[PATH[0] <- EXTTREE], VALUE )
@@ -649,14 +649,14 @@ Merkle Tree Aux Functions
                                  , P1   => P1[1 .. #sizeByteArray(P1) -Int 1], _
                                  , P2   => P2[1 .. #sizeByteArray(P2) -Int 1], _
                                  )
-      requires #sizeByteArray(P1) >Int 0
-       andBool #sizeByteArray(P2) >Int 0
+      requires 0 <Int #sizeByteArray(P1)
+       andBool 0 <Int #sizeByteArray(P2)
        andBool P1[0] ==Int P2[0]
 
     rule #merkleExtensionSplitter( PATH, P1, TREE, P2, VALUE )
       => MerkleExtension( PATH, #merkleExtensionBrancher( MerklePut( MerkleBranch( .Map, "" ), P2, VALUE ), P1, TREE ) )
-      requires #sizeByteArray(P1) >Int 0
-       andBool #sizeByteArray(P2) >Int 0
+      requires 0 <Int #sizeByteArray(P1)
+       andBool 0 <Int #sizeByteArray(P2)
        andBool P1[0] =/=Int P2[0]
 
     rule #merkleExtensionSplitter( PATH, P1, TREE, P2, VALUE )

--- a/tests/specs/lemmas.k
+++ b/tests/specs/lemmas.k
@@ -176,9 +176,6 @@ module LEMMAS-JAVA [symbolic, kast]
 
     rule (#if C #then B1 #else B2 #fi) +Int A => #if C #then (B1 +Int A) #else (B2 +Int A) #fi  [simplification]
 
-    rule X >Int Y => Y <Int X    [simplification]
-    rule X >=Int Y => Y <=Int X  [simplification]
-
     rule notBool (X <Int Y) => Y <=Int X  [simplification]
     rule notBool (X <=Int Y) => Y <Int X  [simplification]
 

--- a/tests/specs/lemmas.k
+++ b/tests/specs/lemmas.k
@@ -11,7 +11,7 @@ module LEMMAS
 
     //Byte array store operations sorting. Slices with lower index first. Helps applying rule below.
     rule MEM [ N := BUF:ByteArray ] [ M := BUF' ] => MEM [ M := BUF' ] [ N := BUF ]
-      requires N >Int M andBool N -Int M >=Int #sizeByteArray(BUF')                                               [simplification]
+      requires M <Int N andBool #sizeByteArray(BUF') <=Int N -Int M                                               [simplification]
 
     rule M [ N := BUF ] [ N := BUF' ] => M [ N := BUF' ] requires #sizeByteArray(BUF) ==Int #sizeByteArray(BUF')  [simplification]
 
@@ -25,7 +25,7 @@ module LEMMAS
        andBool #range(0 < WIDTH <= SIZE -Int START)                                                       [simplification]
 
     rule #sizeByteArray(#range(_, START, WIDTH)) => WIDTH
-      requires WIDTH >=Int 0 andBool START >=Int 0                                                        [simplification]
+      requires 0 <=Int WIDTH andBool 0 <=Int START                                                        [simplification]
 
     //Todo custom ==K unification doesn't work in Haskell yet
     //++ unification
@@ -38,7 +38,7 @@ module LEMMAS-JAVA [symbolic, kast]
     imports EDSL
     imports K-REFLECTION
 
-    rule BUF [ L .. W ] => .ByteArray requires L >=Int #sizeByteArray(BUF)  [simplification]
+    rule BUF [ L .. W ] => .ByteArray requires #sizeByteArray(BUF) <=Int L  [simplification]
 
     rule #asWord( BUF => #drop(1, BUF) ) requires BUF [ 0 ] ==Int 0  [simplification]
 
@@ -47,32 +47,32 @@ module LEMMAS-JAVA [symbolic, kast]
 
     rule #take(N, BUF)          => BUF                                              requires N ==Int #sizeByteArray(BUF)   [simplification]
     rule #take(N, BUF1 ++ BUF2) => #take(N, BUF1)                                   requires N <=Int #sizeByteArray(BUF1)  [simplification]
-    rule #take(N, BUF1 ++ BUF2) => BUF1 ++ #take(N -Int #sizeByteArray(BUF1), BUF2) requires N  >Int #sizeByteArray(BUF1)  [simplification]
+    rule #take(N, BUF1 ++ BUF2) => BUF1 ++ #take(N -Int #sizeByteArray(BUF1), BUF2) requires #sizeByteArray(BUF1) <Int N   [simplification]
 
-    rule #drop(N, BUF)          => .ByteArray                               requires N >=Int #sizeByteArray(BUF)   [simplification]
-    rule #drop(N, BUF1 ++ BUF2) => #drop(N -Int #sizeByteArray(BUF1), BUF2) requires N >=Int #sizeByteArray(BUF1)  [simplification]
-    rule #drop(N, BUF1 ++ BUF2) => #drop(N, BUF1) ++ BUF2                   requires N  <Int #sizeByteArray(BUF1)  [simplification]
+    rule #drop(N, BUF)          => .ByteArray                               requires #sizeByteArray(BUF)  <=Int N  [simplification]
+    rule #drop(N, BUF1 ++ BUF2) => #drop(N -Int #sizeByteArray(BUF1), BUF2) requires #sizeByteArray(BUF1) <=Int N  [simplification]
+    rule #drop(N, BUF1 ++ BUF2) => #drop(N, BUF1) ++ BUF2                   requires N <Int #sizeByteArray(BUF1)   [simplification]
 
     rule #asWord(#buf(N, BUF)) => BUF  [simplification]
 
     rule #asWord(BUF) /Int 26959946667150639794667015087019630673637144422540572481103610249216 => #asWord(#take(4, BUF))  [simplification]
 
-    rule #range(M, N, K) => .ByteArray requires notBool K >Int 0  [simplification]
+    rule #range(M, N, K) => .ByteArray requires notBool 0 <Int K  [simplification]
 
     rule #range(M [ N := BUF:ByteArray ], L, K) => #range(M, L, minInt(K, N -Int L)) ++ #range(M [ N := BUF ], N, K -Int minInt(K, N -Int L))
-      requires K >Int 0
+      requires 0 <Int K
        andBool L <Int N
       [simplification]
 
     rule #range(M [ N := BUF ], L, K) => BUF [ L -Int N .. minInt(K, #sizeByteArray(BUF) -Int (L -Int N)) ] ++ #range(M, N +Int #sizeByteArray(BUF), K -Int minInt(K, #sizeByteArray(BUF) -Int (L -Int N)))
-      requires K  >Int 0
-       andBool L >=Int N
+      requires 0  <Int K
+       andBool N <=Int L
        andBool L  <Int N +Int #sizeByteArray(BUF)
       [simplification]
 
     rule #range(M [ N := BUF ], L, K) => #range(M, L, K)
-      requires K  >Int 0
-       andBool L >=Int N +Int #sizeByteArray(BUF)
+      requires 0  <Int K
+       andBool N +Int #sizeByteArray(BUF) <=Int L
       [simplification]
 
     rule keccak(BUF1 ++ BUF2) => hash2(#asWord(BUF1), #asWord(BUF2)) requires #sizeByteArray(BUF1) ==Int 32 andBool #sizeByteArray(BUF2) ==Int 32  [simplification]
@@ -84,8 +84,8 @@ module LEMMAS-JAVA [symbolic, kast]
 
     // for Solidity
     rule #asWord(WS) /Int D => #asWord(#take(#sizeByteArray(WS) -Int log256Int(D), WS))
-      requires D ==Int 256 ^Int log256Int(D) andBool D >=Int 0
-       andBool #sizeByteArray(WS) >=Int log256Int(D)
+      requires D ==Int 256 ^Int log256Int(D) andBool 0 <=Int D
+       andBool log256Int(D) <=Int #sizeByteArray(WS)
        andBool #noOverflow(WS)
       [simplification]
 
@@ -98,7 +98,7 @@ module LEMMAS-JAVA [symbolic, kast]
  // -------------------------------------------------------
     rule #noOverflow(WS) => #sizeByteArray(WS) <=Int 32 andBool #noOverflowAux(WS)
 
-    rule #noOverflowAux(BA        ) => 0 <=Int BA[0] andBool BA[0] <Int 256 andBool #noOverflowAux(#drop(1,BA)) requires #sizeByteArray(BA) >Int 0
+    rule #noOverflowAux(BA        ) => 0 <=Int BA[0] andBool BA[0] <Int 256 andBool #noOverflowAux(#drop(1,BA)) requires 0 <Int #sizeByteArray(BA)
     rule #noOverflowAux(.ByteArray) => true
 
     // TODO: drop hash1 and keccakIntList once new vyper hashed location scheme is captured in edsl.md
@@ -241,11 +241,11 @@ module LEMMAS-HASKELL [symbolic, kore]
        andBool START +Int WIDTH <=Int #sizeByteArray(BUF1) [simplification]
 
     rule (BUF1 ++ BUF2)[START .. WIDTH] => BUF2 [START -Int #sizeByteArray(BUF1) .. WIDTH]
-      requires START >=Int #sizeByteArray(BUF1) [simplification]
+      requires #sizeByteArray(BUF1) <=Int START [simplification]
 
     rule #asWord(BUF) /Int D => #asWord(BUF[0 .. #sizeByteArray(BUF) -Int log256Int(D)])
-      requires D ==Int 256 ^Int log256Int(D) andBool D >=Int 0
-       andBool #sizeByteArray(BUF) >=Int log256Int(D) [simplification]
+      requires D ==Int 256 ^Int log256Int(D) andBool 0 <=Int D
+       andBool log256Int(D) <=Int #sizeByteArray(BUF) [simplification]
 
     rule #padToWidth(32, #asByteStack(V)) => #buf(32, V)
       requires #rangeUInt(256, V) [simplification]
@@ -260,29 +260,29 @@ module LEMMAS-HASKELL [symbolic, kore]
     rule maxUInt160 &Int N => N
       requires #rangeUInt(160, N) [simplification]
 
-    rule #range(M, N, K) => .ByteArray requires notBool K >Int 0  [simplification]
+    rule #range(M, N, K) => .ByteArray requires notBool 0 <Int K  [simplification]
 
     rule #range(M [ N := BUF:ByteArray ], L, K) => #range(M, L, minInt(K, N -Int L)) ++ #range(M [ N := BUF ], N, K -Int minInt(K, N -Int L))
-      requires K >Int 0
+      requires 0 <Int K
        andBool L <Int N
       [simplification]
 
     rule #range(M [ N := BUF ], L, K) => BUF [ L -Int N .. minInt(K, #sizeByteArray(BUF) -Int (L -Int N)) ] ++ #range(M, N +Int #sizeByteArray(BUF), K -Int minInt(K, #sizeByteArray(BUF) -Int (L -Int N)))
-      requires K  >Int 0
-       andBool L >=Int N
+      requires 0  <Int K
+       andBool N <=Int L
        andBool L  <Int N +Int #sizeByteArray(BUF)
       [simplification]
 
     rule #range(M [ N := BUF ], L, K) => #range(M, L, K)
-      requires K  >Int 0
-       andBool L >=Int N +Int #sizeByteArray(BUF)
+      requires K <Int 0
+       andBool N +Int #sizeByteArray(BUF) <=Int L
       [simplification]
 
     rule 0 <=Int keccak(V)                  => true  [simplification]
     rule         keccak(V) <=Int maxUInt256 => true  [simplification]
 
     // Defineness axiom for #buf
-    rule #Ceil(#buf(@SIZE, @DATA)) => {(@SIZE >=Int 0) #Equals true} #And #Ceil(@SIZE) #And #Ceil(@DATA) [anywhere]
+    rule #Ceil(#buf(@SIZE, @DATA)) => {(0 <=Int @SIZE) #Equals true} #And #Ceil(@SIZE) #And #Ceil(@DATA) [anywhere]
 
     rule N <=Int maxInt(P, Q) => true requires N <=Int P orBool N <=Int Q  [simplification]
     rule minInt(P, Q)         => P    requires P <=Int Q                   [simplification]

--- a/web3.md
+++ b/web3.md
@@ -388,7 +388,7 @@ WEB3 JSON RPC
  // ------------------------------------------------------------------------
     rule getIntElementsSmallerThan (_, .List,               RESULTS) => RESULTS
     rule getIntElementsSmallerThan (X, (ListItem(I:Int) L), RESULTS) => getIntElementsSmallerThan (X, L, ListItem(I) RESULTS) requires I  <Int X
-    rule getIntElementsSmallerThan (X, (ListItem(I:Int) L), RESULTS) => getIntElementsSmallerThan (X, L, RESULTS)             requires I >=Int X
+    rule getIntElementsSmallerThan (X, (ListItem(I:Int) L), RESULTS) => getIntElementsSmallerThan (X, L, RESULTS)             requires X <=Int I
 
     rule getIntElementsGreaterThan (_, .List ,              RESULTS) => RESULTS
     rule getIntElementsGreaterThan (X, (ListItem(I:Int) L), RESULTS) => getIntElementsGreaterThan (X, L, ListItem(I) RESULTS) requires X  <Int I
@@ -1267,7 +1267,7 @@ Transaction Execution
            <to>         ACCTTO </to>
            ...
          </message>
-      requires ( GLIMIT -Int G0(SCHED, DATA, (ACCTTO ==K .Account)) ) >=Int 0
+      requires 0 <=Int ( GLIMIT -Int G0(SCHED, DATA, (ACCTTO ==K .Account)) )
 
     syntax KItem ::= "#executeTx" Int
  // ---------------------------------

--- a/web3.md
+++ b/web3.md
@@ -186,7 +186,7 @@ WEB3 JSON RPC
          <batch> [ .JSONs ] </batch>
          <web3output> FD </web3output>
          <web3response> RESPONSE </web3response>
-      requires size(RESPONSE) >Int 0
+      requires 0 <Int size(RESPONSE)
 
     rule <k> #loadFromBatch ~> _ => getRequest() </k>
          <batch> [ .JSONs ] </batch>
@@ -391,7 +391,7 @@ WEB3 JSON RPC
     rule getIntElementsSmallerThan (X, (ListItem(I:Int) L), RESULTS) => getIntElementsSmallerThan (X, L, RESULTS)             requires I >=Int X
 
     rule getIntElementsGreaterThan (_, .List ,              RESULTS) => RESULTS
-    rule getIntElementsGreaterThan (X, (ListItem(I:Int) L), RESULTS) => getIntElementsGreaterThan (X, L, ListItem(I) RESULTS) requires I  >Int X
+    rule getIntElementsGreaterThan (X, (ListItem(I:Int) L), RESULTS) => getIntElementsGreaterThan (X, L, ListItem(I) RESULTS) requires X  <Int I
     rule getIntElementsGreaterThan (X, (ListItem(I:Int) L), RESULTS) => getIntElementsGreaterThan (X, L, RESULTS)             requires I <=Int X
 
     syntax JSONs ::= #acctsToJArray ( List ) [function]
@@ -525,7 +525,7 @@ WEB3 JSON RPC
     rule <k> #evm_revert ... </k>
          <params>    ( [ DATA:Int, .JSONs ] )                    </params>
          <snapshots> ( SNAPSHOTS => range(SNAPSHOTS, 0, DATA ) ) </snapshots>
-      requires size(SNAPSHOTS) >Int DATA
+      requires DATA <Int size(SNAPSHOTS)
 
     rule <k> #evm_revert => #rpcResponseError(-32000, "Incorrect number of arguments. Method 'evm_revert' requires exactly 1 arguments. Request specified 0 arguments: [null].")  ... </k>
          <params> [ .JSONs ] </params>
@@ -691,7 +691,7 @@ eth_sendTransaction
                                                         }
                                                       }
                                                     }
-      requires lengthBytes(RD) >Int 68
+      requires 68 <Int lengthBytes(RD)
     rule #generateException(TXHASH, PCOUNT, RD, SC) => { "message": "VM Exception while processing transaction: " +String StatusCode2TruffleString(SC),
                                                       "code": -32000,
                                                       "data": {
@@ -702,7 +702,7 @@ eth_sendTransaction
                                                         }
                                                       }
                                                     }
-      requires notBool lengthBytes(RD) >Int 68
+      requires notBool 68 <Int lengthBytes(RD)
 
     syntax String ::= #parseReason ( Bytes ) [function]
  // ---------------------------------------------------
@@ -1950,7 +1950,7 @@ Retrieving logs
       requires START <=Int END
 
     rule <k> #getLogs(START => START +Int 1, END, RESULT) ... </k>                           [owise]
-    rule <k> #getLogs(START, END, RESULT) => #serializeEthGetLogs(RESULT, [.JSONs]) ... </k> requires START  >Int END
+    rule <k> #getLogs(START, END, RESULT) => #serializeEthGetLogs(RESULT, [.JSONs]) ... </k> requires END <Int START
 
     rule <k> #serializeEthGetLogs(.List, RESULTS:JSONs) => #rpcResponseSuccess([flattenJSONs(RESULTS)]) ... </k>
     rule <k> #serializeEthGetLogs((ListItem({LOGS|TXID|TXHASH|BN|BH}:LogData) LIST:List), RESULTS) => #serializeEthGetLogs(LIST, [flattenJSONs(RESULTS, [#serializeLogs(LOGS,0,TXID,TXHASH,BH,BN)])]) ... </k>


### PR DESCRIPTION
This switches `>Int` for `<Int` and `>=Int` for `<=Int` throughout the semantics so that we only need to write lemmas for one way of comparing things.