### PR TITLE
Makefile: allows the main file to have .k extension

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -179,13 +179,14 @@ java_dir           := $(DEFN_DIR)/java
 java_files         := $(ALL_FILES)
 java_main_module   := ETHEREUM-SIMULATION
 java_syntax_module := $(java_main_module)
-java_main_file     := driver
-java_kompiled      := $(java_dir)/$(java_main_file)-kompiled/timestamp
+java_main_file     := driver.md
+java_main_filename := $(basename $(notdir $(java_main_file)))
+java_kompiled      := $(java_dir)/$(java_main_filename)-kompiled/timestamp
 
 build-java: $(java_kompiled)
 
 $(java_kompiled): $(java_files)
-	$(KOMPILE_JAVA) $(java_main_file).md                  \
+	$(KOMPILE_JAVA) $(java_main_file)                     \
 	                --directory $(java_dir) -I $(CURDIR)  \
 	                --main-module $(java_main_module)     \
 	                --syntax-module $(java_syntax_module)
@@ -196,13 +197,14 @@ specs_dir           := $(DEFN_DIR)/specs
 specs_files         := $(ALL_FILES)
 specs_main_module   := EVM-IMP-SPECS
 specs_syntax_module := $(specs_main_module)
-specs_main_file     := evm-imp-specs
-specs_kompiled      := $(specs_dir)/$(specs_main_file)-kompiled/timestamp
+specs_main_file     := evm-imp-specs.md
+specs_main_filename := $(basename $(notdir $(specs_main_file)))
+specs_kompiled      := $(specs_dir)/$(specs_main_filename)-kompiled/timestamp
 
 build-specs: $(specs_kompiled)
 
 $(specs_kompiled): $(specs_files)
-	$(KOMPILE_JAVA) $(specs_main_file).md                  \
+	$(KOMPILE_JAVA) $(specs_main_file)                     \
 	                --directory $(specs_dir) -I $(CURDIR)  \
 	                --main-module $(specs_main_module)     \
 	                --syntax-module $(specs_syntax_module)
@@ -213,13 +215,14 @@ haskell_dir            := $(DEFN_DIR)/haskell
 haskell_files          := $(ALL_FILES)
 haskell_main_module    := ETHEREUM-SIMULATION
 haskell_syntax_module  := $(haskell_main_module)
-haskell_main_file      := driver
-haskell_kompiled       := $(haskell_dir)/$(haskell_main_file)-kompiled/definition.kore
+haskell_main_file      := driver.md
+haskell_main_filename  := $(basename $(notdir $(haskell_main_file)))
+haskell_kompiled       := $(haskell_dir)/$(haskell_main_filename)-kompiled/definition.kore
 
 build-haskell: $(haskell_kompiled)
 
 $(haskell_kompiled): $(haskell_files)
-	$(KOMPILE_HASKELL) $(haskell_main_file).md                  \
+	$(KOMPILE_HASKELL) $(haskell_main_file)                     \
 	                   --directory $(haskell_dir) -I $(CURDIR)  \
 	                   --main-module $(haskell_main_module)     \
 	                   --syntax-module $(haskell_syntax_module)
@@ -230,10 +233,11 @@ web3_dir           := $(abspath $(DEFN_DIR)/web3)
 web3_files         := $(ALL_FILES)
 web3_main_module   := WEB3
 web3_syntax_module := $(web3_main_module)
-web3_main_file     := web3
+web3_main_file     := web3.md
+web3_main_filename := $(basename $(notdir $(web3_main_file)))
 web3_kompiled      := $(web3_dir)/build/kevm-client
-web3_kore          := $(web3_dir)/$(web3_main_file)-kompiled/definition.kore
-export web3_main_file
+web3_kore          := $(web3_dir)/$(web3_main_filename)-kompiled/definition.kore
+export web3_main_filename
 export web3_dir
 
 ifeq (,$(RELEASE))
@@ -245,7 +249,7 @@ endif
 build-web3: $(web3_kompiled)
 
 $(web3_kore): $(web3_files)
-	$(KOMPILE_WEB3) $(web3_main_file).md                  \
+	$(KOMPILE_WEB3) $(web3_main_file)                     \
 	                --directory $(web3_dir) -I $(CURDIR)  \
 	                --main-module $(web3_main_module)     \
 	                --syntax-module $(web3_syntax_module)
@@ -260,13 +264,14 @@ llvm_dir           := $(DEFN_DIR)/llvm
 llvm_files         := $(ALL_FILES)
 llvm_main_module   := ETHEREUM-SIMULATION
 llvm_syntax_module := $(llvm_main_module)
-llvm_main_file     := driver
-llvm_kompiled      := $(llvm_dir)/$(llvm_main_file)-kompiled/interpreter
+llvm_main_file     := driver.md
+llvm_main_filename := $(basename $(notdir $(llvm_main_file)))
+llvm_kompiled      := $(llvm_dir)/$(llvm_main_filename)-kompiled/interpreter
 
 build-llvm: $(llvm_kompiled)
 
 $(llvm_kompiled): $(llvm_files) $(libff_out)
-	$(KOMPILE_STANDALONE) $(llvm_main_file).md                  \
+	$(KOMPILE_STANDALONE) $(llvm_main_file)                     \
 	                      --directory $(llvm_dir) -I $(CURDIR)  \
 	                      --main-module $(llvm_main_module)     \
 	                      --syntax-module $(llvm_syntax_module)

--- a/cmake/client/CMakeLists.txt
+++ b/cmake/client/CMakeLists.txt
@@ -5,7 +5,7 @@ list(APPEND CMAKE_MODULE_PATH "$ENV{K_RELEASE}/lib/cmake/kframework")
 include(LLVMKompilePrelude)
 project (KevmClient CXX)
 
-set(KOMPILED_DIR $ENV{web3_dir}/$ENV{web3_main_file}-kompiled)
+set(KOMPILED_DIR $ENV{web3_dir}/$ENV{web3_main_filename}-kompiled)
 set(KOMPILE_USE_MAIN "library")
 set(TARGET_NAME "kevm-client")
 

--- a/kevm
+++ b/kevm
@@ -52,12 +52,12 @@ run_kast() {
 }
 
 run_prove() {
-    local def_module run_dir additional_proof_args
+    local def_module run_dir additional_proof_args repl_cmd repl_script
 
     def_module="$1" ; shift
 
-    repl_cmd="${repl_cmd:-$k_release_dir/bin/kore-repl}"
-    repl_script="${repl_script:-$kevm_dir/kast.kscript}"
+    repl_cmd="${REPL_CMD:-$k_release_dir/bin/kore-repl}"
+    repl_script="${REPL_SCRIPT:-$kevm_dir/kast.kscript}"
 
     additional_proof_args=()
     ! $debug || additional_proof_args+=(--debug)

--- a/kevm
+++ b/kevm
@@ -56,9 +56,12 @@ run_prove() {
 
     def_module="$1" ; shift
 
+    repl_cmd="${repl_cmd:-$k_release_dir/bin/kore-repl}"
+    repl_script="${repl_script:-$kevm_dir/kast.kscript}"
+
     additional_proof_args=()
     ! $debug || additional_proof_args+=(--debug)
-    ! $repl  || additional_proof_args+=(--haskell-backend-command "$k_release_dir/bin/kore-repl --repl-script $kevm_dir/kast.kscript")
+    ! $repl  || additional_proof_args+=(--haskell-backend-command "$repl_cmd --repl-script $repl_script")
 
     export K_OPTS=${K_OPTS:--Xmx8G}
     ! $debug || set -x


### PR DESCRIPTION
This allows e.g., `make build-haskell --haskell_main_file=/path/to/verification.k` that is needed for using kore-repl.