### PR TITLE
Updates to --repl and formatting on benchmarks

### DIFF
--- a/kevm
+++ b/kevm
@@ -52,16 +52,13 @@ run_kast() {
 }
 
 run_prove() {
-    local def_module run_dir additional_proof_args repl_cmd repl_script
+    local def_module run_dir additional_proof_args
 
     def_module="$1" ; shift
 
-    repl_cmd="${REPL_CMD:-$k_release_dir/bin/kore-repl}"
-    repl_script="${REPL_SCRIPT:-$kevm_dir/kast.kscript}"
-
     additional_proof_args=()
     ! $debug      || additional_proof_args+=(--debug)
-    ! $repl       || additional_proof_args+=(--haskell-backend-command "$repl_cmd --repl-script $repl_script")
+    ! $repl       || additional_proof_args+=(--debugger --debug-script kast.kscript)
     ! $bug_report || additional_proof_args+=(--haskell-backend-command "kore-exec --bug-report kevm-bug")
 
     export K_OPTS=${K_OPTS:--Xmx16G}

--- a/kevm
+++ b/kevm
@@ -52,16 +52,12 @@ run_kast() {
 }
 
 run_prove() {
-    local def_module run_dir additional_proof_args repl_cmd repl_script
+    local def_module run_dir additional_proof_args
 
     def_module="$1" ; shift
 
-    repl_cmd="${REPL_CMD:-$k_release_dir/bin/kore-repl}"
-    repl_script="${REPL_SCRIPT:-$kevm_dir/kast.kscript}"
-
     additional_proof_args=()
     ! $debug      || additional_proof_args+=(--debug)
-    ! $repl       || additional_proof_args+=(--haskell-backend-command "$repl_cmd --repl-script $repl_script")
     ! $bug_report || additional_proof_args+=(--haskell-backend-command "kore-exec --bug-report kevm-bug")
 
     export K_OPTS=${K_OPTS:--Xmx16G}
@@ -257,7 +253,6 @@ backend="llvm"
 debug=false
 dump=false
 unparse=true
-repl=false
 bug_report=false
 [[ ! "$run_command" == 'prove' ]] || backend='java'
 [[ ! "$run_command" =~ klab*   ]] || backend='java'
@@ -271,7 +266,6 @@ while [[ $# -gt 0 ]]; do
         --debug)              debug=true        ; shift   ;;
         --dump)               dump=true         ; shift   ;;
         --no-unparse)         unparse=false     ; shift   ;;
-        --repl)               repl=true         ; shift   ;;
         --bug-report)         bug_report=true   ; shift   ;;
         --backend)            backend="$2"      ; shift 2 ;;
         --backend-dir)        backend_dir="$2"  ; shift 2 ;;
@@ -282,8 +276,6 @@ while [[ $# -gt 0 ]]; do
 done
 set -- "${args[@]}"
 backend_dir="${backend_dir:-$defn_dir/$backend}"
-
-! $repl || [[ "$backend" == haskell ]] || fatal "Option --repl only usable with --backend haskell!"
 
 # get the run file
 if [[ ! "$run_command" =~ web3* ]]; then

--- a/kevm
+++ b/kevm
@@ -52,12 +52,16 @@ run_kast() {
 }
 
 run_prove() {
-    local def_module run_dir additional_proof_args
+    local def_module run_dir additional_proof_args repl_cmd repl_script
 
     def_module="$1" ; shift
 
+    repl_cmd="${REPL_CMD:-$k_release_dir/bin/kore-repl}"
+    repl_script="${REPL_SCRIPT:-$kevm_dir/kast.kscript}"
+
     additional_proof_args=()
     ! $debug      || additional_proof_args+=(--debug)
+    ! $repl       || additional_proof_args+=(--haskell-backend-command "$repl_cmd --repl-script $repl_script")
     ! $bug_report || additional_proof_args+=(--haskell-backend-command "kore-exec --bug-report kevm-bug")
 
     export K_OPTS=${K_OPTS:--Xmx16G}
@@ -253,6 +257,7 @@ backend="llvm"
 debug=false
 dump=false
 unparse=true
+repl=false
 bug_report=false
 [[ ! "$run_command" == 'prove' ]] || backend='java'
 [[ ! "$run_command" =~ klab*   ]] || backend='java'
@@ -266,6 +271,7 @@ while [[ $# -gt 0 ]]; do
         --debug)              debug=true        ; shift   ;;
         --dump)               dump=true         ; shift   ;;
         --no-unparse)         unparse=false     ; shift   ;;
+        --repl)               repl=true         ; shift   ;;
         --bug-report)         bug_report=true   ; shift   ;;
         --backend)            backend="$2"      ; shift 2 ;;
         --backend-dir)        backend_dir="$2"  ; shift 2 ;;
@@ -276,6 +282,8 @@ while [[ $# -gt 0 ]]; do
 done
 set -- "${args[@]}"
 backend_dir="${backend_dir:-$defn_dir/$backend}"
+
+! $repl || [[ "$backend" == haskell ]] || fatal "Option --repl only usable with --backend haskell!"
 
 # get the run file
 if [[ ! "$run_command" =~ web3* ]]; then

--- a/tests/specs/benchmarks/address00-spec.k
+++ b/tests/specs/benchmarks/address00-spec.k
@@ -3,7 +3,7 @@ requires "verification.k"
 module ADDRESS00-SPEC
   imports VERIFICATION
 
-  // fn-execute 
+  // fn-execute
   rule
     <k> (#execute => #halt) ~> _ </k>
     <exit-code> 1 </exit-code>
@@ -109,23 +109,20 @@ _
         <messages> _ </messages>
       </network>
     </ethereum>
-    requires
-     #rangeAddress(CONTRACT_ID)
+    requires #rangeAddress(CONTRACT_ID)
      andBool #rangeAddress(CALLEE_ID)
      andBool #rangeUInt(256, NOW)
      andBool #rangeUInt(128, BLOCK_NUM) // Solidity
 
      // Account address normality
-     andBool CONTRACT_ID  >Int 0 andBool (notBool CONTRACT_ID  in #precompiledAccounts(BYZANTIUM))
-     andBool CALLEE_ID  >Int 0 andBool (notBool CALLEE_ID  in #precompiledAccounts(BYZANTIUM))
+     andBool CONTRACT_ID >Int 0 andBool (notBool CONTRACT_ID in #precompiledAccounts(BYZANTIUM))
+     andBool CALLEE_ID   >Int 0 andBool (notBool CALLEE_ID   in #precompiledAccounts(BYZANTIUM))
 
-andBool #rangeUInt(256, CONTRACT_BAL)
-andBool #rangeUInt(256, CALLEE_BAL)andBool #range(0 <= CD < 1024)
-andBool #rangeAddress(MSG_SENDER)andBool #rangeAddress(A0)
-    ensures true
-
-
-
+     andBool #rangeUInt(256, CONTRACT_BAL)
+     andBool #rangeUInt(256, CALLEE_BAL)
+     andBool #range(0 <= CD < 1024)
+     andBool #rangeAddress(MSG_SENDER)
+     andBool #rangeAddress(A0)
 
 endmodule
 

--- a/tests/specs/benchmarks/bytes00-spec.k
+++ b/tests/specs/benchmarks/bytes00-spec.k
@@ -3,7 +3,7 @@ requires "verification.k"
 module BYTES00-SPEC
   imports VERIFICATION
 
-  // fn-execute 
+  // fn-execute
   rule
     <k> (#execute => #halt) ~> _ </k>
     <exit-code> 1 </exit-code>
@@ -22,12 +22,12 @@ module BYTES00-SPEC
           <jumpDests> #computeValidJumpDests(#parseByteStack("0x608060405260043610603f576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff16806309c5eabe146044575b600080fd5b348015604f57600080fd5b5060a8600480360381019080803590602001908201803590602001908080601f016020809104026020016040519081016040528093929190818152602001838380828437820191505050505050919291929050505060be565b6040518082815260200191505060405180910390f35b6000815190509190505600a165627a7a72305820443b6929f0411657e3b5f5371823da4795cb8ece704713e7934fea316a2af24a0029")) </jumpDests>
           <id> CONTRACT_ID </id> // this
           <caller> MSG_SENDER </caller> // msg.sender
-          <callData> #abiCallData("execute", #bytes(#buf(DATA_LEN,DATA))) </callData> // msg.data
+          <callData> #abiCallData("execute", #bytes(#buf(DATA_LEN, _DATA))) </callData> // msg.data
           <callValue> 0 </callValue> // msg.value
           <wordStack> .WordStack => ?_ </wordStack>
           <localMem> .Memory => ?_ </localMem>
           <pc> 0 => ?_ </pc>
-          <gas> #gas(INITGAS, 0, 0) => ?_ </gas>
+          <gas> #gas(_INITGAS, 0, 0) => ?_ </gas>
           <memoryUsed> 0 => ?_ </memoryUsed>
           <callGas> _ => ?_ </callGas>
           <static> false </static> // NOTE: non-static call
@@ -40,7 +40,7 @@ module BYTES00-SPEC
         </substate>
         <gasPrice> _ </gasPrice>
         <origin> _ </origin> // tx.origin
-        <blockhashes> BLOCK_HASHES </blockhashes> // block.blockhash
+        <blockhashes> _BLOCK_HASHES </blockhashes> // block.blockhash
         <block>
           <previousHash> _ </previousHash>
           <ommersHash> _ </ommersHash>
@@ -109,23 +109,20 @@ _
         <messages> _ </messages>
       </network>
     </ethereum>
-    requires
-     #rangeAddress(CONTRACT_ID)
+    requires #rangeAddress(CONTRACT_ID)
      andBool #rangeAddress(CALLEE_ID)
      andBool #rangeUInt(256, NOW)
      andBool #rangeUInt(128, BLOCK_NUM) // Solidity
 
      // Account address normality
-     andBool CONTRACT_ID  >Int 0 andBool (notBool CONTRACT_ID  in #precompiledAccounts(BYZANTIUM))
-     andBool CALLEE_ID  >Int 0 andBool (notBool CALLEE_ID  in #precompiledAccounts(BYZANTIUM))
+     andBool CONTRACT_ID >Int 0 andBool (notBool CONTRACT_ID in #precompiledAccounts(BYZANTIUM))
+     andBool CALLEE_ID   >Int 0 andBool (notBool CALLEE_ID   in #precompiledAccounts(BYZANTIUM))
 
-andBool #rangeUInt(256, CONTRACT_BAL)
-andBool #rangeUInt(256, CALLEE_BAL)andBool #range(0 <= CD < 1024)
-andBool #rangeAddress(MSG_SENDER)andBool #range( 0 <= DATA_LEN < 2 ^Int 16)
-    ensures true
-
-
-
+     andBool #rangeUInt(256, CONTRACT_BAL)
+     andBool #rangeUInt(256, CALLEE_BAL)
+     andBool #range(0 <= CD < 1024)
+     andBool #rangeAddress(MSG_SENDER)
+     andBool #range(0 <= DATA_LEN < pow16)
 
 endmodule
 

--- a/tests/specs/benchmarks/ecrecover00-siginvalid-spec.k
+++ b/tests/specs/benchmarks/ecrecover00-siginvalid-spec.k
@@ -3,7 +3,7 @@ requires "verification.k"
 module ECRECOVER00-SIGINVALID-SPEC
   imports VERIFICATION
 
-  // fn-execute-siginvalid 
+  // fn-execute-siginvalid
   rule
     <k> (#execute => #halt) ~> _ </k>
     <exit-code> 1 </exit-code>
@@ -27,7 +27,7 @@ module ECRECOVER00-SIGINVALID-SPEC
           <wordStack> .WordStack => ?_ </wordStack>
           <localMem> .Memory => ?_ </localMem>
           <pc> 0 => ?_ </pc>
-          <gas> #gas(INITGAS, 0, 0) => ?_ </gas>
+          <gas> #gas(_INITGAS, 0, 0) => ?_ </gas>
           <memoryUsed> 0 => ?_ </memoryUsed>
           <callGas> _ => ?_ </callGas>
           <static> false </static> // NOTE: non-static call
@@ -40,7 +40,7 @@ module ECRECOVER00-SIGINVALID-SPEC
         </substate>
         <gasPrice> _ </gasPrice>
         <origin> _ </origin> // tx.origin
-        <blockhashes> BLOCK_HASHES </blockhashes> // block.blockhash
+        <blockhashes> _BLOCK_HASHES </blockhashes> // block.blockhash
         <block>
           <previousHash> _ </previousHash>
           <ommersHash> _ </ommersHash>
@@ -109,27 +109,25 @@ _
         <messages> _ </messages>
       </network>
     </ethereum>
-    requires
-     #rangeAddress(CONTRACT_ID)
+    requires #rangeAddress(CONTRACT_ID)
      andBool #rangeAddress(CALLEE_ID)
      andBool #rangeUInt(256, NOW)
      andBool #rangeUInt(128, BLOCK_NUM) // Solidity
 
      // Account address normality
-     andBool CONTRACT_ID  >Int 0 andBool (notBool CONTRACT_ID  in #precompiledAccounts(BYZANTIUM))
-     andBool CALLEE_ID  >Int 0 andBool (notBool CALLEE_ID  in #precompiledAccounts(BYZANTIUM))
+     andBool CONTRACT_ID >Int 0 andBool (notBool CONTRACT_ID in #precompiledAccounts(BYZANTIUM))
+     andBool CALLEE_ID   >Int 0 andBool (notBool CALLEE_ID   in #precompiledAccounts(BYZANTIUM))
 
-andBool #rangeUInt(256, CONTRACT_BAL)
-andBool #rangeUInt(256, CALLEE_BAL)andBool #range(0 <= CD < 1024)
-andBool #rangeAddress(MSG_SENDER)andBool #rangeUInt(256, HASH)
-andBool #rangeUInt(8, SIGV)
-andBool #rangeBytes(32, SIGR)
-andBool #rangeBytes(32, SIGS)
-andBool ECREC_DATA ==K #encodeArgs( #bytes32(HASH), #uint8(SIGV), #bytes32(SIGR), #bytes32(SIGS) )andBool #ecrecEmpty( ECREC_DATA )
-    ensures true
-
-
-
+     andBool #rangeUInt(256, CONTRACT_BAL)
+     andBool #rangeUInt(256, CALLEE_BAL)
+     andBool #range(0 <= CD < 1024)
+     andBool #rangeAddress(MSG_SENDER)
+     andBool #rangeUInt(256, HASH)
+     andBool #rangeUInt(8, SIGV)
+     andBool #rangeBytes(32, SIGR)
+     andBool #rangeBytes(32, SIGS)
+     andBool ECREC_DATA ==K #encodeArgs( #bytes32(HASH), #uint8(SIGV), #bytes32(SIGR), #bytes32(SIGS) )
+     andBool #ecrecEmpty( ECREC_DATA )
 
 endmodule
 

--- a/tests/specs/benchmarks/ecrecover00-sigvalid-spec.k
+++ b/tests/specs/benchmarks/ecrecover00-sigvalid-spec.k
@@ -3,7 +3,7 @@ requires "verification.k"
 module ECRECOVER00-SIGVALID-SPEC
   imports VERIFICATION
 
-  // fn-execute-sigvalid 
+  // fn-execute-sigvalid
   rule
     <k> (#execute => #halt) ~> _ </k>
     <exit-code> 1 </exit-code>
@@ -27,7 +27,7 @@ module ECRECOVER00-SIGVALID-SPEC
           <wordStack> .WordStack => ?_ </wordStack>
           <localMem> .Memory => ?_ </localMem>
           <pc> 0 => ?_ </pc>
-          <gas> #gas(INITGAS, 0, 0) => ?_ </gas>
+          <gas> #gas(_INITGAS, 0, 0) => ?_ </gas>
           <memoryUsed> 0 => ?_ </memoryUsed>
           <callGas> _ => ?_ </callGas>
           <static> false </static> // NOTE: non-static call
@@ -40,7 +40,7 @@ module ECRECOVER00-SIGVALID-SPEC
         </substate>
         <gasPrice> _ </gasPrice>
         <origin> _ </origin> // tx.origin
-        <blockhashes> BLOCK_HASHES </blockhashes> // block.blockhash
+        <blockhashes> _BLOCK_HASHES </blockhashes> // block.blockhash
         <block>
           <previousHash> _ </previousHash>
           <ommersHash> _ </ommersHash>
@@ -109,28 +109,26 @@ _
         <messages> _ </messages>
       </network>
     </ethereum>
-    requires
-     #rangeAddress(CONTRACT_ID)
+    requires #rangeAddress(CONTRACT_ID)
      andBool #rangeAddress(CALLEE_ID)
      andBool #rangeUInt(256, NOW)
      andBool #rangeUInt(128, BLOCK_NUM) // Solidity
 
      // Account address normality
-     andBool CONTRACT_ID  >Int 0 andBool (notBool CONTRACT_ID  in #precompiledAccounts(BYZANTIUM))
-     andBool CALLEE_ID  >Int 0 andBool (notBool CALLEE_ID  in #precompiledAccounts(BYZANTIUM))
+     andBool CONTRACT_ID >Int 0 andBool (notBool CONTRACT_ID in #precompiledAccounts(BYZANTIUM))
+     andBool CALLEE_ID   >Int 0 andBool (notBool CALLEE_ID   in #precompiledAccounts(BYZANTIUM))
 
-andBool #rangeUInt(256, CONTRACT_BAL)
-andBool #rangeUInt(256, CALLEE_BAL)andBool #range(0 <= CD < 1024)
-andBool #rangeAddress(MSG_SENDER)andBool #rangeUInt(256, HASH)
-andBool #rangeUInt(8, SIGV)
-andBool #rangeBytes(32, SIGR)
-andBool #rangeBytes(32, SIGS)
-andBool ECREC_DATA ==K #encodeArgs( #bytes32(HASH), #uint8(SIGV), #bytes32(SIGR), #bytes32(SIGS) )andBool RECOVERED ==Int #symEcrec( ECREC_DATA )
-andBool notBool #ecrecEmpty( ECREC_DATA )
-    ensures true
-
-
-
+     andBool #rangeUInt(256, CONTRACT_BAL)
+     andBool #rangeUInt(256, CALLEE_BAL)
+     andBool #range(0 <= CD < 1024)
+     andBool #rangeAddress(MSG_SENDER)
+     andBool #rangeUInt(256, HASH)
+     andBool #rangeUInt(8, SIGV)
+     andBool #rangeBytes(32, SIGR)
+     andBool #rangeBytes(32, SIGS)
+     andBool ECREC_DATA ==K #encodeArgs( #bytes32(HASH), #uint8(SIGV), #bytes32(SIGR), #bytes32(SIGS) )
+     andBool RECOVERED ==Int #symEcrec( ECREC_DATA )
+     andBool notBool #ecrecEmpty( ECREC_DATA )
 
 endmodule
 

--- a/tests/specs/benchmarks/ecrecoverloop00-sig0-invalid-spec.k
+++ b/tests/specs/benchmarks/ecrecoverloop00-sig0-invalid-spec.k
@@ -3,7 +3,7 @@ requires "verification.k"
 module ECRECOVERLOOP00-SIG0-INVALID-SPEC
   imports VERIFICATION
 
-  // fn-execute-sig0-invalid 
+  // fn-execute-sig0-invalid
   rule
     <k> (#execute => #halt) ~> _ </k>
     <exit-code> 1 </exit-code>
@@ -30,7 +30,7 @@ module ECRECOVERLOOP00-SIG0-INVALID-SPEC
           <wordStack> .WordStack => ?_ </wordStack>
           <localMem> .Memory => ?_ </localMem>
           <pc> 0 => ?_ </pc>
-          <gas> #gas(INITGAS, 0, 0) => ?_ </gas>
+          <gas> #gas(_INITGAS, 0, 0) => ?_ </gas>
           <memoryUsed> 0 => ?_ </memoryUsed>
           <callGas> _ => ?_ </callGas>
           <static> false </static> // NOTE: non-static call
@@ -43,7 +43,7 @@ module ECRECOVERLOOP00-SIG0-INVALID-SPEC
         </substate>
         <gasPrice> _ </gasPrice>
         <origin> _ </origin> // tx.origin
-        <blockhashes> BLOCK_HASHES </blockhashes> // block.blockhash
+        <blockhashes> _BLOCK_HASHES </blockhashes> // block.blockhash
         <block>
           <previousHash> _ </previousHash>
           <ommersHash> _ </ommersHash>
@@ -112,31 +112,29 @@ _
         <messages> _ </messages>
       </network>
     </ethereum>
-    requires
-     #rangeAddress(CONTRACT_ID)
+    requires #rangeAddress(CONTRACT_ID)
      andBool #rangeAddress(CALLEE_ID)
      andBool #rangeUInt(256, NOW)
      andBool #rangeUInt(128, BLOCK_NUM) // Solidity
 
      // Account address normality
-     andBool CONTRACT_ID  >Int 0 andBool (notBool CONTRACT_ID  in #precompiledAccounts(BYZANTIUM))
-     andBool CALLEE_ID  >Int 0 andBool (notBool CALLEE_ID  in #precompiledAccounts(BYZANTIUM))
+     andBool CONTRACT_ID >Int 0 andBool (notBool CONTRACT_ID in #precompiledAccounts(BYZANTIUM))
+     andBool CALLEE_ID   >Int 0 andBool (notBool CALLEE_ID   in #precompiledAccounts(BYZANTIUM))
 
-andBool #rangeUInt(256, CONTRACT_BAL)
-andBool #rangeUInt(256, CALLEE_BAL)andBool #range(0 <= CD < 1024)
-andBool #rangeAddress(MSG_SENDER)andBool #rangeUInt(256, HASH)
-andBool #rangeUInt(8, SIGV0)
-andBool #rangeUInt(8, SIGV1)
-andBool #rangeBytes(32, SIGR0)
-andBool #rangeBytes(32, SIGR1)
-andBool #rangeBytes(32, SIGS0)
-andBool #rangeBytes(32, SIGS1)
-andBool ECREC_DATA0 ==K #encodeArgs( #bytes32(HASH), #uint8(SIGV0), #bytes32(SIGR0), #bytes32(SIGS0) )
-andBool ECREC_DATA1 ==K #encodeArgs( #bytes32(HASH), #uint8(SIGV1), #bytes32(SIGR1), #bytes32(SIGS1) )andBool #ecrecEmpty( ECREC_DATA0 )
-    ensures true
-
-
-
+     andBool #rangeUInt(256, CONTRACT_BAL)
+     andBool #rangeUInt(256, CALLEE_BAL)
+     andBool #range(0 <= CD < 1024)
+     andBool #rangeAddress(MSG_SENDER)
+     andBool #rangeUInt(256, HASH)
+     andBool #rangeUInt(8, SIGV0)
+     andBool #rangeUInt(8, SIGV1)
+     andBool #rangeBytes(32, SIGR0)
+     andBool #rangeBytes(32, SIGR1)
+     andBool #rangeBytes(32, SIGS0)
+     andBool #rangeBytes(32, SIGS1)
+     andBool ECREC_DATA0 ==K #encodeArgs( #bytes32(HASH), #uint8(SIGV0), #bytes32(SIGR0), #bytes32(SIGS0) )
+     andBool ECREC_DATA1 ==K #encodeArgs( #bytes32(HASH), #uint8(SIGV1), #bytes32(SIGR1), #bytes32(SIGS1) )
+     andBool #ecrecEmpty( ECREC_DATA0 )
 
 endmodule
 

--- a/tests/specs/benchmarks/ecrecoverloop00-sig1-invalid-spec.k
+++ b/tests/specs/benchmarks/ecrecoverloop00-sig1-invalid-spec.k
@@ -3,7 +3,7 @@ requires "verification.k"
 module ECRECOVERLOOP00-SIG1-INVALID-SPEC
   imports VERIFICATION
 
-  // fn-execute-sig1-invalid 
+  // fn-execute-sig1-invalid
   rule
     <k> (#execute => #halt) ~> _ </k>
     <exit-code> 1 </exit-code>
@@ -30,7 +30,7 @@ module ECRECOVERLOOP00-SIG1-INVALID-SPEC
           <wordStack> .WordStack => ?_ </wordStack>
           <localMem> .Memory => ?_ </localMem>
           <pc> 0 => ?_ </pc>
-          <gas> #gas(INITGAS, 0, 0) => ?_ </gas>
+          <gas> #gas(_INITGAS, 0, 0) => ?_ </gas>
           <memoryUsed> 0 => ?_ </memoryUsed>
           <callGas> _ => ?_ </callGas>
           <static> false </static> // NOTE: non-static call
@@ -43,7 +43,7 @@ module ECRECOVERLOOP00-SIG1-INVALID-SPEC
         </substate>
         <gasPrice> _ </gasPrice>
         <origin> _ </origin> // tx.origin
-        <blockhashes> BLOCK_HASHES </blockhashes> // block.blockhash
+        <blockhashes> _BLOCK_HASHES </blockhashes> // block.blockhash
         <block>
           <previousHash> _ </previousHash>
           <ommersHash> _ </ommersHash>
@@ -112,31 +112,29 @@ _
         <messages> _ </messages>
       </network>
     </ethereum>
-    requires
-     #rangeAddress(CONTRACT_ID)
+    requires #rangeAddress(CONTRACT_ID)
      andBool #rangeAddress(CALLEE_ID)
      andBool #rangeUInt(256, NOW)
      andBool #rangeUInt(128, BLOCK_NUM) // Solidity
 
      // Account address normality
-     andBool CONTRACT_ID  >Int 0 andBool (notBool CONTRACT_ID  in #precompiledAccounts(BYZANTIUM))
-     andBool CALLEE_ID  >Int 0 andBool (notBool CALLEE_ID  in #precompiledAccounts(BYZANTIUM))
+     andBool CONTRACT_ID >Int 0 andBool (notBool CONTRACT_ID in #precompiledAccounts(BYZANTIUM))
+     andBool CALLEE_ID   >Int 0 andBool (notBool CALLEE_ID   in #precompiledAccounts(BYZANTIUM))
 
-andBool #rangeUInt(256, CONTRACT_BAL)
-andBool #rangeUInt(256, CALLEE_BAL)andBool #range(0 <= CD < 1024)
-andBool #rangeAddress(MSG_SENDER)andBool #rangeUInt(256, HASH)
-andBool #rangeUInt(8, SIGV0)
-andBool #rangeUInt(8, SIGV1)
-andBool #rangeBytes(32, SIGR0)
-andBool #rangeBytes(32, SIGR1)
-andBool #rangeBytes(32, SIGS0)
-andBool #rangeBytes(32, SIGS1)
-andBool ECREC_DATA0 ==K #encodeArgs( #bytes32(HASH), #uint8(SIGV0), #bytes32(SIGR0), #bytes32(SIGS0) )
-andBool ECREC_DATA1 ==K #encodeArgs( #bytes32(HASH), #uint8(SIGV1), #bytes32(SIGR1), #bytes32(SIGS1) )andBool #ecrecEmpty( ECREC_DATA1 )
-    ensures true
-
-
-
+     andBool #rangeUInt(256, CONTRACT_BAL)
+     andBool #rangeUInt(256, CALLEE_BAL)
+     andBool #range(0 <= CD < 1024)
+     andBool #rangeAddress(MSG_SENDER)
+     andBool #rangeUInt(256, HASH)
+     andBool #rangeUInt(8, SIGV0)
+     andBool #rangeUInt(8, SIGV1)
+     andBool #rangeBytes(32, SIGR0)
+     andBool #rangeBytes(32, SIGR1)
+     andBool #rangeBytes(32, SIGS0)
+     andBool #rangeBytes(32, SIGS1)
+     andBool ECREC_DATA0 ==K #encodeArgs( #bytes32(HASH), #uint8(SIGV0), #bytes32(SIGR0), #bytes32(SIGS0) )
+     andBool ECREC_DATA1 ==K #encodeArgs( #bytes32(HASH), #uint8(SIGV1), #bytes32(SIGR1), #bytes32(SIGS1) )
+     andBool #ecrecEmpty( ECREC_DATA1 )
 
 endmodule
 

--- a/tests/specs/benchmarks/ecrecoverloop00-sigs-valid-spec.k
+++ b/tests/specs/benchmarks/ecrecoverloop00-sigs-valid-spec.k
@@ -3,7 +3,7 @@ requires "verification.k"
 module ECRECOVERLOOP00-SIGS-VALID-SPEC
   imports VERIFICATION
 
-  // fn-execute-sigs-valid 
+  // fn-execute-sigs-valid
   rule
     <k> (#execute => #halt) ~> _ </k>
     <exit-code> 1 </exit-code>
@@ -30,7 +30,7 @@ module ECRECOVERLOOP00-SIGS-VALID-SPEC
           <wordStack> .WordStack => ?_ </wordStack>
           <localMem> .Memory => ?_ </localMem>
           <pc> 0 => ?_ </pc>
-          <gas> #gas(INITGAS, 0, 0) => ?_ </gas>
+          <gas> #gas(_INITGAS, 0, 0) => ?_ </gas>
           <memoryUsed> 0 => ?_ </memoryUsed>
           <callGas> _ => ?_ </callGas>
           <static> false </static> // NOTE: non-static call
@@ -43,7 +43,7 @@ module ECRECOVERLOOP00-SIGS-VALID-SPEC
         </substate>
         <gasPrice> _ </gasPrice>
         <origin> _ </origin> // tx.origin
-        <blockhashes> BLOCK_HASHES </blockhashes> // block.blockhash
+        <blockhashes> _BLOCK_HASHES </blockhashes> // block.blockhash
         <block>
           <previousHash> _ </previousHash>
           <ommersHash> _ </ommersHash>
@@ -112,34 +112,32 @@ _
         <messages> _ </messages>
       </network>
     </ethereum>
-    requires
-     #rangeAddress(CONTRACT_ID)
+    requires #rangeAddress(CONTRACT_ID)
      andBool #rangeAddress(CALLEE_ID)
      andBool #rangeUInt(256, NOW)
      andBool #rangeUInt(128, BLOCK_NUM) // Solidity
 
      // Account address normality
-     andBool CONTRACT_ID  >Int 0 andBool (notBool CONTRACT_ID  in #precompiledAccounts(BYZANTIUM))
-     andBool CALLEE_ID  >Int 0 andBool (notBool CALLEE_ID  in #precompiledAccounts(BYZANTIUM))
+     andBool CONTRACT_ID >Int 0 andBool (notBool CONTRACT_ID in #precompiledAccounts(BYZANTIUM))
+     andBool CALLEE_ID   >Int 0 andBool (notBool CALLEE_ID   in #precompiledAccounts(BYZANTIUM))
 
-andBool #rangeUInt(256, CONTRACT_BAL)
-andBool #rangeUInt(256, CALLEE_BAL)andBool #range(0 <= CD < 1024)
-andBool #rangeAddress(MSG_SENDER)andBool #rangeUInt(256, HASH)
-andBool #rangeUInt(8, SIGV0)
-andBool #rangeUInt(8, SIGV1)
-andBool #rangeBytes(32, SIGR0)
-andBool #rangeBytes(32, SIGR1)
-andBool #rangeBytes(32, SIGS0)
-andBool #rangeBytes(32, SIGS1)
-andBool ECREC_DATA0 ==K #encodeArgs( #bytes32(HASH), #uint8(SIGV0), #bytes32(SIGR0), #bytes32(SIGS0) )
-andBool ECREC_DATA1 ==K #encodeArgs( #bytes32(HASH), #uint8(SIGV1), #bytes32(SIGR1), #bytes32(SIGS1) )andBool RECOVERED0 ==Int #symEcrec( ECREC_DATA0 )
-andBool RECOVERED1 ==Int #symEcrec( ECREC_DATA1 )
-andBool notBool #ecrecEmpty( ECREC_DATA0 )
-andBool notBool #ecrecEmpty( ECREC_DATA1 )
-    ensures true
-
-
-
+     andBool #rangeUInt(256, CONTRACT_BAL)
+     andBool #rangeUInt(256, CALLEE_BAL)
+     andBool #range(0 <= CD < 1024)
+     andBool #rangeAddress(MSG_SENDER)
+     andBool #rangeUInt(256, HASH)
+     andBool #rangeUInt(8, SIGV0)
+     andBool #rangeUInt(8, SIGV1)
+     andBool #rangeBytes(32, SIGR0)
+     andBool #rangeBytes(32, SIGR1)
+     andBool #rangeBytes(32, SIGS0)
+     andBool #rangeBytes(32, SIGS1)
+     andBool ECREC_DATA0 ==K #encodeArgs( #bytes32(HASH), #uint8(SIGV0), #bytes32(SIGR0), #bytes32(SIGS0) )
+     andBool ECREC_DATA1 ==K #encodeArgs( #bytes32(HASH), #uint8(SIGV1), #bytes32(SIGR1), #bytes32(SIGS1) )
+     andBool RECOVERED0 ==Int #symEcrec( ECREC_DATA0 )
+     andBool RECOVERED1 ==Int #symEcrec( ECREC_DATA1 )
+     andBool notBool #ecrecEmpty( ECREC_DATA0 )
+     andBool notBool #ecrecEmpty( ECREC_DATA1 )
 
 endmodule
 

--- a/tests/specs/benchmarks/ecrecoverloop02-sig0-invalid-spec.k
+++ b/tests/specs/benchmarks/ecrecoverloop02-sig0-invalid-spec.k
@@ -3,7 +3,7 @@ requires "verification.k"
 module ECRECOVERLOOP02-SIG0-INVALID-SPEC
   imports VERIFICATION
 
-  // fn-execute-sig0-invalid 
+  // fn-execute-sig0-invalid
   rule
     <k> (#execute => #halt) ~> _ </k>
     <exit-code> 1 </exit-code>
@@ -31,7 +31,7 @@ module ECRECOVERLOOP02-SIG0-INVALID-SPEC
           <wordStack> .WordStack => ?_ </wordStack>
           <localMem> .Memory => ?_ </localMem>
           <pc> 0 => ?_ </pc>
-          <gas> #gas(INITGAS, 0, 0) => ?_ </gas>
+          <gas> #gas(_INITGAS, 0, 0) => ?_ </gas>
           <memoryUsed> 0 => ?_ </memoryUsed>
           <callGas> _ => ?_ </callGas>
           <static> false </static> // NOTE: non-static call
@@ -44,7 +44,7 @@ module ECRECOVERLOOP02-SIG0-INVALID-SPEC
         </substate>
         <gasPrice> _ </gasPrice>
         <origin> _ </origin> // tx.origin
-        <blockhashes> BLOCK_HASHES </blockhashes> // block.blockhash
+        <blockhashes> _BLOCK_HASHES </blockhashes> // block.blockhash
         <block>
           <previousHash> _ </previousHash>
           <ommersHash> _ </ommersHash>
@@ -113,32 +113,30 @@ _
         <messages> _ </messages>
       </network>
     </ethereum>
-    requires
-     #rangeAddress(CONTRACT_ID)
+    requires #rangeAddress(CONTRACT_ID)
      andBool #rangeAddress(CALLEE_ID)
      andBool #rangeUInt(256, NOW)
      andBool #rangeUInt(128, BLOCK_NUM) // Solidity
 
      // Account address normality
-     andBool CONTRACT_ID  >Int 0 andBool (notBool CONTRACT_ID  in #precompiledAccounts(BYZANTIUM))
-     andBool CALLEE_ID  >Int 0 andBool (notBool CALLEE_ID  in #precompiledAccounts(BYZANTIUM))
+     andBool CONTRACT_ID >Int 0 andBool (notBool CONTRACT_ID in #precompiledAccounts(BYZANTIUM))
+     andBool CALLEE_ID   >Int 0 andBool (notBool CALLEE_ID   in #precompiledAccounts(BYZANTIUM))
 
-andBool #rangeUInt(256, CONTRACT_BAL)
-andBool #rangeUInt(256, CALLEE_BAL)andBool #range(0 <= CD < 1024)
-andBool #rangeAddress(MSG_SENDER)andBool #rangeUInt(256, HASH)
-andBool #rangeUInt(8, SIGV0)
-andBool #rangeUInt(8, SIGV1)
-andBool #rangeBytes(32, SIGR0)
-andBool #rangeBytes(32, SIGR1)
-andBool #rangeBytes(32, SIGS0)
-andBool #rangeBytes(32, SIGS1)
-andBool #range(0 <= DATA_LEN < 2 ^Int 16)
-andBool ECREC_DATA0 ==K #encodeArgs( #bytes32(HASH), #uint8(SIGV0), #bytes32(SIGR0), #bytes32(SIGS0) )
-andBool ECREC_DATA1 ==K #encodeArgs( #bytes32(HASH), #uint8(SIGV1), #bytes32(SIGR1), #bytes32(SIGS1) )andBool #ecrecEmpty( ECREC_DATA0 )
-    ensures true
-
-
-
+     andBool #rangeUInt(256, CONTRACT_BAL)
+     andBool #rangeUInt(256, CALLEE_BAL)
+     andBool #range(0 <= CD < 1024)
+     andBool #rangeAddress(MSG_SENDER)
+     andBool #rangeUInt(256, HASH)
+     andBool #rangeUInt(8, SIGV0)
+     andBool #rangeUInt(8, SIGV1)
+     andBool #rangeBytes(32, SIGR0)
+     andBool #rangeBytes(32, SIGR1)
+     andBool #rangeBytes(32, SIGS0)
+     andBool #rangeBytes(32, SIGS1)
+     andBool #range(0 <= DATA_LEN < 2 ^Int 16)
+     andBool ECREC_DATA0 ==K #encodeArgs( #bytes32(HASH), #uint8(SIGV0), #bytes32(SIGR0), #bytes32(SIGS0) )
+     andBool ECREC_DATA1 ==K #encodeArgs( #bytes32(HASH), #uint8(SIGV1), #bytes32(SIGR1), #bytes32(SIGS1) )
+     andBool #ecrecEmpty( ECREC_DATA0 )
 
 endmodule
 

--- a/tests/specs/benchmarks/ecrecoverloop02-sig1-invalid-spec.k
+++ b/tests/specs/benchmarks/ecrecoverloop02-sig1-invalid-spec.k
@@ -3,7 +3,7 @@ requires "verification.k"
 module ECRECOVERLOOP02-SIG1-INVALID-SPEC
   imports VERIFICATION
 
-  // fn-execute-sig1-invalid 
+  // fn-execute-sig1-invalid
   rule
     <k> (#execute => #halt) ~> _ </k>
     <exit-code> 1 </exit-code>
@@ -31,7 +31,7 @@ module ECRECOVERLOOP02-SIG1-INVALID-SPEC
           <wordStack> .WordStack => ?_ </wordStack>
           <localMem> .Memory => ?_ </localMem>
           <pc> 0 => ?_ </pc>
-          <gas> #gas(INITGAS, 0, 0) => ?_ </gas>
+          <gas> #gas(_INITGAS, 0, 0) => ?_ </gas>
           <memoryUsed> 0 => ?_ </memoryUsed>
           <callGas> _ => ?_ </callGas>
           <static> false </static> // NOTE: non-static call
@@ -44,7 +44,7 @@ module ECRECOVERLOOP02-SIG1-INVALID-SPEC
         </substate>
         <gasPrice> _ </gasPrice>
         <origin> _ </origin> // tx.origin
-        <blockhashes> BLOCK_HASHES </blockhashes> // block.blockhash
+        <blockhashes> _BLOCK_HASHES </blockhashes> // block.blockhash
         <block>
           <previousHash> _ </previousHash>
           <ommersHash> _ </ommersHash>
@@ -113,33 +113,31 @@ _
         <messages> _ </messages>
       </network>
     </ethereum>
-    requires
-     #rangeAddress(CONTRACT_ID)
+    requires #rangeAddress(CONTRACT_ID)
      andBool #rangeAddress(CALLEE_ID)
      andBool #rangeUInt(256, NOW)
      andBool #rangeUInt(128, BLOCK_NUM) // Solidity
 
      // Account address normality
-     andBool CONTRACT_ID  >Int 0 andBool (notBool CONTRACT_ID  in #precompiledAccounts(BYZANTIUM))
-     andBool CALLEE_ID  >Int 0 andBool (notBool CALLEE_ID  in #precompiledAccounts(BYZANTIUM))
+     andBool CONTRACT_ID >Int 0 andBool (notBool CONTRACT_ID in #precompiledAccounts(BYZANTIUM))
+     andBool CALLEE_ID   >Int 0 andBool (notBool CALLEE_ID   in #precompiledAccounts(BYZANTIUM))
 
-andBool #rangeUInt(256, CONTRACT_BAL)
-andBool #rangeUInt(256, CALLEE_BAL)andBool #range(0 <= CD < 1024)
-andBool #rangeAddress(MSG_SENDER)andBool #rangeUInt(256, HASH)
-andBool #rangeUInt(8, SIGV0)
-andBool #rangeUInt(8, SIGV1)
-andBool #rangeBytes(32, SIGR0)
-andBool #rangeBytes(32, SIGR1)
-andBool #rangeBytes(32, SIGS0)
-andBool #rangeBytes(32, SIGS1)
-andBool #range(0 <= DATA_LEN < 2 ^Int 16)
-andBool ECREC_DATA0 ==K #encodeArgs( #bytes32(HASH), #uint8(SIGV0), #bytes32(SIGR0), #bytes32(SIGS0) )
-andBool ECREC_DATA1 ==K #encodeArgs( #bytes32(HASH), #uint8(SIGV1), #bytes32(SIGR1), #bytes32(SIGS1) )andBool notBool #ecrecEmpty( ECREC_DATA0 )
-andBool #ecrecEmpty( ECREC_DATA1 )
-    ensures true
-
-
-
+     andBool #rangeUInt(256, CONTRACT_BAL)
+     andBool #rangeUInt(256, CALLEE_BAL)
+     andBool #range(0 <= CD < 1024)
+     andBool #rangeAddress(MSG_SENDER)
+     andBool #rangeUInt(256, HASH)
+     andBool #rangeUInt(8, SIGV0)
+     andBool #rangeUInt(8, SIGV1)
+     andBool #rangeBytes(32, SIGR0)
+     andBool #rangeBytes(32, SIGR1)
+     andBool #rangeBytes(32, SIGS0)
+     andBool #rangeBytes(32, SIGS1)
+     andBool #range(0 <= DATA_LEN < pow16)
+     andBool ECREC_DATA0 ==K #encodeArgs( #bytes32(HASH), #uint8(SIGV0), #bytes32(SIGR0), #bytes32(SIGS0) )
+     andBool ECREC_DATA1 ==K #encodeArgs( #bytes32(HASH), #uint8(SIGV1), #bytes32(SIGR1), #bytes32(SIGS1) )
+     andBool notBool #ecrecEmpty( ECREC_DATA0 )
+     andBool #ecrecEmpty( ECREC_DATA1 )
 
 endmodule
 

--- a/tests/specs/benchmarks/ecrecoverloop02-sigs-valid-spec.k
+++ b/tests/specs/benchmarks/ecrecoverloop02-sigs-valid-spec.k
@@ -3,7 +3,7 @@ requires "verification.k"
 module ECRECOVERLOOP02-SIGS-VALID-SPEC
   imports VERIFICATION
 
-  // fn-execute-sigs-valid 
+  // fn-execute-sigs-valid
   rule
     <k> (#execute => #halt) ~> _ </k>
     <exit-code> 1 </exit-code>
@@ -31,7 +31,7 @@ module ECRECOVERLOOP02-SIGS-VALID-SPEC
           <wordStack> .WordStack => ?_ </wordStack>
           <localMem> .Memory => ?_ </localMem>
           <pc> 0 => ?_ </pc>
-          <gas> #gas(INITGAS, 0, 0) => ?_ </gas>
+          <gas> #gas(_INITGAS, 0, 0) => ?_ </gas>
           <memoryUsed> 0 => ?_ </memoryUsed>
           <callGas> _ => ?_ </callGas>
           <static> false </static> // NOTE: non-static call
@@ -44,7 +44,7 @@ module ECRECOVERLOOP02-SIGS-VALID-SPEC
         </substate>
         <gasPrice> _ </gasPrice>
         <origin> _ </origin> // tx.origin
-        <blockhashes> BLOCK_HASHES </blockhashes> // block.blockhash
+        <blockhashes> _BLOCK_HASHES </blockhashes> // block.blockhash
         <block>
           <previousHash> _ </previousHash>
           <ommersHash> _ </ommersHash>
@@ -113,35 +113,33 @@ _
         <messages> _ </messages>
       </network>
     </ethereum>
-    requires
-     #rangeAddress(CONTRACT_ID)
+    requires #rangeAddress(CONTRACT_ID)
      andBool #rangeAddress(CALLEE_ID)
      andBool #rangeUInt(256, NOW)
      andBool #rangeUInt(128, BLOCK_NUM) // Solidity
 
      // Account address normality
-     andBool CONTRACT_ID  >Int 0 andBool (notBool CONTRACT_ID  in #precompiledAccounts(BYZANTIUM))
-     andBool CALLEE_ID  >Int 0 andBool (notBool CALLEE_ID  in #precompiledAccounts(BYZANTIUM))
+     andBool CONTRACT_ID >Int 0 andBool (notBool CONTRACT_ID in #precompiledAccounts(BYZANTIUM))
+     andBool CALLEE_ID   >Int 0 andBool (notBool CALLEE_ID   in #precompiledAccounts(BYZANTIUM))
 
-andBool #rangeUInt(256, CONTRACT_BAL)
-andBool #rangeUInt(256, CALLEE_BAL)andBool #range(0 <= CD < 1024)
-andBool #rangeAddress(MSG_SENDER)andBool #rangeUInt(256, HASH)
-andBool #rangeUInt(8, SIGV0)
-andBool #rangeUInt(8, SIGV1)
-andBool #rangeBytes(32, SIGR0)
-andBool #rangeBytes(32, SIGR1)
-andBool #rangeBytes(32, SIGS0)
-andBool #rangeBytes(32, SIGS1)
-andBool #range(0 <= DATA_LEN < 2 ^Int 16)
-andBool ECREC_DATA0 ==K #encodeArgs( #bytes32(HASH), #uint8(SIGV0), #bytes32(SIGR0), #bytes32(SIGS0) )
-andBool ECREC_DATA1 ==K #encodeArgs( #bytes32(HASH), #uint8(SIGV1), #bytes32(SIGR1), #bytes32(SIGS1) )andBool RECOVERED0 ==Int #symEcrec( ECREC_DATA0 )
-andBool RECOVERED1 ==Int #symEcrec( ECREC_DATA1 )
-andBool notBool #ecrecEmpty( ECREC_DATA0 )
-andBool notBool #ecrecEmpty( ECREC_DATA1 )
-    ensures true
-
-
-
+     andBool #rangeUInt(256, CONTRACT_BAL)
+     andBool #rangeUInt(256, CALLEE_BAL)
+     andBool #range(0 <= CD < 1024)
+     andBool #rangeAddress(MSG_SENDER)
+     andBool #rangeUInt(256, HASH)
+     andBool #rangeUInt(8, SIGV0)
+     andBool #rangeUInt(8, SIGV1)
+     andBool #rangeBytes(32, SIGR0)
+     andBool #rangeBytes(32, SIGR1)
+     andBool #rangeBytes(32, SIGS0)
+     andBool #rangeBytes(32, SIGS1)
+     andBool #range(0 <= DATA_LEN < pow16)
+     andBool ECREC_DATA0 ==K #encodeArgs( #bytes32(HASH), #uint8(SIGV0), #bytes32(SIGR0), #bytes32(SIGS0) )
+     andBool ECREC_DATA1 ==K #encodeArgs( #bytes32(HASH), #uint8(SIGV1), #bytes32(SIGR1), #bytes32(SIGS1) )
+     andBool RECOVERED0 ==Int #symEcrec( ECREC_DATA0 )
+     andBool RECOVERED1 ==Int #symEcrec( ECREC_DATA1 )
+     andBool notBool #ecrecEmpty( ECREC_DATA0 )
+     andBool notBool #ecrecEmpty( ECREC_DATA1 )
 
 endmodule
 

--- a/tests/specs/benchmarks/encode_keccak00-spec.k
+++ b/tests/specs/benchmarks/encode_keccak00-spec.k
@@ -3,7 +3,7 @@ requires "verification.k"
 module ENCODE_KECCAK00-SPEC
   imports VERIFICATION
 
-  // fn-execute 
+  // fn-execute
   rule
     <k> (#execute => #halt) ~> _ </k>
     <exit-code> 1 </exit-code>
@@ -27,7 +27,7 @@ module ENCODE_KECCAK00-SPEC
           <wordStack> .WordStack => ?_ </wordStack>
           <localMem> .Memory => ?_ </localMem>
           <pc> 0 => ?_ </pc>
-          <gas> #gas(INITGAS, 0, 0) => ?_ </gas>
+          <gas> #gas(_INITGAS, 0, 0) => ?_ </gas>
           <memoryUsed> 0 => ?_ </memoryUsed>
           <callGas> _ => ?_ </callGas>
           <static> false </static> // NOTE: non-static call
@@ -40,7 +40,7 @@ module ENCODE_KECCAK00-SPEC
         </substate>
         <gasPrice> _ </gasPrice>
         <origin> _ </origin> // tx.origin
-        <blockhashes> BLOCK_HASHES </blockhashes> // block.blockhash
+        <blockhashes> _BLOCK_HASHES </blockhashes> // block.blockhash
         <block>
           <previousHash> _ </previousHash>
           <ommersHash> _ </ommersHash>
@@ -109,24 +109,21 @@ _
         <messages> _ </messages>
       </network>
     </ethereum>
-    requires
-     #rangeAddress(CONTRACT_ID)
+    requires #rangeAddress(CONTRACT_ID)
      andBool #rangeAddress(CALLEE_ID)
      andBool #rangeUInt(256, NOW)
      andBool #rangeUInt(128, BLOCK_NUM) // Solidity
 
      // Account address normality
-     andBool CONTRACT_ID  >Int 0 andBool (notBool CONTRACT_ID  in #precompiledAccounts(BYZANTIUM))
-     andBool CALLEE_ID  >Int 0 andBool (notBool CALLEE_ID  in #precompiledAccounts(BYZANTIUM))
+     andBool CONTRACT_ID >Int 0 andBool (notBool CONTRACT_ID in #precompiledAccounts(BYZANTIUM))
+     andBool CALLEE_ID   >Int 0 andBool (notBool CALLEE_ID   in #precompiledAccounts(BYZANTIUM))
 
-andBool #rangeUInt(256, CONTRACT_BAL)
-andBool #rangeUInt(256, CALLEE_BAL)andBool #range(0 <= CD < 1024)
-andBool #rangeAddress(MSG_SENDER)andBool #rangeUInt(256, A0)
-andBool #rangeUInt(256, A1)
-    ensures true
-
-
-
+     andBool #rangeUInt(256, CONTRACT_BAL)
+     andBool #rangeUInt(256, CALLEE_BAL)
+     andBool #range(0 <= CD < 1024)
+     andBool #rangeAddress(MSG_SENDER)
+     andBool #rangeUInt(256, A0)
+     andBool #rangeUInt(256, A1)
 
 endmodule
 

--- a/tests/specs/benchmarks/encodepacked_keccak01-spec.k
+++ b/tests/specs/benchmarks/encodepacked_keccak01-spec.k
@@ -3,7 +3,7 @@ requires "verification.k"
 module ENCODEPACKED_KECCAK01-SPEC
   imports VERIFICATION
 
-  // fn-execute 
+  // fn-execute
   rule
     <k> (#execute => #halt) ~> _ </k>
     <exit-code> 1 </exit-code>
@@ -27,7 +27,7 @@ module ENCODEPACKED_KECCAK01-SPEC
           <wordStack> .WordStack => ?_ </wordStack>
           <localMem> .Memory => ?_ </localMem>
           <pc> 0 => ?_ </pc>
-          <gas> #gas(INITGAS, 0, 0) => ?_ </gas>
+          <gas> #gas(_INITGAS, 0, 0) => ?_ </gas>
           <memoryUsed> 0 => ?_ </memoryUsed>
           <callGas> _ => ?_ </callGas>
           <static> false </static> // NOTE: non-static call
@@ -40,7 +40,7 @@ module ENCODEPACKED_KECCAK01-SPEC
         </substate>
         <gasPrice> _ </gasPrice>
         <origin> _ </origin> // tx.origin
-        <blockhashes> BLOCK_HASHES </blockhashes> // block.blockhash
+        <blockhashes> _BLOCK_HASHES </blockhashes> // block.blockhash
         <block>
           <previousHash> _ </previousHash>
           <ommersHash> _ </ommersHash>
@@ -109,23 +109,20 @@ _
         <messages> _ </messages>
       </network>
     </ethereum>
-    requires
-     #rangeAddress(CONTRACT_ID)
+    requires #rangeAddress(CONTRACT_ID)
      andBool #rangeAddress(CALLEE_ID)
      andBool #rangeUInt(256, NOW)
      andBool #rangeUInt(128, BLOCK_NUM) // Solidity
 
      // Account address normality
-     andBool CONTRACT_ID  >Int 0 andBool (notBool CONTRACT_ID  in #precompiledAccounts(BYZANTIUM))
-     andBool CALLEE_ID  >Int 0 andBool (notBool CALLEE_ID  in #precompiledAccounts(BYZANTIUM))
+     andBool CONTRACT_ID >Int 0 andBool (notBool CONTRACT_ID in #precompiledAccounts(BYZANTIUM))
+     andBool CALLEE_ID   >Int 0 andBool (notBool CALLEE_ID   in #precompiledAccounts(BYZANTIUM))
 
-andBool #rangeUInt(256, CONTRACT_BAL)
-andBool #rangeUInt(256, CALLEE_BAL)andBool #range(0 <= CD < 1024)
-andBool #rangeAddress(MSG_SENDER)andBool #rangeUInt(256, A0)
-    ensures true
-
-
-
+     andBool #rangeUInt(256, CONTRACT_BAL)
+     andBool #rangeUInt(256, CALLEE_BAL)
+     andBool #range(0 <= CD < 1024)
+     andBool #rangeAddress(MSG_SENDER)
+     andBool #rangeUInt(256, A0)
 
 endmodule
 

--- a/tests/specs/benchmarks/keccak00-spec.k
+++ b/tests/specs/benchmarks/keccak00-spec.k
@@ -3,7 +3,7 @@ requires "verification.k"
 module KECCAK00-SPEC
   imports VERIFICATION
 
-  // fn-execute 
+  // fn-execute
   rule
     <k> (#execute => #halt) ~> _ </k>
     <exit-code> 1 </exit-code>
@@ -27,7 +27,7 @@ module KECCAK00-SPEC
           <wordStack> .WordStack => ?_ </wordStack>
           <localMem> .Memory => ?_ </localMem>
           <pc> 0 => ?_ </pc>
-          <gas> #gas(INITGAS, 0, 0) => ?_ </gas>
+          <gas> #gas(_INITGAS, 0, 0) => ?_ </gas>
           <memoryUsed> 0 => ?_ </memoryUsed>
           <callGas> _ => ?_ </callGas>
           <static> false </static> // NOTE: non-static call
@@ -40,7 +40,7 @@ module KECCAK00-SPEC
         </substate>
         <gasPrice> _ </gasPrice>
         <origin> _ </origin> // tx.origin
-        <blockhashes> BLOCK_HASHES </blockhashes> // block.blockhash
+        <blockhashes> _BLOCK_HASHES </blockhashes> // block.blockhash
         <block>
           <previousHash> _ </previousHash>
           <ommersHash> _ </ommersHash>
@@ -109,23 +109,20 @@ _
         <messages> _ </messages>
       </network>
     </ethereum>
-    requires
-     #rangeAddress(CONTRACT_ID)
+    requires #rangeAddress(CONTRACT_ID)
      andBool #rangeAddress(CALLEE_ID)
      andBool #rangeUInt(256, NOW)
      andBool #rangeUInt(128, BLOCK_NUM) // Solidity
 
      // Account address normality
-     andBool CONTRACT_ID  >Int 0 andBool (notBool CONTRACT_ID  in #precompiledAccounts(BYZANTIUM))
-     andBool CALLEE_ID  >Int 0 andBool (notBool CALLEE_ID  in #precompiledAccounts(BYZANTIUM))
+     andBool CONTRACT_ID >Int 0 andBool (notBool CONTRACT_ID in #precompiledAccounts(BYZANTIUM))
+     andBool CALLEE_ID   >Int 0 andBool (notBool CALLEE_ID   in #precompiledAccounts(BYZANTIUM))
 
-andBool #rangeUInt(256, CONTRACT_BAL)
-andBool #rangeUInt(256, CALLEE_BAL)andBool #range(0 <= CD < 1024)
-andBool #rangeAddress(MSG_SENDER)andBool #range( 0 <= DATA_LEN < 2 ^Int 16)
-    ensures true
-
-
-
+     andBool #rangeUInt(256, CONTRACT_BAL)
+     andBool #rangeUInt(256, CALLEE_BAL)
+     andBool #range(0 <= CD < 1024)
+     andBool #rangeAddress(MSG_SENDER)
+     andBool #range(0 <= DATA_LEN < pow16)
 
 endmodule
 

--- a/tests/specs/benchmarks/overflow00-nooverflow-spec.k
+++ b/tests/specs/benchmarks/overflow00-nooverflow-spec.k
@@ -3,7 +3,7 @@ requires "verification.k"
 module OVERFLOW00-NOOVERFLOW-SPEC
   imports VERIFICATION
 
-  // fn-execute-nooverflow 
+  // fn-execute-nooverflow
   rule
     <k> (#execute => #halt) ~> _ </k>
     <exit-code> 1 </exit-code>
@@ -109,22 +109,20 @@ _
         <messages> _ </messages>
       </network>
     </ethereum>
-    requires
-     #rangeAddress(CONTRACT_ID)
+    requires #rangeAddress(CONTRACT_ID)
      andBool #rangeAddress(CALLEE_ID)
      andBool #rangeUInt(256, NOW)
      andBool #rangeUInt(128, BLOCK_NUM) // Solidity
 
      // Account address normality
-     andBool CONTRACT_ID  >Int 0 andBool (notBool CONTRACT_ID  in #precompiledAccounts(BYZANTIUM))
-     andBool CALLEE_ID  >Int 0 andBool (notBool CALLEE_ID  in #precompiledAccounts(BYZANTIUM))
+     andBool CONTRACT_ID >Int 0 andBool (notBool CONTRACT_ID in #precompiledAccounts(BYZANTIUM))
+     andBool CALLEE_ID   >Int 0 andBool (notBool CALLEE_ID   in #precompiledAccounts(BYZANTIUM))
 
-andBool #rangeUInt(256, CONTRACT_BAL)
-andBool #rangeUInt(256, CALLEE_BAL) andBool #range(0 <= CD < 1024)
-andBool #rangeAddress(MSG_SENDER) andBool #range(0 <= A0 < 2 ^Int 256 -Int 1)
-    ensures true
-
-
+     andBool #rangeUInt(256, CONTRACT_BAL)
+     andBool #rangeUInt(256, CALLEE_BAL)
+     andBool #range(0 <= CD < 1024)
+     andBool #rangeAddress(MSG_SENDER)
+     andBool #range(0 <= A0 < pow256 -Int 1)
 
 endmodule
 

--- a/tests/specs/benchmarks/overflow00-overflow-spec.k
+++ b/tests/specs/benchmarks/overflow00-overflow-spec.k
@@ -3,7 +3,7 @@ requires "verification.k"
 module OVERFLOW00-OVERFLOW-SPEC
   imports VERIFICATION
 
-  // fn-execute-overflow 
+  // fn-execute-overflow
   rule
     <k> (#execute => #halt) ~> _ </k>
     <exit-code> 1 </exit-code>
@@ -109,23 +109,20 @@ _
         <messages> _ </messages>
       </network>
     </ethereum>
-    requires
-     #rangeAddress(CONTRACT_ID)
+    requires #rangeAddress(CONTRACT_ID)
      andBool #rangeAddress(CALLEE_ID)
      andBool #rangeUInt(256, NOW)
      andBool #rangeUInt(128, BLOCK_NUM) // Solidity
 
      // Account address normality
-     andBool CONTRACT_ID  >Int 0 andBool (notBool CONTRACT_ID  in #precompiledAccounts(BYZANTIUM))
-     andBool CALLEE_ID  >Int 0 andBool (notBool CALLEE_ID  in #precompiledAccounts(BYZANTIUM))
+     andBool CONTRACT_ID >Int 0 andBool (notBool CONTRACT_ID in #precompiledAccounts(BYZANTIUM))
+     andBool CALLEE_ID   >Int 0 andBool (notBool CALLEE_ID   in #precompiledAccounts(BYZANTIUM))
 
-andBool #rangeUInt(256, CONTRACT_BAL)
-andBool #rangeUInt(256, CALLEE_BAL) andBool #range(0 <= CD < 1024)
-andBool #rangeAddress(MSG_SENDER) andBool A0 ==Int 2 ^Int 256 -Int 1
-    ensures true
-
-
-
+     andBool #rangeUInt(256, CONTRACT_BAL)
+     andBool #rangeUInt(256, CALLEE_BAL)
+     andBool #range(0 <= CD < 1024)
+     andBool #rangeAddress(MSG_SENDER)
+     andBool A0 ==Int pow256 -Int 1
 
 endmodule
 

--- a/tests/specs/benchmarks/requires01-a0gt0-spec.k
+++ b/tests/specs/benchmarks/requires01-a0gt0-spec.k
@@ -3,7 +3,7 @@ requires "verification.k"
 module REQUIRES01-A0GT0-SPEC
   imports VERIFICATION
 
-  // fn-execute-a0gt0 
+  // fn-execute-a0gt0
   rule
     <k> (#execute => #halt) ~> _ </k>
     <exit-code> 1 </exit-code>
@@ -109,23 +109,21 @@ _
         <messages> _ </messages>
       </network>
     </ethereum>
-    requires
-     #rangeAddress(CONTRACT_ID)
+    requires #rangeAddress(CONTRACT_ID)
      andBool #rangeAddress(CALLEE_ID)
      andBool #rangeUInt(256, NOW)
      andBool #rangeUInt(128, BLOCK_NUM) // Solidity
 
      // Account address normality
-     andBool CONTRACT_ID  >Int 0 andBool (notBool CONTRACT_ID  in #precompiledAccounts(BYZANTIUM))
-     andBool CALLEE_ID  >Int 0 andBool (notBool CALLEE_ID  in #precompiledAccounts(BYZANTIUM))
+     andBool CONTRACT_ID >Int 0 andBool (notBool CONTRACT_ID in #precompiledAccounts(BYZANTIUM))
+     andBool CALLEE_ID   >Int 0 andBool (notBool CALLEE_ID   in #precompiledAccounts(BYZANTIUM))
 
-andBool #rangeUInt(256, CONTRACT_BAL)
-andBool #rangeUInt(256, CALLEE_BAL)andBool #range(0 <= CD < 1024)
-andBool #rangeAddress(MSG_SENDER)andBool #rangeUInt(256, A0)andBool A0 >Int 0
-    ensures true
-
-
-
+     andBool #rangeUInt(256, CONTRACT_BAL)
+     andBool #rangeUInt(256, CALLEE_BAL)
+     andBool #range(0 <= CD < 1024)
+     andBool #rangeAddress(MSG_SENDER)
+     andBool #rangeUInt(256, A0)
+     andBool A0 >Int 0
 
 endmodule
 

--- a/tests/specs/benchmarks/requires01-a0gt0-spec.k
+++ b/tests/specs/benchmarks/requires01-a0gt0-spec.k
@@ -27,7 +27,7 @@ module REQUIRES01-A0GT0-SPEC
           <wordStack> .WordStack => ?_ </wordStack>
           <localMem> .Memory => ?_ </localMem>
           <pc> 0 => ?_ </pc>
-          <gas> #gas(INITGAS, 0, 0) => ?_ </gas>
+          <gas> #gas(_INITGAS, 0, 0) => ?_ </gas>
           <memoryUsed> 0 => ?_ </memoryUsed>
           <callGas> _ => ?_ </callGas>
           <static> false </static> // NOTE: non-static call
@@ -40,7 +40,7 @@ module REQUIRES01-A0GT0-SPEC
         </substate>
         <gasPrice> _ </gasPrice>
         <origin> _ </origin> // tx.origin
-        <blockhashes> BLOCK_HASHES </blockhashes> // block.blockhash
+        <blockhashes> _BLOCK_HASHES </blockhashes> // block.blockhash
         <block>
           <previousHash> _ </previousHash>
           <ommersHash> _ </ommersHash>

--- a/tests/specs/benchmarks/requires01-a0gt0-spec.k
+++ b/tests/specs/benchmarks/requires01-a0gt0-spec.k
@@ -69,12 +69,8 @@ module REQUIRES01-A0GT0-SPEC
             <acctID> CONTRACT_ID </acctID>
             <balance> CONTRACT_BAL </balance>
             <code> #parseByteStack("0x608060405260043610603f576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff168063fe0d94c1146044575b600080fd5b348015604f57600080fd5b50606c6004803603810190808035906020019092919050505060ae565b604051808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060405180910390f35b6000808211151560bd57600080fd5b600590509190505600a165627a7a72305820885b6ddc678a06d1bd68f28d6a516e4fb72fb2d325ac780ffc7605ac95a408390029") </code>
-            <storage>
-_
-            </storage>
-            <origStorage>
-_
-            </origStorage>
+            <storage> _S </storage>
+            <origStorage> _OS </origStorage>
             <nonce> _ </nonce>
           </account>
 

--- a/tests/specs/benchmarks/requires01-a0le0-spec.k
+++ b/tests/specs/benchmarks/requires01-a0le0-spec.k
@@ -3,7 +3,7 @@ requires "verification.k"
 module REQUIRES01-A0LE0-SPEC
   imports VERIFICATION
 
-  // fn-execute-a0le0 
+  // fn-execute-a0le0
   rule
     <k> (#execute => #halt) ~> _ </k>
     <exit-code> 1 </exit-code>
@@ -109,23 +109,20 @@ _
         <messages> _ </messages>
       </network>
     </ethereum>
-    requires
-     #rangeAddress(CONTRACT_ID)
+    requires #rangeAddress(CONTRACT_ID)
      andBool #rangeAddress(CALLEE_ID)
      andBool #rangeUInt(256, NOW)
      andBool #rangeUInt(128, BLOCK_NUM) // Solidity
 
      // Account address normality
-     andBool CONTRACT_ID  >Int 0 andBool (notBool CONTRACT_ID  in #precompiledAccounts(BYZANTIUM))
-     andBool CALLEE_ID  >Int 0 andBool (notBool CALLEE_ID  in #precompiledAccounts(BYZANTIUM))
+     andBool CONTRACT_ID >Int 0 andBool (notBool CONTRACT_ID in #precompiledAccounts(BYZANTIUM))
+     andBool CALLEE_ID   >Int 0 andBool (notBool CALLEE_ID   in #precompiledAccounts(BYZANTIUM))
 
-andBool #rangeUInt(256, CONTRACT_BAL)
-andBool #rangeUInt(256, CALLEE_BAL)andBool #range(0 <= CD < 1024)
-andBool #rangeAddress(MSG_SENDER)andBool #rangeUInt(256, A0)andBool A0 <=Int 0
-    ensures true
-
-
-
+     andBool #rangeUInt(256, CONTRACT_BAL)
+     andBool #rangeUInt(256, CALLEE_BAL)
+     andBool #range(0 <= CD < 1024)
+     andBool #rangeAddress(MSG_SENDER)
+     andBool #rangeUInt(256, A0)
+     andBool A0 <=Int 0
 
 endmodule
-

--- a/tests/specs/benchmarks/requires01-a0le0-spec.k
+++ b/tests/specs/benchmarks/requires01-a0le0-spec.k
@@ -69,12 +69,8 @@ module REQUIRES01-A0LE0-SPEC
             <acctID> CONTRACT_ID </acctID>
             <balance> CONTRACT_BAL </balance>
             <code> #parseByteStack("0x608060405260043610603f576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff168063fe0d94c1146044575b600080fd5b348015604f57600080fd5b50606c6004803603810190808035906020019092919050505060ae565b604051808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060405180910390f35b6000808211151560bd57600080fd5b600590509190505600a165627a7a72305820885b6ddc678a06d1bd68f28d6a516e4fb72fb2d325ac780ffc7605ac95a408390029") </code>
-            <storage>
-_
-            </storage>
-            <origStorage>
-_
-            </origStorage>
+            <storage> _S </storage>
+            <origStorage> _OS </origStorage>
             <nonce> _ </nonce>
           </account>
 

--- a/tests/specs/benchmarks/requires01-a0le0-spec.k
+++ b/tests/specs/benchmarks/requires01-a0le0-spec.k
@@ -27,7 +27,7 @@ module REQUIRES01-A0LE0-SPEC
           <wordStack> .WordStack => ?_ </wordStack>
           <localMem> .Memory => ?_ </localMem>
           <pc> 0 => ?_ </pc>
-          <gas> #gas(INITGAS, 0, 0) => ?_ </gas>
+          <gas> #gas(_INITGAS, 0, 0) => ?_ </gas>
           <memoryUsed> 0 => ?_ </memoryUsed>
           <callGas> _ => ?_ </callGas>
           <static> false </static> // NOTE: non-static call
@@ -40,7 +40,7 @@ module REQUIRES01-A0LE0-SPEC
         </substate>
         <gasPrice> _ </gasPrice>
         <origin> _ </origin> // tx.origin
-        <blockhashes> BLOCK_HASHES </blockhashes> // block.blockhash
+        <blockhashes> _BLOCK_HASHES </blockhashes> // block.blockhash
         <block>
           <previousHash> _ </previousHash>
           <ommersHash> _ </ommersHash>

--- a/tests/specs/benchmarks/staticarray00-spec.k
+++ b/tests/specs/benchmarks/staticarray00-spec.k
@@ -3,7 +3,7 @@ requires "verification.k"
 module STATICARRAY00-SPEC
   imports VERIFICATION
 
-  // fn-execute 
+  // fn-execute
   rule
     <k> (#execute => #halt) ~> _ </k>
     <exit-code> 1 </exit-code>
@@ -27,7 +27,7 @@ module STATICARRAY00-SPEC
           <wordStack> .WordStack => ?_ </wordStack>
           <localMem> .Memory => ?_ </localMem>
           <pc> 0 => ?_ </pc>
-          <gas> #gas(INITGAS, 0, 0) => ?_ </gas>
+          <gas> #gas(_INITGAS, 0, 0) => ?_ </gas>
           <memoryUsed> 0 => ?_ </memoryUsed>
           <callGas> _ => ?_ </callGas>
           <static> false </static> // NOTE: non-static call
@@ -40,7 +40,7 @@ module STATICARRAY00-SPEC
         </substate>
         <gasPrice> _ </gasPrice>
         <origin> _ </origin> // tx.origin
-        <blockhashes> BLOCK_HASHES </blockhashes> // block.blockhash
+        <blockhashes> _BLOCK_HASHES </blockhashes> // block.blockhash
         <block>
           <previousHash> _ </previousHash>
           <ommersHash> _ </ommersHash>
@@ -109,25 +109,22 @@ _
         <messages> _ </messages>
       </network>
     </ethereum>
-    requires
-     #rangeAddress(CONTRACT_ID)
+    requires #rangeAddress(CONTRACT_ID)
      andBool #rangeAddress(CALLEE_ID)
      andBool #rangeUInt(256, NOW)
      andBool #rangeUInt(128, BLOCK_NUM) // Solidity
 
      // Account address normality
-     andBool CONTRACT_ID  >Int 0 andBool (notBool CONTRACT_ID  in #precompiledAccounts(BYZANTIUM))
-     andBool CALLEE_ID  >Int 0 andBool (notBool CALLEE_ID  in #precompiledAccounts(BYZANTIUM))
+     andBool CONTRACT_ID >Int 0 andBool (notBool CONTRACT_ID in #precompiledAccounts(BYZANTIUM))
+     andBool CALLEE_ID   >Int 0 andBool (notBool CALLEE_ID   in #precompiledAccounts(BYZANTIUM))
 
-andBool #rangeUInt(256, CONTRACT_BAL)
-andBool #rangeUInt(256, CALLEE_BAL)andBool #range(0 <= CD < 1024)
-andBool #rangeAddress(MSG_SENDER)andBool #rangeUInt(256, A0)
-andBool #rangeUInt(256, A1)
-andBool #rangeUInt(256, A2)
-    ensures true
-
-
-
+     andBool #rangeUInt(256, CONTRACT_BAL)
+     andBool #rangeUInt(256, CALLEE_BAL)
+     andBool #range(0 <= CD < 1024)
+     andBool #rangeAddress(MSG_SENDER)
+     andBool #rangeUInt(256, A0)
+     andBool #rangeUInt(256, A1)
+     andBool #rangeUInt(256, A2)
 
 endmodule
 

--- a/tests/specs/benchmarks/staticloop00-a0lt10-spec.k
+++ b/tests/specs/benchmarks/staticloop00-a0lt10-spec.k
@@ -3,7 +3,7 @@ requires "verification.k"
 module STATICLOOP00-A0LT10-SPEC
   imports VERIFICATION
 
-  // fn-execute-a0lt10 
+  // fn-execute-a0lt10
   rule
     <k> (#execute => #halt) ~> _ </k>
     <exit-code> 1 </exit-code>
@@ -27,7 +27,7 @@ module STATICLOOP00-A0LT10-SPEC
           <wordStack> .WordStack => ?_ </wordStack>
           <localMem> .Memory => ?_ </localMem>
           <pc> 0 => ?_ </pc>
-          <gas> #gas(INITGAS, 0, 0) => ?_ </gas>
+          <gas> #gas(_INITGAS, 0, 0) => ?_ </gas>
           <memoryUsed> 0 => ?_ </memoryUsed>
           <callGas> _ => ?_ </callGas>
           <static> false </static> // NOTE: non-static call
@@ -40,7 +40,7 @@ module STATICLOOP00-A0LT10-SPEC
         </substate>
         <gasPrice> _ </gasPrice>
         <origin> _ </origin> // tx.origin
-        <blockhashes> BLOCK_HASHES </blockhashes> // block.blockhash
+        <blockhashes> _BLOCK_HASHES </blockhashes> // block.blockhash
         <block>
           <previousHash> _ </previousHash>
           <ommersHash> _ </ommersHash>
@@ -109,23 +109,20 @@ _
         <messages> _ </messages>
       </network>
     </ethereum>
-    requires
-     #rangeAddress(CONTRACT_ID)
+    requires #rangeAddress(CONTRACT_ID)
      andBool #rangeAddress(CALLEE_ID)
      andBool #rangeUInt(256, NOW)
      andBool #rangeUInt(128, BLOCK_NUM) // Solidity
 
      // Account address normality
-     andBool CONTRACT_ID  >Int 0 andBool (notBool CONTRACT_ID  in #precompiledAccounts(BYZANTIUM))
-     andBool CALLEE_ID  >Int 0 andBool (notBool CALLEE_ID  in #precompiledAccounts(BYZANTIUM))
+     andBool CONTRACT_ID >Int 0 andBool (notBool CONTRACT_ID in #precompiledAccounts(BYZANTIUM))
+     andBool CALLEE_ID   >Int 0 andBool (notBool CALLEE_ID   in #precompiledAccounts(BYZANTIUM))
 
-andBool #rangeUInt(256, CONTRACT_BAL)
-andBool #rangeUInt(256, CALLEE_BAL)andBool #range(0 <= CD < 1024)
-andBool #rangeAddress(MSG_SENDER)andBool #range(0 <= A0 < 10)
-    ensures true
-
-
-
+     andBool #rangeUInt(256, CONTRACT_BAL)
+     andBool #rangeUInt(256, CALLEE_BAL)
+     andBool #range(0 <= CD < 1024)
+     andBool #rangeAddress(MSG_SENDER)
+     andBool #range(0 <= A0 < 10)
 
 endmodule
 

--- a/tests/specs/functional/lemmas-no-smt-spec.k
+++ b/tests/specs/functional/lemmas-no-smt-spec.k
@@ -9,7 +9,7 @@ module VERIFICATION
     syntax KItem ::= runLemma ( StepSort )
                    | doneLemma( StepSort )
  // --------------------------------------
-    rule runLemma( T ) => doneLemma( T )
+    rule <k> runLemma( T ) => doneLemma( T ) ... </k>
 
 endmodule
 
@@ -19,21 +19,21 @@ module LEMMAS-NO-SMT-SPEC
  // Arithmetic simplification
  // -------------------------
 
-    rule runLemma ( 5 +Int X ) => doneLemma ( X +Int 5 )
-    rule runLemma ( X -Int 5 ) => doneLemma ( X +Int (0 -Int 5) )
-    rule runLemma ( (X +Int 3) +Int 5 ) => doneLemma ( X +Int 8 )
-    rule runLemma ( 3 +Int (X +Int 5) ) => doneLemma ( X +Int 8 )
-    rule runLemma ( 5 -Int (X +Int 3) ) => doneLemma ( 2 -Int X )
-    rule runLemma ( 5 +Int (3 +Int X) ) => doneLemma ( 8 +Int X )
-    rule runLemma ( 5 +Int (3 -Int X) ) => doneLemma ( 8 -Int X )
-    rule runLemma ( (5 -Int X) +Int 3 ) => doneLemma ( 8 -Int X )
-    rule runLemma ( 5 -Int (3 +Int X) ) => doneLemma ( 2 -Int X )
-    rule runLemma ( 5 -Int (3 -Int X) ) => doneLemma ( 2 +Int X )
-    rule runLemma ( (X -Int 5) -Int 3 ) => doneLemma ( X -Int 8 )
-    rule runLemma ( 5 &Int (3 &Int X) ) => doneLemma ( 1 &Int X )
+    rule <k> runLemma ( 5 +Int X )          => doneLemma ( X +Int 5          ) ... </k>
+    rule <k> runLemma ( X -Int 5 )          => doneLemma ( X +Int (0 -Int 5) ) ... </k>
+    rule <k> runLemma ( (X +Int 3) +Int 5 ) => doneLemma ( X +Int 8          ) ... </k>
+    rule <k> runLemma ( 3 +Int (X +Int 5) ) => doneLemma ( X +Int 8          ) ... </k>
+    rule <k> runLemma ( 5 -Int (X +Int 3) ) => doneLemma ( 2 -Int X          ) ... </k>
+    rule <k> runLemma ( 5 +Int (3 +Int X) ) => doneLemma ( 8 +Int X          ) ... </k>
+    rule <k> runLemma ( 5 +Int (3 -Int X) ) => doneLemma ( 8 -Int X          ) ... </k>
+    rule <k> runLemma ( (5 -Int X) +Int 3 ) => doneLemma ( 8 -Int X          ) ... </k>
+    rule <k> runLemma ( 5 -Int (3 +Int X) ) => doneLemma ( 2 -Int X          ) ... </k>
+    rule <k> runLemma ( 5 -Int (3 -Int X) ) => doneLemma ( 2 +Int X          ) ... </k>
+    rule <k> runLemma ( (X -Int 5) -Int 3 ) => doneLemma ( X -Int 8          ) ... </k>
+    rule <k> runLemma ( 5 &Int (3 &Int X) ) => doneLemma ( 1 &Int X          ) ... </k>
 
  // Boolean simplification
  // ----------------------
-    rule runLemma ( B ==Bool false ==Bool false ) => doneLemma ( B )
+    rule <k> runLemma ( B ==Bool false ==Bool false ) => doneLemma ( B ) ... </k>
 
 endmodule


### PR DESCRIPTION
This PR does 4 things:

-   Change the `--repl` option of KEVM to use the now supported `--debugger --debug-script` options of the K frontend.
-   Formats all the `benchmarks` specs.
-   Fixes warnings about anonymous variables in all the `benchmarks/` specs.
-   Formats the `lemmas` specifications to have `<k>` tags around the claims.