### PR TITLE
porting address00-spec to haskell backend

### DIFF
--- a/edsl.md
+++ b/edsl.md
@@ -219,7 +219,7 @@ where `F1 : F2 : F3 : F4` is the (two's complement) byte-array representation of
     rule #getValue(   #bool( DATA )) => DATA
       requires #range(0 <= DATA <= 1)
 
-    syntax Int ::= #ceil32 ( Int ) [function, smtlib(ceil32), smt-prelude]
+    syntax Int ::= #ceil32 ( Int ) [function, smt-hook(ceil32), smt-prelude]
  // -----------------------------------------
     rule [#ceil32]: #ceil32(N) => ((N +Int 31) /Int 32) *Int 32
 ```

--- a/edsl.md
+++ b/edsl.md
@@ -220,7 +220,7 @@ where `F1 : F2 : F3 : F4` is the (two's complement) byte-array representation of
       requires #range(0 <= DATA <= 1)
 
     syntax Int ::= #ceil32 ( Int ) [function, smt-hook(ceil32), smt-prelude]
- // -----------------------------------------
+ // ------------------------------------------------------------------------
     rule [#ceil32]: #ceil32(N) => ((N +Int 31) /Int 32) *Int 32
 ```
 

--- a/tests/failing-symbolic.haskell
+++ b/tests/failing-symbolic.haskell
@@ -1,4 +1,3 @@
-tests/specs/benchmarks/address00-spec.k
 tests/specs/benchmarks/bytes00-spec.k
 tests/specs/benchmarks/ecrecover00-siginvalid-spec.k
 tests/specs/benchmarks/ecrecover00-sigvalid-spec.k

--- a/tests/specs/benchmarks/address00-spec.k
+++ b/tests/specs/benchmarks/address00-spec.k
@@ -27,7 +27,7 @@ module ADDRESS00-SPEC
           <wordStack> .WordStack => ?_ </wordStack>
           <localMem> .Memory => ?_ </localMem>
           <pc> 0 => ?_ </pc>
-          <gas> #gas(INITGAS, 0, 0) => ?_ </gas>
+          <gas> 1000000000 => ?_ </gas>
           <memoryUsed> 0 => ?_ </memoryUsed>
           <callGas> _ => ?_ </callGas>
           <static> false </static> // NOTE: non-static call

--- a/tests/specs/benchmarks/address00-spec.k
+++ b/tests/specs/benchmarks/address00-spec.k
@@ -16,20 +16,20 @@ module ADDRESS00-SPEC
         <endPC> _ => ?_ </endPC>
         <callStack> _ </callStack>
         <interimStates> _ </interimStates>
-        <touchedAccounts> _ => _ </touchedAccounts>
+        <touchedAccounts> _ => ?_ </touchedAccounts>
         <callState>
           <program> #parseByteStack("0x608060405260043610603f576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff1680634b64e492146044575b600080fd5b348015604f57600080fd5b506082600480360381019080803573ffffffffffffffffffffffffffffffffffffffff16906020019092919050505060c4565b604051808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060405180910390f35b60008190509190505600a165627a7a72305820fef7ba925e24a935e59bb401907893518a66095fa9e2c2506b29051dfdaa6ff80029") </program>
           <jumpDests> #computeValidJumpDests(#parseByteStack("0x608060405260043610603f576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff1680634b64e492146044575b600080fd5b348015604f57600080fd5b506082600480360381019080803573ffffffffffffffffffffffffffffffffffffffff16906020019092919050505060c4565b604051808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060405180910390f35b60008190509190505600a165627a7a72305820fef7ba925e24a935e59bb401907893518a66095fa9e2c2506b29051dfdaa6ff80029")) </jumpDests>
-          <id> #CONTRACT_ID </id> // this
+          <id> CONTRACT_ID </id> // this
           <caller> MSG_SENDER </caller> // msg.sender
           <callData> #abiCallData("execute", #address(A0)) </callData> // msg.data
           <callValue> 0 </callValue> // msg.value
-          <wordStack> .WordStack => _ </wordStack>
-          <localMem> .Memory => _ </localMem>
-          <pc> 0 => _ </pc>
-          <gas> #gas(INITGAS, 0, 0) => _ </gas>
-          <memoryUsed> 0 => _ </memoryUsed>
-          <callGas> _ => _ </callGas>
+          <wordStack> .WordStack => ?_ </wordStack>
+          <localMem> .Memory => ?_ </localMem>
+          <pc> 0 => ?_ </pc>
+          <gas> #gas(INITGAS, 0, 0) => ?_ </gas>
+          <memoryUsed> 0 => ?_ </memoryUsed>
+          <callGas> _ => ?_ </callGas>
           <static> false </static> // NOTE: non-static call
           <callDepth> CD </callDepth>
         </callState>
@@ -63,10 +63,10 @@ module ADDRESS00-SPEC
       <network>
         <chainID> _ </chainID>
 
-        <activeAccounts> SetItem(#CONTRACT_ID) SetItem(#CALLEE_ID) SetItem(1) _:Set </activeAccounts>
+        <activeAccounts> SetItem(CONTRACT_ID) SetItem(CALLEE_ID) SetItem(1) _:Set </activeAccounts>
         <accounts>
           <account>
-            <acctID> #CONTRACT_ID </acctID>
+            <acctID> CONTRACT_ID </acctID>
             <balance> CONTRACT_BAL </balance>
             <code> #parseByteStack("0x608060405260043610603f576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff1680634b64e492146044575b600080fd5b348015604f57600080fd5b506082600480360381019080803573ffffffffffffffffffffffffffffffffffffffff16906020019092919050505060c4565b604051808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060405180910390f35b60008190509190505600a165627a7a72305820fef7ba925e24a935e59bb401907893518a66095fa9e2c2506b29051dfdaa6ff80029") </code>
             <storage>
@@ -79,7 +79,7 @@ _
           </account>
 
           <account>
-            <acctID> #CALLEE_ID </acctID>
+            <acctID> CALLEE_ID </acctID>
             <balance> CALLEE_BAL </balance>
             <code> _ </code>
             <storage>
@@ -110,14 +110,14 @@ _
       </network>
     </ethereum>
     requires
-     #rangeAddress(#CONTRACT_ID)
-     andBool #rangeAddress(#CALLEE_ID)
+     #rangeAddress(CONTRACT_ID)
+     andBool #rangeAddress(CALLEE_ID)
      andBool #rangeUInt(256, NOW)
      andBool #rangeUInt(128, BLOCK_NUM) // Solidity
 
      // Account address normality
-     andBool #CONTRACT_ID  >Int 0 andBool (notBool #CONTRACT_ID  in #precompiledAccounts(BYZANTIUM))
-     andBool #CALLEE_ID  >Int 0 andBool (notBool #CALLEE_ID  in #precompiledAccounts(BYZANTIUM))
+     andBool CONTRACT_ID  >Int 0 andBool (notBool CONTRACT_ID  in #precompiledAccounts(BYZANTIUM))
+     andBool CALLEE_ID  >Int 0 andBool (notBool CALLEE_ID  in #precompiledAccounts(BYZANTIUM))
 
 andBool #rangeUInt(256, CONTRACT_BAL)
 andBool #rangeUInt(256, CALLEE_BAL)andBool #range(0 <= CD < 1024)

--- a/tests/specs/benchmarks/verification.k
+++ b/tests/specs/benchmarks/verification.k
@@ -1,8 +1,8 @@
 requires "../lemmas.k"
 
 module VERIFICATION
-    imports K-REFLECTION
     imports LEMMAS
+    imports VERIFICATION-JAVA
 
     rule Rsstore(BYZANTIUM, NEW, CURR, ORIG) => 0 requires NEW =/=Int 0
 
@@ -48,30 +48,6 @@ module VERIFICATION
   // ########################
 
     rule <k> EXTCODESIZE ACCT => #extCodeSize(ACCT) ~> #push ... </k>  [trusted]
-
-    // accumulate the gas cost and never run out of gas
-    rule <k> MEM' ~> #deductMemoryGas => . ... </k>
-         <gas> #gas(INITGAS, NONMEM, MEM) => #gas(INITGAS, NONMEM, MEM +Int MEM') </gas>
-         <callGas> _ => #gas(INITGAS, NONMEM, MEM) </callGas>
-      [trusted, matching(#gas)]
-
-    //Will run only if rule above doesn't match
-    rule <k> G ~> #deductGas => . ... </k>
-         <gas> #gas(INITGAS, NONMEM, MEM) => #gas(INITGAS, NONMEM +Int G, MEM) </gas>
-         <callGas> _ => #gas(INITGAS, NONMEM, MEM) </callGas>
-      [trusted, matching(#gas)]
-
-    rule <k> ECREC => #end EVMC_SUCCESS ... </k>
-         <callData> DATA </callData>
-         <output> _ => #ecrec(#symEcrec(DATA)) </output>
-      requires notBool #isConcrete(DATA) andBool #sizeByteArray(DATA) ==Int 128 andBool notBool #ecrecEmpty(DATA)
-      [trusted]
-
-    rule <k> ECREC => #end EVMC_SUCCESS ... </k>
-         <callData> DATA </callData>
-         <output> _ => #ecrec(.Account) </output>
-      requires notBool #isConcrete(DATA) andBool #sizeByteArray(DATA) ==Int 128 andBool #ecrecEmpty(DATA)
-      [trusted]
 
   // ########################
   // ABI Encoding
@@ -189,12 +165,6 @@ module VERIFICATION
     rule A -Int (A -Int I1) => I1
 
     rule (A +Int I1) -Int A => I1
-
-    rule ((A +Int I1) +Int B) +Int I2 => (A +Int B) +Int (I1 +Int I2)
-      requires notBool #isConcrete(A) andBool notBool #isConcrete(B) andBool #isConcrete(I1) andBool #isConcrete(I2)
-
-    rule (A +Int I1) +Int (B +Int I2) => (A +Int B) +Int (I1 +Int I2)
-      requires notBool #isConcrete(A) andBool notBool #isConcrete(B) andBool #isConcrete(I1) andBool #isConcrete(I2)
 
     rule (A +Int B) +Int (C -Int B) => A +Int C
 
@@ -316,5 +286,49 @@ rule #ecrecData(SIGS, I, DATA_HASH) => #encodeArgs(#bytes32(DATA_HASH), #uint8(#
     rule 0 <=Int #CALLEE_ID               => true
     rule         #CALLEE_ID   <Int pow160 => true
     rule         #CALLEE_ID   <Int pow256 => true
+
+endmodule
+
+module VERIFICATION-JAVA [symbolic, kast]
+    imports LEMMAS
+    imports K-REFLECTION
+
+  // ########################
+  // Rule Replacement
+  // ########################
+
+    // accumulate the gas cost and never run out of gas
+    rule <k> MEM' ~> #deductMemoryGas => . ... </k>
+         <gas> #gas(INITGAS, NONMEM, MEM) => #gas(INITGAS, NONMEM, MEM +Int MEM') </gas>
+         <callGas> _ => #gas(INITGAS, NONMEM, MEM) </callGas>
+      [trusted, matching(#gas)]
+
+    //Will run only if rule above doesn't match
+    rule <k> G ~> #deductGas => . ... </k>
+         <gas> #gas(INITGAS, NONMEM, MEM) => #gas(INITGAS, NONMEM +Int G, MEM) </gas>
+         <callGas> _ => #gas(INITGAS, NONMEM, MEM) </callGas>
+      [trusted, matching(#gas)]
+
+    rule <k> ECREC => #end EVMC_SUCCESS ... </k>
+         <callData> DATA </callData>
+         <output> _ => #ecrec(#symEcrec(DATA)) </output>
+      requires notBool #isConcrete(DATA) andBool #sizeByteArray(DATA) ==Int 128 andBool notBool #ecrecEmpty(DATA)
+      [trusted]
+
+    rule <k> ECREC => #end EVMC_SUCCESS ... </k>
+         <callData> DATA </callData>
+         <output> _ => #ecrec(.Account) </output>
+      requires notBool #isConcrete(DATA) andBool #sizeByteArray(DATA) ==Int 128 andBool #ecrecEmpty(DATA)
+      [trusted]
+
+  // ########################
+  // Arithmetic
+  // ########################
+
+    rule ((A +Int I1) +Int B) +Int I2 => (A +Int B) +Int (I1 +Int I2)
+      requires notBool #isConcrete(A) andBool notBool #isConcrete(B) andBool #isConcrete(I1) andBool #isConcrete(I2)
+
+    rule (A +Int I1) +Int (B +Int I2) => (A +Int B) +Int (I1 +Int I2)
+      requires notBool #isConcrete(A) andBool notBool #isConcrete(B) andBool #isConcrete(I1) andBool #isConcrete(I2)
 
 endmodule

--- a/tests/specs/benchmarks/verification.k
+++ b/tests/specs/benchmarks/verification.k
@@ -1,10 +1,7 @@
 requires "../lemmas.k"
 
-module VERIFICATION
+module VERIFICATION-COMMON
     imports LEMMAS
-    imports VERIFICATION-JAVA
-
-    rule Rsstore(BYZANTIUM, NEW, CURR, ORIG) => 0 requires NEW =/=Int 0
 
   // ########################
   // Ecrecover
@@ -15,6 +12,25 @@ module VERIFICATION
 
     //Symbolic predicate representing whether output of #ecrec is empty. No implementation.
     syntax Bool ::= #ecrecEmpty( ByteArray ) [function]
+
+  // ########################
+  // Symbolic Gas
+  // ########################
+
+    syntax Int ::= #gas ( Int , Int , Int )  [function]  // startGas, nonMemory, memory
+ // -----------------------------------------------------------------------------------
+
+endmodule
+
+module VERIFICATION
+    imports VERIFICATION-COMMON
+    imports VERIFICATION-JAVA
+
+    rule Rsstore(BYZANTIUM, NEW, CURR, ORIG) => 0 requires NEW =/=Int 0
+
+  // ########################
+  // Ecrecover
+  // ########################
 
     // Range for #symEcrec
 
@@ -28,13 +44,6 @@ module VERIFICATION
     // General range conversion lemmas like below are not an option, dramatic performance decrease:
     rule 0 <=Int  #symEcrec(DATA)             => true
     rule          #symEcrec(DATA) <Int pow256 => true
-
-  // ########################
-  // Symbolic Gas
-  // ########################
-
-    syntax Int ::= #gas ( Int , Int , Int )  [function]  // startGas, nonMemory, memory
- // -----------------------------------------------------------------------------------
 
   // ########################
   // Symbolic Call
@@ -290,7 +299,7 @@ rule #ecrecData(SIGS, I, DATA_HASH) => #encodeArgs(#bytes32(DATA_HASH), #uint8(#
 endmodule
 
 module VERIFICATION-JAVA [symbolic, kast]
-    imports LEMMAS
+    imports VERIFICATION-COMMON
     imports K-REFLECTION
 
   // ########################


### PR DESCRIPTION
Changes:
- The `matching` attribute is not supported yet by the haskell backend, and thus the #gas rule doesn't work. So, the spec is simply modified to have a concrete initial gas in the precondition.
- The `#isConcrete` function is not supported by the haskell backend. (It has a nicer alternative.) For now, all the lemmas that use `#isConcrete` are disabled in the haskell backend.