### PR TITLE
fix invalid #lookup.* rule names in concrete-rules.txt

### DIFF
--- a/tests/specs/concrete-rules.txt
+++ b/tests/specs/concrete-rules.txt
@@ -5,8 +5,6 @@ EVM.Cgascap
 EVM.Cmem
 EVM.Csstore.new
 EVM.Csstore.old
-EVM-TYPES.#lookup.none
-EVM-TYPES.#lookup.some
 EVM.#memoryUsageUpdate.some
 EVM.Rsstore.new
 EVM.Rsstore.old

--- a/tests/specs/concrete-rules.txt
+++ b/tests/specs/concrete-rules.txt
@@ -5,8 +5,8 @@ EVM.Cgascap
 EVM.Cmem
 EVM.Csstore.new
 EVM.Csstore.old
-EVM.#lookup.none
-EVM.#lookup.some
+EVM-TYPES.#lookup.none
+EVM-TYPES.#lookup.some
 EVM.#memoryUsageUpdate.some
 EVM.Rsstore.new
 EVM.Rsstore.old


### PR DESCRIPTION
Fix a bug introduced at https://github.com/kframework/evm-semantics/commit/223f21ce46625298962413953e388f5eccfefd58#diff-558a5f8e4337c04713ebea82c99dde22R19-R20