### PR TITLE
Some more functional marked total, add --bug-report option

### DIFF
--- a/edsl.md
+++ b/edsl.md
@@ -137,8 +137,8 @@ where `F1 : F2 : F3 : F4` is the (two's complement) byte-array representation of
     rule #isStaticType(   #string( _ )) => false
     rule #isStaticType(#array(_, _, _)) => false
 
-    syntax Int ::= #sizeOfDynamicType ( TypedArg ) [function, functional]
- // ---------------------------------------------------------------------
+    syntax Int ::= #sizeOfDynamicType ( TypedArg ) [function]
+ // ---------------------------------------------------------
     rule #sizeOfDynamicType(#bytes(BS)) => 32 +Int #ceil32(#sizeByteArray(BS))
 
     rule #sizeOfDynamicType(#array(T, N, _)) => 32 *Int (1 +Int N)
@@ -147,14 +147,12 @@ where `F1 : F2 : F3 : F4` is the (two's complement) byte-array representation of
     rule #sizeOfDynamicType(#array(T, N, ELEMS)) => 32 *Int (1 +Int N +Int #sizeOfDynamicTypeAux(ELEMS))
       requires notBool #isStaticType(T)
 
-    rule #sizeOfDynamicType(_) => 0 [owise]
-
-    syntax Int ::= #sizeOfDynamicTypeAux ( TypedArgs ) [function, functional]
- // -------------------------------------------------------------------------
+    syntax Int ::= #sizeOfDynamicTypeAux ( TypedArgs ) [function]
+ // -------------------------------------------------------------
     rule #sizeOfDynamicTypeAux(TARG, TARGS) => #sizeOfDynamicType(TARG) +Int #sizeOfDynamicTypeAux(TARGS)
       requires notBool #isStaticType(TARG)
 
-    rule #sizeOfDynamicTypeAux(_) => 0 [owise]
+    rule #sizeOfDynamicTypeAux(.TypedArg) => 0
 
     syntax ByteArray ::= #enc ( TypedArg ) [function]
  // -------------------------------------------------

--- a/edsl.md
+++ b/edsl.md
@@ -69,8 +69,8 @@ where `F1 : F2 : F3 : F4` is the (two's complement) byte-array representation of
     rule #generateSignatureArgs(TARGA:TypedArg, .TypedArgs)            => #typeName(TARGA)
     rule #generateSignatureArgs(TARGA:TypedArg, TARGB:TypedArg, TARGS) => #typeName(TARGA) +String "," +String #generateSignatureArgs(TARGB, TARGS)
 
-    syntax String ::= #typeName ( TypedArg ) [function]
- // ---------------------------------------------------
+    syntax String ::= #typeName ( TypedArg ) [function, functional]
+ // ---------------------------------------------------------------
     rule #typeName(   #uint160( _ )) => "uint160"
     rule #typeName(   #address( _ )) => "address"
     rule #typeName(   #uint256( _ )) => "uint256"
@@ -100,13 +100,13 @@ where `F1 : F2 : F3 : F4` is the (two's complement) byte-array representation of
         => #encodeArgsAux(ARGS, OFFSET +Int #sizeOfDynamicType(ARG), HEADS ++ #enc(#uint256(OFFSET)), TAILS ++ #enc(ARG))
       requires notBool(#isStaticType(ARG))
 
-    syntax Int ::= #lenOfHeads ( TypedArgs ) [function]
- // ---------------------------------------------------
+    syntax Int ::= #lenOfHeads ( TypedArgs ) [function, functional]
+ // ---------------------------------------------------------------
     rule #lenOfHeads(.TypedArgs) => 0
     rule #lenOfHeads(ARG, ARGS)  => #lenOfHead(ARG) +Int #lenOfHeads(ARGS)
 
-    syntax Int ::= #lenOfHead ( TypedArg ) [function]
- // -------------------------------------------------
+    syntax Int ::= #lenOfHead ( TypedArg ) [function, functional]
+ // -------------------------------------------------------------
     rule #lenOfHead(  #uint160( _ )) => 32
     rule #lenOfHead(  #address( _ )) => 32
     rule #lenOfHead(  #uint256( _ )) => 32
@@ -137,8 +137,8 @@ where `F1 : F2 : F3 : F4` is the (two's complement) byte-array representation of
     rule #isStaticType(   #string( _ )) => false
     rule #isStaticType(#array(_, _, _)) => false
 
-    syntax Int ::= #sizeOfDynamicType ( TypedArg ) [function]
- // ---------------------------------------------------------
+    syntax Int ::= #sizeOfDynamicType ( TypedArg ) [function, functional]
+ // ---------------------------------------------------------------------
     rule #sizeOfDynamicType(#bytes(BS)) => 32 +Int #ceil32(#sizeByteArray(BS))
 
     rule #sizeOfDynamicType(#array(T, N, _)) => 32 *Int (1 +Int N)
@@ -147,12 +147,14 @@ where `F1 : F2 : F3 : F4` is the (two's complement) byte-array representation of
     rule #sizeOfDynamicType(#array(T, N, ELEMS)) => 32 *Int (1 +Int N +Int #sizeOfDynamicTypeAux(ELEMS))
       requires notBool #isStaticType(T)
 
-    syntax Int ::= #sizeOfDynamicTypeAux ( TypedArgs ) [function]
- // -------------------------------------------------------------
+    rule #sizeOfDynamicType(_) => 0 [owise]
+
+    syntax Int ::= #sizeOfDynamicTypeAux ( TypedArgs ) [function, functional]
+ // -------------------------------------------------------------------------
     rule #sizeOfDynamicTypeAux(TARG, TARGS) => #sizeOfDynamicType(TARG) +Int #sizeOfDynamicTypeAux(TARGS)
       requires notBool #isStaticType(TARG)
 
-    rule #sizeOfDynamicTypeAux(.TypedArgs) => 0
+    rule #sizeOfDynamicTypeAux(_) => 0 [owise]
 
     syntax ByteArray ::= #enc ( TypedArg ) [function]
  // -------------------------------------------------
@@ -219,8 +221,8 @@ where `F1 : F2 : F3 : F4` is the (two's complement) byte-array representation of
     rule #getValue(   #bool( DATA )) => DATA
       requires #range(0 <= DATA <= 1)
 
-    syntax Int ::= #ceil32 ( Int ) [function, smt-hook(ceil32), smt-prelude]
- // ------------------------------------------------------------------------
+    syntax Int ::= #ceil32 ( Int ) [function, functional, smt-hook(ceil32), smt-prelude]
+ // ------------------------------------------------------------------------------------
     rule [#ceil32]: #ceil32(N) => ((N +Int 31) /Int 32) *Int 32
 ```
 

--- a/edsl.md
+++ b/edsl.md
@@ -152,7 +152,7 @@ where `F1 : F2 : F3 : F4` is the (two's complement) byte-array representation of
     rule #sizeOfDynamicTypeAux(TARG, TARGS) => #sizeOfDynamicType(TARG) +Int #sizeOfDynamicTypeAux(TARGS)
       requires notBool #isStaticType(TARG)
 
-    rule #sizeOfDynamicTypeAux(.TypedArg) => 0
+    rule #sizeOfDynamicTypeAux(.TypedArgs) => 0
 
     syntax ByteArray ::= #enc ( TypedArg ) [function]
  // -------------------------------------------------

--- a/edsl.md
+++ b/edsl.md
@@ -60,9 +60,9 @@ where `F1 : F2 : F3 : F4` is the (two's complement) byte-array representation of
  // ------------------------------------------------------------------------
     rule #signatureCallData( FNAME , ARGS ) => #parseByteStack(substrString(Keccak256(#generateSignature(FNAME, ARGS)), 0, 8))
 
-    syntax String ::= #generateSignature     ( String, TypedArgs ) [function]
-                    | #generateSignatureArgs ( TypedArgs )         [function]
- // -------------------------------------------------------------------------
+    syntax String ::= #generateSignature     ( String, TypedArgs ) [function, functional]
+                    | #generateSignatureArgs ( TypedArgs )         [function, functional]
+ // -------------------------------------------------------------------------------------
     rule #generateSignature( FNAME , ARGS ) => FNAME +String "(" +String #generateSignatureArgs(ARGS) +String ")"
 
     rule #generateSignatureArgs(.TypedArgs)                            => ""
@@ -121,8 +121,8 @@ where `F1 : F2 : F3 : F4` is the (two's complement) byte-array representation of
     rule #lenOfHead(   #string( _ )) => 32
     rule #lenOfHead(#array(_, _, _)) => 32
 
-    syntax Bool ::= #isStaticType ( TypedArg ) [function]
- // -----------------------------------------------------
+    syntax Bool ::= #isStaticType ( TypedArg ) [function, functional]
+ // -----------------------------------------------------------------
     rule #isStaticType(  #uint160( _ )) => true
     rule #isStaticType(  #address( _ )) => true
     rule #isStaticType(  #uint256( _ )) => true

--- a/kevm
+++ b/kevm
@@ -60,8 +60,9 @@ run_prove() {
     repl_script="${REPL_SCRIPT:-$kevm_dir/kast.kscript}"
 
     additional_proof_args=()
-    ! $debug || additional_proof_args+=(--debug)
-    ! $repl  || additional_proof_args+=(--haskell-backend-command "$repl_cmd --repl-script $repl_script")
+    ! $debug      || additional_proof_args+=(--debug)
+    ! $repl       || additional_proof_args+=(--haskell-backend-command "$repl_cmd --repl-script $repl_script")
+    ! $bug_report || additional_proof_args+=(--haskell-backend-command "kore-exec --bug-report kevm-bug")
 
     export K_OPTS=${K_OPTS:--Xmx16G}
     ! $debug || set -x
@@ -257,6 +258,7 @@ debug=false
 dump=false
 unparse=true
 repl=false
+bug_report=false
 [[ ! "$run_command" == 'prove' ]] || backend='java'
 [[ ! "$run_command" =~ klab*   ]] || backend='java'
 [[ ! "$run_command" =~ web3*   ]] || backend='llvm'
@@ -270,6 +272,7 @@ while [[ $# -gt 0 ]]; do
         --dump)               dump=true         ; shift   ;;
         --no-unparse)         unparse=false     ; shift   ;;
         --repl)               repl=true         ; shift   ;;
+        --bug-report)         bug_report=true   ; shift   ;;
         --backend)            backend="$2"      ; shift 2 ;;
         --backend-dir)        backend_dir="$2"  ; shift 2 ;;
         -p|--port)            kevm_port="$2"    ; shift 2 ;;


### PR DESCRIPTION
The function `#sizeOfDynamicType` gets some weird behavior on static types, to become total.

This makes a lot of the functions that `#encodeArgs` uses total, but unfortunately because of the nature of `getValue` we can't make `#enc` total, so we can't make `#encodeArgs` total.