### PR TITLE
Make benchmarks/bytes00 pass on haskell backend

### DIFF
--- a/kevm
+++ b/kevm
@@ -52,16 +52,12 @@ run_kast() {
 }
 
 run_prove() {
-    local def_module run_dir additional_proof_args repl_cmd repl_script
+    local def_module run_dir additional_proof_args
 
     def_module="$1" ; shift
 
-    repl_cmd="${REPL_CMD:-$k_release_dir/bin/kore-repl}"
-    repl_script="${REPL_SCRIPT:-$kevm_dir/kast.kscript}"
-
     additional_proof_args=()
     ! $debug      || additional_proof_args+=(--debug)
-    ! $repl       || additional_proof_args+=(--haskell-backend-command "$repl_cmd --repl-script $repl_script")
     ! $bug_report || additional_proof_args+=(--haskell-backend-command "kore-exec --bug-report kevm-bug")
 
     export K_OPTS=${K_OPTS:--Xmx16G}
@@ -257,7 +253,6 @@ backend="llvm"
 debug=false
 dump=false
 unparse=true
-repl=false
 bug_report=false
 [[ ! "$run_command" == 'prove' ]] || backend='java'
 [[ ! "$run_command" =~ klab*   ]] || backend='java'
@@ -271,7 +266,6 @@ while [[ $# -gt 0 ]]; do
         --debug)              debug=true        ; shift   ;;
         --dump)               dump=true         ; shift   ;;
         --no-unparse)         unparse=false     ; shift   ;;
-        --repl)               repl=true         ; shift   ;;
         --bug-report)         bug_report=true   ; shift   ;;
         --backend)            backend="$2"      ; shift 2 ;;
         --backend-dir)        backend_dir="$2"  ; shift 2 ;;
@@ -282,8 +276,6 @@ while [[ $# -gt 0 ]]; do
 done
 set -- "${args[@]}"
 backend_dir="${backend_dir:-$defn_dir/$backend}"
-
-! $repl || [[ "$backend" == haskell ]] || fatal "Option --repl only usable with --backend haskell!"
 
 # get the run file
 if [[ ! "$run_command" =~ web3* ]]; then

--- a/tests/failing-symbolic.haskell
+++ b/tests/failing-symbolic.haskell
@@ -1,4 +1,3 @@
-tests/specs/benchmarks/bytes00-spec.k
 tests/specs/benchmarks/ecrecover00-siginvalid-spec.k
 tests/specs/benchmarks/ecrecover00-sigvalid-spec.k
 tests/specs/benchmarks/ecrecoverloop00-sig0-invalid-spec.k

--- a/tests/specs/benchmarks/bytes00-spec.k
+++ b/tests/specs/benchmarks/bytes00-spec.k
@@ -3,7 +3,7 @@ requires "verification.k"
 module BYTES00-SPEC
   imports VERIFICATION
 
-  // fn-execute 
+  // fn-execute
   rule
     <k> (#execute => #halt) ~> _ </k>
     <exit-code> 1 </exit-code>
@@ -22,12 +22,12 @@ module BYTES00-SPEC
           <jumpDests> #computeValidJumpDests(#parseByteStack("0x608060405260043610603f576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff16806309c5eabe146044575b600080fd5b348015604f57600080fd5b5060a8600480360381019080803590602001908201803590602001908080601f016020809104026020016040519081016040528093929190818152602001838380828437820191505050505050919291929050505060be565b6040518082815260200191505060405180910390f35b6000815190509190505600a165627a7a72305820443b6929f0411657e3b5f5371823da4795cb8ece704713e7934fea316a2af24a0029")) </jumpDests>
           <id> CONTRACT_ID </id> // this
           <caller> MSG_SENDER </caller> // msg.sender
-          <callData> #abiCallData("execute", #bytes(#buf(DATA_LEN,DATA))) </callData> // msg.data
+          <callData> #abiCallData("execute", #bytes(#buf(DATA_LEN, _DATA))) </callData> // msg.data
           <callValue> 0 </callValue> // msg.value
           <wordStack> .WordStack => ?_ </wordStack>
           <localMem> .Memory => ?_ </localMem>
           <pc> 0 => ?_ </pc>
-          <gas> #gas(INITGAS, 0, 0) => ?_ </gas>
+          <gas> #gas(_INITGAS, 0, 0) => ?_ </gas>
           <memoryUsed> 0 => ?_ </memoryUsed>
           <callGas> _ => ?_ </callGas>
           <static> false </static> // NOTE: non-static call
@@ -40,7 +40,7 @@ module BYTES00-SPEC
         </substate>
         <gasPrice> _ </gasPrice>
         <origin> _ </origin> // tx.origin
-        <blockhashes> BLOCK_HASHES </blockhashes> // block.blockhash
+        <blockhashes> _BLOCK_HASHES </blockhashes> // block.blockhash
         <block>
           <previousHash> _ </previousHash>
           <ommersHash> _ </ommersHash>
@@ -109,23 +109,20 @@ _
         <messages> _ </messages>
       </network>
     </ethereum>
-    requires
-     #rangeAddress(CONTRACT_ID)
+    requires #rangeAddress(CONTRACT_ID)
      andBool #rangeAddress(CALLEE_ID)
      andBool #rangeUInt(256, NOW)
      andBool #rangeUInt(128, BLOCK_NUM) // Solidity
 
      // Account address normality
-     andBool CONTRACT_ID  >Int 0 andBool (notBool CONTRACT_ID  in #precompiledAccounts(BYZANTIUM))
-     andBool CALLEE_ID  >Int 0 andBool (notBool CALLEE_ID  in #precompiledAccounts(BYZANTIUM))
+     andBool CONTRACT_ID >Int 0 andBool (notBool CONTRACT_ID in #precompiledAccounts(BYZANTIUM))
+     andBool CALLEE_ID   >Int 0 andBool (notBool CALLEE_ID   in #precompiledAccounts(BYZANTIUM))
 
-andBool #rangeUInt(256, CONTRACT_BAL)
-andBool #rangeUInt(256, CALLEE_BAL)andBool #range(0 <= CD < 1024)
-andBool #rangeAddress(MSG_SENDER)andBool #range( 0 <= DATA_LEN < 2 ^Int 16)
-    ensures true
-
-
-
+     andBool #rangeUInt(256, CONTRACT_BAL)
+     andBool #rangeUInt(256, CALLEE_BAL)
+     andBool #range(0 <= CD < 1024)
+     andBool #rangeAddress(MSG_SENDER)
+     andBool #range(0 <= DATA_LEN < pow16)
 
 endmodule
 

--- a/tests/specs/benchmarks/verification.k
+++ b/tests/specs/benchmarks/verification.k
@@ -211,6 +211,10 @@ module VERIFICATION
 
     rule #ceil32(X) => X requires X modInt 32 ==Int 0
 
+    rule 0 <=Int #ceil32(X) -Int X => true requires 0 <=Int X [simplification]
+
+    rule 0 <Int 1 <<Int N => true requires 0 <=Int N [simplification]
+
     rule X <=Int #ceil32(X) => true
       requires X >=Int 0
 
@@ -307,12 +311,37 @@ module VERIFICATION-HASKELL [symbolic, kore]
 
     rule #gas(G) -Int G' => #gas(G +Int G') [simplification]
 
+    rule #gas(_)  <Int I => false requires I <=Int pow256 [simplification]
+    rule #gas(_) <=Int I => false requires I <=Int pow256 [simplification]
+    rule #gas(_) >=Int I => true  requires I <=Int pow256 [simplification]
+    rule I <=Int #gas(_) => true  requires I <=Int pow256 [simplification]
+
     rule #gas(_)  <Int _I => false [concrete(_I), simplification]
     rule #gas(_) <=Int _I => false [concrete(_I), simplification]
     rule #gas(_) >=Int _I => true  [concrete(_I), simplification]
+    rule _I <=Int #gas(_) => true  [concrete(_I), simplification]
 
-    rule #gas(_)  <Int Csstore(_, _, _, _) => false [simplification]
-    rule #gas(_) >=Int Csstore(_, _, _, _) => true  [simplification]
+    rule I +Int I' <=Int #gas(G) => true requires I <=Int #gas(G) andBool I' <=Int #gas(G) [simplification]
+    rule I -Int I' <=Int #gas(G) => true requires I <=Int #gas(G) andBool I' <=Int #gas(G) [simplification]
+    rule I *Int I' <=Int #gas(G) => true requires I <=Int #gas(G) andBool I' <=Int #gas(G) [simplification]
+    rule I /Int I' <=Int #gas(G) => true requires I <=Int #gas(G) andBool I' <=Int #gas(G) [simplification]
+
+    rule #gas(G) <Int I +Int I' => false requires notBool (#gas(G) <Int I orBool #gas(G) <Int I') [simplification]
+    rule #gas(G) <Int I -Int I' => false requires notBool (#gas(G) <Int I orBool #gas(G) <Int I') [simplification]
+    rule #gas(G) <Int I *Int I' => false requires notBool (#gas(G) <Int I orBool #gas(G) <Int I') [simplification]
+    rule #gas(G) <Int I /Int I' => false requires notBool (#gas(G) <Int I orBool #gas(G) <Int I') [simplification]
+
+    rule #gas(G) <=Int I +Int I' => false requires notBool (#gas(G) <=Int I orBool #gas(G) <=Int I') [simplification]
+    rule #gas(G) <=Int I -Int I' => false requires notBool (#gas(G) <=Int I orBool #gas(G) <=Int I') [simplification]
+    rule #gas(G) <=Int I *Int I' => false requires notBool (#gas(G) <=Int I orBool #gas(G) <=Int I') [simplification]
+    rule #gas(G) <=Int I /Int I' => false requires notBool (#gas(G) <=Int I orBool #gas(G) <=Int I') [simplification]
+
+    rule #gas(_) <Int Csstore(_, _, _, _) => false [simplification]
+    rule #gas(_) <Int Cmem(_, _)          => false [simplification]
+
+    rule #gas(_) >=Int Csstore(_, _, _, _) => true [simplification]
+
+    rule Cmem(_, _) <=Int #gas(_) => true [simplification]
 endmodule
 
 module VERIFICATION-JAVA [symbolic, kast]

--- a/tests/specs/functional/lemmas-no-smt-spec.k
+++ b/tests/specs/functional/lemmas-no-smt-spec.k
@@ -9,7 +9,7 @@ module VERIFICATION
     syntax KItem ::= runLemma ( StepSort )
                    | doneLemma( StepSort )
  // --------------------------------------
-    rule runLemma( T ) => doneLemma( T )
+    rule <k> runLemma( T ) => doneLemma( T ) ... </k>
 
 endmodule
 
@@ -19,21 +19,21 @@ module LEMMAS-NO-SMT-SPEC
  // Arithmetic simplification
  // -------------------------
 
-    rule runLemma ( 5 +Int X ) => doneLemma ( X +Int 5 )
-    rule runLemma ( X -Int 5 ) => doneLemma ( X +Int (0 -Int 5) )
-    rule runLemma ( (X +Int 3) +Int 5 ) => doneLemma ( X +Int 8 )
-    rule runLemma ( 3 +Int (X +Int 5) ) => doneLemma ( X +Int 8 )
-    rule runLemma ( 5 -Int (X +Int 3) ) => doneLemma ( 2 -Int X )
-    rule runLemma ( 5 +Int (3 +Int X) ) => doneLemma ( 8 +Int X )
-    rule runLemma ( 5 +Int (3 -Int X) ) => doneLemma ( 8 -Int X )
-    rule runLemma ( (5 -Int X) +Int 3 ) => doneLemma ( 8 -Int X )
-    rule runLemma ( 5 -Int (3 +Int X) ) => doneLemma ( 2 -Int X )
-    rule runLemma ( 5 -Int (3 -Int X) ) => doneLemma ( 2 +Int X )
-    rule runLemma ( (X -Int 5) -Int 3 ) => doneLemma ( X -Int 8 )
-    rule runLemma ( 5 &Int (3 &Int X) ) => doneLemma ( 1 &Int X )
+    rule <k> runLemma ( 5 +Int X )          => doneLemma ( X +Int 5          ) ... </k>
+    rule <k> runLemma ( X -Int 5 )          => doneLemma ( X +Int (0 -Int 5) ) ... </k>
+    rule <k> runLemma ( (X +Int 3) +Int 5 ) => doneLemma ( X +Int 8          ) ... </k>
+    rule <k> runLemma ( 3 +Int (X +Int 5) ) => doneLemma ( X +Int 8          ) ... </k>
+    rule <k> runLemma ( 5 -Int (X +Int 3) ) => doneLemma ( 2 -Int X          ) ... </k>
+    rule <k> runLemma ( 5 +Int (3 +Int X) ) => doneLemma ( 8 +Int X          ) ... </k>
+    rule <k> runLemma ( 5 +Int (3 -Int X) ) => doneLemma ( 8 -Int X          ) ... </k>
+    rule <k> runLemma ( (5 -Int X) +Int 3 ) => doneLemma ( 8 -Int X          ) ... </k>
+    rule <k> runLemma ( 5 -Int (3 +Int X) ) => doneLemma ( 2 -Int X          ) ... </k>
+    rule <k> runLemma ( 5 -Int (3 -Int X) ) => doneLemma ( 2 +Int X          ) ... </k>
+    rule <k> runLemma ( (X -Int 5) -Int 3 ) => doneLemma ( X -Int 8          ) ... </k>
+    rule <k> runLemma ( 5 &Int (3 &Int X) ) => doneLemma ( 1 &Int X          ) ... </k>
 
  // Boolean simplification
  // ----------------------
-    rule runLemma ( B ==Bool false ==Bool false ) => doneLemma ( B )
+    rule <k> runLemma ( B ==Bool false ==Bool false ) => doneLemma ( B ) ... </k>
 
 endmodule


### PR DESCRIPTION
This makes the `bytes00` proof pass on the Haskell backend, but it takes roughly 5 hours on my machine, so should not be merged yet.