### PR TITLE
Fix simplification rules for #Ceil(#buf)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,9 +134,9 @@ SOURCE_FILES       := asm           \
 EXTRA_SOURCE_FILES :=
 ALL_FILES          := $(patsubst %, %.md, $(SOURCE_FILES) $(EXTRA_SOURCE_FILES))
 
-tangle_concrete := k & ( ( ! ( symbolic | nobytes ) ) | concrete | bytes   )
-tangle_java     := k & ( ( ! ( concrete | bytes   ) ) | symbolic | nobytes )
-tangle_haskell  := k & ( ( ! ( concrete | nobytes ) ) | symbolic | bytes   )
+tangle_concrete := k & (! ceil) & ( ( ! ( symbolic | nobytes ) ) | concrete | bytes   )
+tangle_java     := k & (! ceil) & ( ( ! ( concrete | bytes   ) ) | symbolic | nobytes )
+tangle_haskell  := k            & ( ( ! ( concrete | nobytes ) ) | symbolic | bytes   )
 
 HOOK_NAMESPACES = KRYPTO JSON
 

--- a/edsl.md
+++ b/edsl.md
@@ -194,7 +194,7 @@ where `F1 : F2 : F3 : F4` is the (two's complement) byte-array representation of
       [anywhere, simplification]
 ```
 
-```
+```k
     syntax Int ::= #getValue ( TypedArg ) [function]
  // ------------------------------------------------
     rule #getValue(#uint160( DATA )) => DATA

--- a/edsl.md
+++ b/edsl.md
@@ -184,13 +184,17 @@ where `F1 : F2 : F3 : F4` is the (two's complement) byte-array representation of
     rule #buf(SIZE, DATA) => #padToWidth(SIZE, #asByteStack(DATA))
       requires #range(0 <= DATA < (2 ^Int (SIZE *Int 8)))
       [concrete]
+```
 
+``` {.k .symbolic .ceil}
     rule #Ceil(#buf(@SIZE, @DATA))
       =>      {(0 <=Int @SIZE) andBool #rangeBytes(@SIZE, @DATA) #Equals true}
          #And #Ceil(@SIZE)
          #And #Ceil(@DATA)
       [anywhere, simplification]
+```
 
+```
     syntax Int ::= #getValue ( TypedArg ) [function]
  // ------------------------------------------------
     rule #getValue(#uint160( DATA )) => DATA

--- a/edsl.md
+++ b/edsl.md
@@ -185,9 +185,10 @@ where `F1 : F2 : F3 : F4` is the (two's complement) byte-array representation of
       requires #range(0 <= DATA < (2 ^Int (SIZE *Int 8)))
       [concrete]
 
-    rule #Ceil(#buf(@SIZE, @DATA)) =>
-      {(0 <=Int @SIZE) andBool #rangeBytes(@SIZE, @DATA) #Equals true}
-      #And #Ceil(@SIZE) #And #Ceil(@DATA)
+    rule #Ceil(#buf(@SIZE, @DATA))
+      =>      {(0 <=Int @SIZE) andBool #rangeBytes(@SIZE, @DATA) #Equals true}
+         #And #Ceil(@SIZE)
+         #And #Ceil(@DATA)
       [anywhere, simplification]
 
     syntax Int ::= #getValue ( TypedArg ) [function]

--- a/edsl.md
+++ b/edsl.md
@@ -185,7 +185,10 @@ where `F1 : F2 : F3 : F4` is the (two's complement) byte-array representation of
       requires #range(0 <= DATA < (2 ^Int (SIZE *Int 8)))
       [concrete]
 
-    rule #Ceil(#buf(SIZE, DATA)) => {(0 <=Int SIZE) andBool #rangeBytes(SIZE, DATA) #Equals true}  [anywhere, simplification]
+    rule #Ceil(#buf(@SIZE, @DATA)) =>
+      {(0 <=Int @SIZE) andBool #rangeBytes(@SIZE, @DATA) #Equals true}
+      #And #Ceil(@SIZE) #And #Ceil(@DATA)
+      [anywhere, simplification]
 
     syntax Int ::= #getValue ( TypedArg ) [function]
  // ------------------------------------------------

--- a/tests/specs/lemmas.k
+++ b/tests/specs/lemmas.k
@@ -303,9 +303,6 @@ module LEMMAS-HASKELL [symbolic, kore]
        andBool L >=Int N +Int #sizeByteArray(BUF)
       [simplification]
 
-    // Defineness axiom for #buf
-    rule #Ceil(#buf(@SIZE, @DATA)) => {(@SIZE >=Int 0) #Equals true} #And #Ceil(@SIZE) #And #Ceil(@DATA) [anywhere]
-
     rule N <=Int maxInt(P, Q) => true requires N <=Int P orBool N <=Int Q  [simplification]
     rule minInt(P, Q)         => P    requires P <=Int Q                   [simplification]
 


### PR DESCRIPTION
This pull request fixes two problems with the simplification rules for `#Ceil(#buf)`:

1. The rule in `lemmas.k` conflicts with the rule in `edsl.md`.
1. The rule in `edsl.md` cannot be applied in most cases.