### PR TITLE
Passing Benchmark Tests

### DIFF
--- a/tests/failing-symbolic.haskell
+++ b/tests/failing-symbolic.haskell
@@ -10,10 +10,7 @@ tests/specs/benchmarks/ecrecoverloop02-sigs-valid-spec.k
 tests/specs/benchmarks/encode_keccak00-spec.k
 tests/specs/benchmarks/encodepacked_keccak01-spec.k
 tests/specs/benchmarks/keccak00-spec.k
-tests/specs/benchmarks/requires01-a0gt0-spec.k
-tests/specs/benchmarks/requires01-a0le0-spec.k
 tests/specs/benchmarks/staticarray00-spec.k
-tests/specs/benchmarks/staticloop00-a0lt10-spec.k
 tests/specs/benchmarks/storagevar02-nooverflow-spec.k
 tests/specs/bihu/collectToken-spec.k
 tests/specs/bihu/forwardToHotWallet-failure-1-spec.k

--- a/tests/specs/benchmarks/verification.k
+++ b/tests/specs/benchmarks/verification.k
@@ -211,6 +211,10 @@ module VERIFICATION
 
     rule #ceil32(X) => X requires X modInt 32 ==Int 0
 
+    rule 0 <=Int #ceil32(X) -Int X => true requires 0 <=Int X [simplification]
+
+    rule 0 <Int 1 <<Int N => true requires 0 <=Int N [simplification]
+
     rule X <=Int #ceil32(X) => true
       requires X >=Int 0
 
@@ -307,12 +311,37 @@ module VERIFICATION-HASKELL [symbolic, kore]
 
     rule #gas(G) -Int G' => #gas(G +Int G') [simplification]
 
+    rule #gas(_)  <Int I => false requires I <=Int pow256 [simplification]
+    rule #gas(_) <=Int I => false requires I <=Int pow256 [simplification]
+    rule #gas(_) >=Int I => true  requires I <=Int pow256 [simplification]
+    rule I <=Int #gas(_) => true  requires I <=Int pow256 [simplification]
+
     rule #gas(_)  <Int _I => false [concrete(_I), simplification]
     rule #gas(_) <=Int _I => false [concrete(_I), simplification]
     rule #gas(_) >=Int _I => true  [concrete(_I), simplification]
+    rule _I <=Int #gas(_) => true  [concrete(_I), simplification]
 
-    rule #gas(_)  <Int Csstore(_, _, _, _) => false [simplification]
-    rule #gas(_) >=Int Csstore(_, _, _, _) => true  [simplification]
+    rule I +Int I' <=Int #gas(G) => true requires I <=Int #gas(G) andBool I' <=Int #gas(G) [simplification]
+    rule I -Int I' <=Int #gas(G) => true requires I <=Int #gas(G) andBool I' <=Int #gas(G) [simplification]
+    rule I *Int I' <=Int #gas(G) => true requires I <=Int #gas(G) andBool I' <=Int #gas(G) [simplification]
+    rule I /Int I' <=Int #gas(G) => true requires I <=Int #gas(G) andBool I' <=Int #gas(G) [simplification]
+
+    rule #gas(G) <Int I +Int I' => false requires notBool (#gas(G) <Int I orBool #gas(G) <Int I') [simplification]
+    rule #gas(G) <Int I -Int I' => false requires notBool (#gas(G) <Int I orBool #gas(G) <Int I') [simplification]
+    rule #gas(G) <Int I *Int I' => false requires notBool (#gas(G) <Int I orBool #gas(G) <Int I') [simplification]
+    rule #gas(G) <Int I /Int I' => false requires notBool (#gas(G) <Int I orBool #gas(G) <Int I') [simplification]
+
+    rule #gas(G) <=Int I +Int I' => false requires notBool (#gas(G) <=Int I orBool #gas(G) <=Int I') [simplification]
+    rule #gas(G) <=Int I -Int I' => false requires notBool (#gas(G) <=Int I orBool #gas(G) <=Int I') [simplification]
+    rule #gas(G) <=Int I *Int I' => false requires notBool (#gas(G) <=Int I orBool #gas(G) <=Int I') [simplification]
+    rule #gas(G) <=Int I /Int I' => false requires notBool (#gas(G) <=Int I orBool #gas(G) <=Int I') [simplification]
+
+    rule #gas(_) <Int Csstore(_, _, _, _) => false [simplification]
+    rule #gas(_) <Int Cmem(_, _)          => false [simplification]
+
+    rule #gas(_) >=Int Csstore(_, _, _, _) => true [simplification]
+
+    rule Cmem(_, _) <=Int #gas(_) => true [simplification]
 endmodule
 
 module VERIFICATION-JAVA [symbolic, kast]

--- a/tests/specs/benchmarks/verification.k
+++ b/tests/specs/benchmarks/verification.k
@@ -211,12 +211,9 @@ module VERIFICATION
 
     rule #ceil32(X) => X requires X modInt 32 ==Int 0
 
-    rule 0 <=Int #ceil32(X) -Int X => true requires 0 <=Int X [simplification]
-
     rule 0 <Int 1 <<Int N => true requires 0 <=Int N [simplification]
 
-    rule X <=Int #ceil32(X) => true
-      requires X >=Int 0
+    rule X <=Int #ceil32(X) => true requires X >=Int 0 [simplification]
 
   // ########################
   // Gnosis

--- a/tests/specs/benchmarks/verification.k
+++ b/tests/specs/benchmarks/verification.k
@@ -305,6 +305,12 @@ endmodule
 module VERIFICATION-HASKELL [symbolic, kore]
     imports VERIFICATION-COMMON
 
+ //
+ // Infiniite Gas
+ // Here we use the construct `#gas` to count _up_ gas used instead of counting down.
+ // This allows (i) computing final gas used, and (ii) never stopping because of out-of-gas.
+ //
+
     syntax Int ::= #gas ( Int ) [function, functional, no-evaluators]
  // -----------------------------------------------------------------
     rule #gas(_, _, _) => #gas(0)


### PR DESCRIPTION
With these changes, now the following tests are passing:

-   `requires01-a0gt0`
-   `requires01-a0le0`
-   `staticloop00-a0lt10`
-   `staticarray00`: not included in this PR because the performance is too bad, passes in 0.43 hrs.
-   `bytes00`: not included in this PR because the performance is too bad, passes in 4.72 hrs.