### PR TITLE
MKR regression tests: dstoken-approve-fail-rough and cat-file-addr-pass-rough

### DIFF
--- a/tests/failing-symbolic.haskell
+++ b/tests/failing-symbolic.haskell
@@ -53,6 +53,7 @@ tests/specs/erc20/hkg/transfer-success-1-spec.k
 tests/specs/erc20/hkg/transfer-success-2-spec.k
 tests/specs/imp-specs/imp-specs-test-spec.k
 tests/specs/mcd/cat-exhaustiveness-spec.k
+tests/specs/mcd/cat-file-addr-pass-rough-spec.k
 tests/specs/mcd/dstoken-approve-fail-rough-spec.k
 tests/specs/mcd/vat-move-diff-spec.k
 tests/specs/opcodes/create-spec.k

--- a/tests/failing-symbolic.haskell
+++ b/tests/failing-symbolic.haskell
@@ -52,6 +52,7 @@ tests/specs/erc20/hkg/transferFrom-success-2-spec.k
 tests/specs/erc20/hkg/transfer-success-1-spec.k
 tests/specs/erc20/hkg/transfer-success-2-spec.k
 tests/specs/imp-specs/imp-specs-test-spec.k
-tests/specs/mcd/vat-move-diff-spec.k
 tests/specs/mcd/cat-exhaustiveness-spec.k
+tests/specs/mcd/dstoken-approve-fail-rough-spec.k
+tests/specs/mcd/vat-move-diff-spec.k
 tests/specs/opcodes/create-spec.k

--- a/tests/specs/mcd/cat-file-addr-pass-rough-spec.k
+++ b/tests/specs/mcd/cat-file-addr-pass-rough-spec.k
@@ -77,18 +77,8 @@ module CAT-FILE-ADDR-PASS-ROUGH-SPEC
               <acctID> ACCT_ID </acctID>
               <balance> ACCT_ID_balance </balance>
               <code> Cat_bin_runtime </code>
-              <storage>
-               .Map
-              [#Cat.wards[CALLER_ID] <- (May) => May]
-              [#Cat.vow <- (Vow) => ABI_data]
-                _:Map
-               </storage>
-              <origStorage>
-               .Map
-              [#Cat.wards[CALLER_ID] <- (Junk_0)]
-              [#Cat.vow <- (Junk_1)]
-                _:Map
-               </origStorage>
+              <storage> STORAGE => STORAGE [ #Cat.vow <- ABI_data ] </storage>
+              <origStorage> ORIGSTORAGE </origStorage>
               <nonce> Nonce_Cat => ?_ </nonce>
             </account>
             <account>
@@ -201,5 +191,11 @@ module CAT-FILE-ADDR-PASS-ROUGH-SPEC
      andBool ((May ==Int 1)
      andBool ((VCallValue ==Int 0)
      andBool ((ABI_what ==Int #string2Word("vow"))))))))))))))
+
+     andBool #lookup(STORAGE, #Cat.wards[CALLER_ID]) ==Int May
+     andBool #lookup(STORAGE, #Cat.vow)              ==Int Vow
+
+     andBool #lookup(ORIGSTORAGE, #Cat.wards[CALLER_ID]) ==Int Junk_0
+     andBool #lookup(ORIGSTORAGE, #Cat.vow)              ==Int Junk_1
 
 endmodule

--- a/tests/specs/mcd/cat-file-addr-pass-rough-spec.k
+++ b/tests/specs/mcd/cat-file-addr-pass-rough-spec.k
@@ -14,7 +14,7 @@ module CAT-FILE-ADDR-PASS-ROUGH-SPEC
           <output> .ByteArray </output>
           <statusCode> _ => EVMC_SUCCESS </statusCode>
           <endPC> _ => ?_ </endPC>
-          <callStack> VCallStack </callStack>
+          <callStack> _VCallStack </callStack>
           <interimStates> _ </interimStates>
           <touchedAccounts> _ => ?_ </touchedAccounts>
           <callState>
@@ -34,7 +34,7 @@ module CAT-FILE-ADDR-PASS-ROUGH-SPEC
             <callDepth> VCallDepth </callDepth>
           </callState>
           <substate>
-            <selfDestruct> VSelfDestruct </selfDestruct>
+            <selfDestruct> _VSelfDestruct </selfDestruct>
             <log> _ => ?_ </log>
             <refund> _ => ?_ </refund>
           </substate>
@@ -50,7 +50,7 @@ module CAT-FILE-ADDR-PASS-ROUGH-SPEC
             <receiptsRoot> _ </receiptsRoot>
             <logsBloom> _ </logsBloom>
             <difficulty> _ </difficulty>
-            <number> BLOCK_NUMBER </number>
+            <number> _BLOCK_NUMBER </number>
             <gasLimit> _ </gasLimit>
             <gasUsed> _ </gasUsed>
             <timestamp> TIME </timestamp>
@@ -79,7 +79,7 @@ module CAT-FILE-ADDR-PASS-ROUGH-SPEC
               <code> Cat_bin_runtime </code>
               <storage> STORAGE => STORAGE [ #Cat.vow <- ABI_data ] </storage>
               <origStorage> ORIGSTORAGE </origStorage>
-              <nonce> Nonce_Cat => ?_ </nonce>
+              <nonce> _Nonce_Cat => ?_ </nonce>
             </account>
             <account>
               <acctID> 1 </acctID>

--- a/tests/specs/mcd/cat-file-addr-pass-rough-spec.k
+++ b/tests/specs/mcd/cat-file-addr-pass-rough-spec.k
@@ -11,7 +11,7 @@ module CAT-FILE-ADDR-PASS-ROUGH-SPEC
       <schedule> ISTANBUL </schedule>
       <ethereum>
         <evm>
-          <output> .WordStack </output>
+          <output> .ByteArray </output>
           <statusCode> _ => EVMC_SUCCESS </statusCode>
           <endPC> _ => ?_ </endPC>
           <callStack> VCallStack </callStack>
@@ -25,7 +25,7 @@ module CAT-FILE-ADDR-PASS-ROUGH-SPEC
             <callData> #abiCallData("file", #bytes32(ABI_what), #address(ABI_data)) ++ CD => ?_ </callData>
             <callValue> VCallValue </callValue>
             <wordStack> .WordStack => ?_ </wordStack>
-            <localMem> .Map => ?_ </localMem>
+            <localMem> .Memory => ?_ </localMem>
             <pc> 0 => ?_ </pc>
             <gas> VGas => ?_ </gas>
             <memoryUsed> 0 => ?_ </memoryUsed>
@@ -84,7 +84,7 @@ module CAT-FILE-ADDR-PASS-ROUGH-SPEC
             <account>
               <acctID> 1 </acctID>
               <balance> ECREC_BAL </balance>
-              <code> .WordStack </code>
+              <code> .ByteArray </code>
               <storage> _:Map </storage>
               <origStorage> _ </origStorage>
               <nonce> _ </nonce>
@@ -92,7 +92,7 @@ module CAT-FILE-ADDR-PASS-ROUGH-SPEC
             <account>
               <acctID> 2 </acctID>
               <balance> SHA256_BAL </balance>
-              <code> .WordStack </code>
+              <code> .ByteArray </code>
               <storage> _:Map </storage>
               <origStorage> _ </origStorage>
               <nonce> _ </nonce>
@@ -100,7 +100,7 @@ module CAT-FILE-ADDR-PASS-ROUGH-SPEC
             <account>
               <acctID> 3 </acctID>
               <balance> RIP160_BAL </balance>
-              <code> .WordStack </code>
+              <code> .ByteArray </code>
               <storage> _:Map </storage>
               <origStorage> _ </origStorage>
               <nonce> _ </nonce>
@@ -108,7 +108,7 @@ module CAT-FILE-ADDR-PASS-ROUGH-SPEC
             <account>
               <acctID> 4 </acctID>
               <balance> ID_BAL </balance>
-              <code> .WordStack </code>
+              <code> .ByteArray </code>
               <storage> _:Map </storage>
               <origStorage> _ </origStorage>
               <nonce> _ </nonce>
@@ -116,7 +116,7 @@ module CAT-FILE-ADDR-PASS-ROUGH-SPEC
             <account>
               <acctID> 5 </acctID>
               <balance> MODEXP_BAL </balance>
-              <code> .WordStack </code>
+              <code> .ByteArray </code>
               <storage> _:Map </storage>
               <origStorage> _ </origStorage>
               <nonce> _ </nonce>
@@ -124,7 +124,7 @@ module CAT-FILE-ADDR-PASS-ROUGH-SPEC
             <account>
               <acctID> 6 </acctID>
               <balance> ECADD_BAL </balance>
-              <code> .WordStack </code>
+              <code> .ByteArray </code>
               <storage> _:Map </storage>
               <origStorage> _ </origStorage>
               <nonce> _ </nonce>
@@ -132,7 +132,7 @@ module CAT-FILE-ADDR-PASS-ROUGH-SPEC
             <account>
               <acctID> 7 </acctID>
               <balance> ECMUL_BAL </balance>
-              <code> .WordStack </code>
+              <code> .ByteArray </code>
               <storage> _:Map </storage>
               <origStorage> _ </origStorage>
               <nonce> _ </nonce>
@@ -140,7 +140,7 @@ module CAT-FILE-ADDR-PASS-ROUGH-SPEC
             <account>
               <acctID> 8 </acctID>
               <balance> ECPAIRING_BAL </balance>
-              <code> .WordStack </code>
+              <code> .ByteArray </code>
               <storage> _:Map </storage>
               <origStorage> _ </origStorage>
               <nonce> _ </nonce>
@@ -148,7 +148,7 @@ module CAT-FILE-ADDR-PASS-ROUGH-SPEC
             <account>
               <acctID> 9 </acctID>
               <balance> BLAKE2_BAL </balance>
-              <code> .WordStack </code>
+              <code> .ByteArray </code>
               <storage> _:Map </storage>
               <origStorage> _ </origStorage>
               <nonce> _ </nonce>

--- a/tests/specs/mcd/cat-file-addr-pass-rough-spec.k
+++ b/tests/specs/mcd/cat-file-addr-pass-rough-spec.k
@@ -1,0 +1,205 @@
+requires "verification.k"
+
+module CAT-FILE-ADDR-PASS-ROUGH-SPEC
+  imports VERIFICATION
+
+    // Cat_file-addr
+    rule [Cat.file-addr.pass.rough]:
+      <k> #execute ~> CONTINUATION => #halt ~> CONTINUATION </k>
+      <exit-code> 1 </exit-code>
+      <mode> NORMAL </mode>
+      <schedule> ISTANBUL </schedule>
+      <ethereum>
+        <evm>
+          <output> .WordStack </output>
+          <statusCode> _ => EVMC_SUCCESS </statusCode>
+          <endPC> _ => ?_ </endPC>
+          <callStack> VCallStack </callStack>
+          <interimStates> _ </interimStates>
+          <touchedAccounts> _ => ?_ </touchedAccounts>
+          <callState>
+            <program> Cat_bin_runtime </program>
+            <jumpDests> #computeValidJumpDests(Cat_bin_runtime) </jumpDests>
+            <id> ACCT_ID </id>
+            <caller> CALLER_ID </caller>
+            <callData> #abiCallData("file", #bytes32(ABI_what), #address(ABI_data)) ++ CD => ?_ </callData>
+            <callValue> VCallValue </callValue>
+            <wordStack> .WordStack => ?_ </wordStack>
+            <localMem> .Map => ?_ </localMem>
+            <pc> 0 => ?_ </pc>
+            <gas> VGas => ?_ </gas>
+            <memoryUsed> 0 => ?_ </memoryUsed>
+            <callGas> _ => ?_ </callGas>
+            <static> false </static>
+            <callDepth> VCallDepth </callDepth>
+          </callState>
+          <substate>
+            <selfDestruct> VSelfDestruct </selfDestruct>
+            <log> _ => ?_ </log>
+            <refund> _ => ?_ </refund>
+          </substate>
+          <gasPrice> _ </gasPrice>
+          <origin> ORIGIN_ID </origin>
+          <blockhashes> _ </blockhashes>
+          <block>
+            <previousHash> _ </previousHash>
+            <ommersHash> _ </ommersHash>
+            <coinbase> _ </coinbase>
+            <stateRoot> _ </stateRoot>
+            <transactionsRoot> _ </transactionsRoot>
+            <receiptsRoot> _ </receiptsRoot>
+            <logsBloom> _ </logsBloom>
+            <difficulty> _ </difficulty>
+            <number> BLOCK_NUMBER </number>
+            <gasLimit> _ </gasLimit>
+            <gasUsed> _ </gasUsed>
+            <timestamp> TIME </timestamp>
+            <extraData> _ </extraData>
+            <mixHash> _ </mixHash>
+            <blockNonce> _ </blockNonce>
+            <ommerBlockHeaders> _ </ommerBlockHeaders>
+          </block>
+        </evm>
+        <network>
+          <chainID> VChainId </chainID>
+          <activeAccounts> SetItem(ACCT_ID)
+          SetItem(1)
+          SetItem(2)
+          SetItem(3)
+          SetItem(4)
+          SetItem(5)
+          SetItem(6)
+          SetItem(7)
+          SetItem(8)
+          SetItem(9) _ </activeAccounts>
+          <accounts>
+            <account>
+              <acctID> ACCT_ID </acctID>
+              <balance> ACCT_ID_balance </balance>
+              <code> Cat_bin_runtime </code>
+              <storage>
+               .Map
+              [#Cat.wards[CALLER_ID] <- (May) => May]
+              [#Cat.vow <- (Vow) => ABI_data]
+                _:Map
+               </storage>
+              <origStorage>
+               .Map
+              [#Cat.wards[CALLER_ID] <- (Junk_0)]
+              [#Cat.vow <- (Junk_1)]
+                _:Map
+               </origStorage>
+              <nonce> Nonce_Cat => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> 1 </acctID>
+              <balance> ECREC_BAL </balance>
+              <code> .WordStack </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 2 </acctID>
+              <balance> SHA256_BAL </balance>
+              <code> .WordStack </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 3 </acctID>
+              <balance> RIP160_BAL </balance>
+              <code> .WordStack </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 4 </acctID>
+              <balance> ID_BAL </balance>
+              <code> .WordStack </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 5 </acctID>
+              <balance> MODEXP_BAL </balance>
+              <code> .WordStack </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 6 </acctID>
+              <balance> ECADD_BAL </balance>
+              <code> .WordStack </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 7 </acctID>
+              <balance> ECMUL_BAL </balance>
+              <code> .WordStack </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 8 </acctID>
+              <balance> ECPAIRING_BAL </balance>
+              <code> .WordStack </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 9 </acctID>
+              <balance> BLAKE2_BAL </balance>
+              <code> .WordStack </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+           ...
+          </accounts>
+          <txOrder> _ </txOrder>
+          <txPending> _ </txPending>
+          <messages> _ </messages>
+        </network>
+      </ethereum>
+    requires #rangeAddress(ACCT_ID)
+     andBool ACCT_ID =/=Int 0
+     andBool #notPrecompileAddress(ACCT_ID)
+     andBool #rangeAddress(CALLER_ID)
+     andBool #rangeAddress(ORIGIN_ID)
+     andBool #rangeUInt(256, TIME)
+     andBool #rangeUInt(256, ACCT_ID_balance)
+     andBool #rangeUInt(256, ECREC_BAL)
+     andBool #rangeUInt(256, SHA256_BAL)
+     andBool #rangeUInt(256, RIP160_BAL)
+     andBool #rangeUInt(256, ID_BAL)
+     andBool #rangeUInt(256, MODEXP_BAL)
+     andBool #rangeUInt(256, ECADD_BAL)
+     andBool #rangeUInt(256, ECMUL_BAL)
+     andBool #rangeUInt(256, ECPAIRING_BAL)
+     andBool #rangeUInt(256, BLAKE2_BAL)
+     andBool VCallDepth <=Int 1024
+     andBool #rangeUInt(256, VCallValue)
+     andBool #rangeUInt(256, VChainId)
+     andBool (#rangeBytes(32, ABI_what)
+     andBool (#rangeAddress(ABI_data)
+     andBool (#rangeUInt(256, May)
+     andBool (#rangeAddress(Vow)
+     andBool (#sizeByteArray(CD) <=Int 1250000000
+     andBool (#notPrecompileAddress(Vow)
+     andBool (VGas >=Int 3000000
+     andBool (#rangeUInt(256, Junk_0)
+     andBool (#rangeUInt(256, Junk_1)
+     andBool ((May ==Int 1)
+     andBool ((VCallValue ==Int 0)
+     andBool ((ABI_what ==Int #string2Word("vow"))))))))))))))
+
+endmodule

--- a/tests/specs/mcd/dstoken-approve-fail-rough-spec.k
+++ b/tests/specs/mcd/dstoken-approve-fail-rough-spec.k
@@ -14,7 +14,7 @@ module DSTOKEN-APPROVE-FAIL-ROUGH-SPEC
           <output> _ => ?_ </output>
           <statusCode> _ => ?FAILURE:EndStatusCode </statusCode>
           <endPC> _ => ?_ </endPC>
-          <callStack> VCallStack </callStack>
+          <callStack> _VCallStack </callStack>
           <interimStates> _ </interimStates>
           <touchedAccounts> _ => ?_ </touchedAccounts>
           <callState>
@@ -34,7 +34,7 @@ module DSTOKEN-APPROVE-FAIL-ROUGH-SPEC
             <callDepth> VCallDepth => ?_ </callDepth>
           </callState>
           <substate>
-            <selfDestruct> VSelfDestruct </selfDestruct>
+            <selfDestruct> _VSelfDestruct </selfDestruct>
             <log> _ => ?_ </log>
             <refund> _ => ?_ </refund>
           </substate>
@@ -50,7 +50,7 @@ module DSTOKEN-APPROVE-FAIL-ROUGH-SPEC
             <receiptsRoot> _ </receiptsRoot>
             <logsBloom> _ </logsBloom>
             <difficulty> _ </difficulty>
-            <number> BLOCK_NUMBER </number>
+            <number> _BLOCK_NUMBER </number>
             <gasLimit> _ </gasLimit>
             <gasUsed> _ </gasUsed>
             <timestamp> TIME </timestamp>
@@ -89,7 +89,7 @@ module DSTOKEN-APPROVE-FAIL-ROUGH-SPEC
               [#DSToken.owner_stopped <- (Junk_1)]
                 _:Map
                </origStorage>
-              <nonce> Nonce_DSToken => ?_ </nonce>
+              <nonce> _Nonce_DSToken => ?_ </nonce>
             </account>
             <account>
               <acctID> 1 </acctID>

--- a/tests/specs/mcd/dstoken-approve-fail-rough-spec.k
+++ b/tests/specs/mcd/dstoken-approve-fail-rough-spec.k
@@ -25,7 +25,7 @@ module DSTOKEN-APPROVE-FAIL-ROUGH-SPEC
             <callData> #abiCallData("approve", #address(ABI_usr), #uint256(ABI_wad)) ++ CD => ?_ </callData>
             <callValue> VCallValue </callValue>
             <wordStack> .WordStack => ?_ </wordStack>
-            <localMem> .Map => ?_ </localMem>
+            <localMem> .Memory => ?_ </localMem>
             <pc> 0 => ?_ </pc>
             <gas> VGas => ?_ </gas>
             <memoryUsed> 0 => ?_ </memoryUsed>
@@ -94,7 +94,7 @@ module DSTOKEN-APPROVE-FAIL-ROUGH-SPEC
             <account>
               <acctID> 1 </acctID>
               <balance> ECREC_BAL </balance>
-              <code> .WordStack </code>
+              <code> .ByteArray </code>
               <storage> _:Map </storage>
               <origStorage> _ </origStorage>
               <nonce> _ </nonce>
@@ -102,7 +102,7 @@ module DSTOKEN-APPROVE-FAIL-ROUGH-SPEC
             <account>
               <acctID> 2 </acctID>
               <balance> SHA256_BAL </balance>
-              <code> .WordStack </code>
+              <code> .ByteArray </code>
               <storage> _:Map </storage>
               <origStorage> _ </origStorage>
               <nonce> _ </nonce>
@@ -110,7 +110,7 @@ module DSTOKEN-APPROVE-FAIL-ROUGH-SPEC
             <account>
               <acctID> 3 </acctID>
               <balance> RIP160_BAL </balance>
-              <code> .WordStack </code>
+              <code> .ByteArray </code>
               <storage> _:Map </storage>
               <origStorage> _ </origStorage>
               <nonce> _ </nonce>
@@ -118,7 +118,7 @@ module DSTOKEN-APPROVE-FAIL-ROUGH-SPEC
             <account>
               <acctID> 4 </acctID>
               <balance> ID_BAL </balance>
-              <code> .WordStack </code>
+              <code> .ByteArray </code>
               <storage> _:Map </storage>
               <origStorage> _ </origStorage>
               <nonce> _ </nonce>
@@ -126,7 +126,7 @@ module DSTOKEN-APPROVE-FAIL-ROUGH-SPEC
             <account>
               <acctID> 5 </acctID>
               <balance> MODEXP_BAL </balance>
-              <code> .WordStack </code>
+              <code> .ByteArray </code>
               <storage> _:Map </storage>
               <origStorage> _ </origStorage>
               <nonce> _ </nonce>
@@ -134,7 +134,7 @@ module DSTOKEN-APPROVE-FAIL-ROUGH-SPEC
             <account>
               <acctID> 6 </acctID>
               <balance> ECADD_BAL </balance>
-              <code> .WordStack </code>
+              <code> .ByteArray </code>
               <storage> _:Map </storage>
               <origStorage> _ </origStorage>
               <nonce> _ </nonce>
@@ -142,7 +142,7 @@ module DSTOKEN-APPROVE-FAIL-ROUGH-SPEC
             <account>
               <acctID> 7 </acctID>
               <balance> ECMUL_BAL </balance>
-              <code> .WordStack </code>
+              <code> .ByteArray </code>
               <storage> _:Map </storage>
               <origStorage> _ </origStorage>
               <nonce> _ </nonce>
@@ -150,7 +150,7 @@ module DSTOKEN-APPROVE-FAIL-ROUGH-SPEC
             <account>
               <acctID> 8 </acctID>
               <balance> ECPAIRING_BAL </balance>
-              <code> .WordStack </code>
+              <code> .ByteArray </code>
               <storage> _:Map </storage>
               <origStorage> _ </origStorage>
               <nonce> _ </nonce>
@@ -158,7 +158,7 @@ module DSTOKEN-APPROVE-FAIL-ROUGH-SPEC
             <account>
               <acctID> 9 </acctID>
               <balance> BLAKE2_BAL </balance>
-              <code> .WordStack </code>
+              <code> .ByteArray </code>
               <storage> _:Map </storage>
               <origStorage> _ </origStorage>
               <nonce> _ </nonce>

--- a/tests/specs/mcd/dstoken-approve-fail-rough-spec.k
+++ b/tests/specs/mcd/dstoken-approve-fail-rough-spec.k
@@ -193,7 +193,7 @@ module DSTOKEN-APPROVE-FAIL-ROUGH-SPEC
      andBool (#rangeAddress(ABI_usr)
      andBool (#rangeUInt(256, ABI_wad)
      andBool (#rangeUInt(256, Allowed)
-     andBool (#rangeUInt(1, Stopped)
+     andBool (#rangeBool(Stopped)
      andBool (#rangeAddress(Owner)
      andBool (#sizeByteArray(CD) <=Int 1250000000
      andBool (#notPrecompileAddress(Owner)

--- a/tests/specs/mcd/dstoken-approve-fail-rough-spec.k
+++ b/tests/specs/mcd/dstoken-approve-fail-rough-spec.k
@@ -1,0 +1,207 @@
+requires "verification.k"
+
+module DSTOKEN-APPROVE-FAIL-ROUGH-SPEC
+    imports VERIFICATION
+
+    // DSToken_approve
+    rule [DSToken.approve.fail.rough]:
+      <k> #execute ~> CONTINUATION => #halt ~> CONTINUATION </k>
+      <exit-code> 1 </exit-code>
+      <mode> NORMAL </mode>
+      <schedule> ISTANBUL </schedule>
+      <ethereum>
+        <evm>
+          <output> _ => ?_ </output>
+          <statusCode> _ => ?FAILURE:EndStatusCode </statusCode>
+          <endPC> _ => ?_ </endPC>
+          <callStack> VCallStack </callStack>
+          <interimStates> _ </interimStates>
+          <touchedAccounts> _ => ?_ </touchedAccounts>
+          <callState>
+            <program> DSToken_bin_runtime </program>
+            <jumpDests> #computeValidJumpDests(DSToken_bin_runtime) </jumpDests>
+            <id> ACCT_ID </id>
+            <caller> CALLER_ID </caller>
+            <callData> #abiCallData("approve", #address(ABI_usr), #uint256(ABI_wad)) ++ CD => ?_ </callData>
+            <callValue> VCallValue </callValue>
+            <wordStack> .WordStack => ?_ </wordStack>
+            <localMem> .Map => ?_ </localMem>
+            <pc> 0 => ?_ </pc>
+            <gas> VGas => ?_ </gas>
+            <memoryUsed> 0 => ?_ </memoryUsed>
+            <callGas> _ => ?_ </callGas>
+            <static> false </static>
+            <callDepth> VCallDepth => ?_ </callDepth>
+          </callState>
+          <substate>
+            <selfDestruct> VSelfDestruct </selfDestruct>
+            <log> _ => ?_ </log>
+            <refund> _ => ?_ </refund>
+          </substate>
+          <gasPrice> _ </gasPrice>
+          <origin> ORIGIN_ID </origin>
+          <blockhashes> _ </blockhashes>
+          <block>
+            <previousHash> _ </previousHash>
+            <ommersHash> _ </ommersHash>
+            <coinbase> _ </coinbase>
+            <stateRoot> _ </stateRoot>
+            <transactionsRoot> _ </transactionsRoot>
+            <receiptsRoot> _ </receiptsRoot>
+            <logsBloom> _ </logsBloom>
+            <difficulty> _ </difficulty>
+            <number> BLOCK_NUMBER </number>
+            <gasLimit> _ </gasLimit>
+            <gasUsed> _ </gasUsed>
+            <timestamp> TIME </timestamp>
+            <extraData> _ </extraData>
+            <mixHash> _ </mixHash>
+            <blockNonce> _ </blockNonce>
+            <ommerBlockHeaders> _ </ommerBlockHeaders>
+          </block>
+        </evm>
+        <network>
+          <chainID> VChainId </chainID>
+          <activeAccounts> SetItem(ACCT_ID)
+          SetItem(1)
+          SetItem(2)
+          SetItem(3)
+          SetItem(4)
+          SetItem(5)
+          SetItem(6)
+          SetItem(7)
+          SetItem(8)
+          SetItem(9) _ </activeAccounts>
+          <accounts>
+            <account>
+              <acctID> ACCT_ID </acctID>
+              <balance> ACCT_ID_balance </balance>
+              <code> DSToken_bin_runtime </code>
+              <storage>
+               .Map
+              [#DSToken.allowance[CALLER_ID][ABI_usr] <- (Allowed) => ?_]
+              [#DSToken.owner_stopped <- (#WordPackAddrUInt8(Owner, Stopped)) => ?_]
+                _:Map
+               </storage>
+              <origStorage>
+               .Map
+              [#DSToken.allowance[CALLER_ID][ABI_usr] <- (Junk_0)]
+              [#DSToken.owner_stopped <- (Junk_1)]
+                _:Map
+               </origStorage>
+              <nonce> Nonce_DSToken => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> 1 </acctID>
+              <balance> ECREC_BAL </balance>
+              <code> .WordStack </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 2 </acctID>
+              <balance> SHA256_BAL </balance>
+              <code> .WordStack </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 3 </acctID>
+              <balance> RIP160_BAL </balance>
+              <code> .WordStack </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 4 </acctID>
+              <balance> ID_BAL </balance>
+              <code> .WordStack </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 5 </acctID>
+              <balance> MODEXP_BAL </balance>
+              <code> .WordStack </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 6 </acctID>
+              <balance> ECADD_BAL </balance>
+              <code> .WordStack </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 7 </acctID>
+              <balance> ECMUL_BAL </balance>
+              <code> .WordStack </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 8 </acctID>
+              <balance> ECPAIRING_BAL </balance>
+              <code> .WordStack </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 9 </acctID>
+              <balance> BLAKE2_BAL </balance>
+              <code> .WordStack </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+           ...
+          </accounts>
+          <txOrder> _ </txOrder>
+          <txPending> _ </txPending>
+          <messages> _ </messages>
+        </network>
+      </ethereum>
+
+    requires #rangeAddress(ACCT_ID)
+     andBool ACCT_ID =/=Int 0
+     andBool #notPrecompileAddress(ACCT_ID)
+     andBool #rangeAddress(CALLER_ID)
+     andBool #rangeAddress(ORIGIN_ID)
+     andBool #rangeUInt(256, TIME)
+     andBool #rangeUInt(256, ACCT_ID_balance)
+     andBool #rangeUInt(256, ECREC_BAL)
+     andBool #rangeUInt(256, SHA256_BAL)
+     andBool #rangeUInt(256, RIP160_BAL)
+     andBool #rangeUInt(256, ID_BAL)
+     andBool #rangeUInt(256, MODEXP_BAL)
+     andBool #rangeUInt(256, ECADD_BAL)
+     andBool #rangeUInt(256, ECMUL_BAL)
+     andBool #rangeUInt(256, ECPAIRING_BAL)
+     andBool #rangeUInt(256, BLAKE2_BAL)
+     andBool VCallDepth <=Int 1024
+     andBool #rangeUInt(256, VCallValue)
+     andBool #rangeUInt(256, VChainId)
+     andBool (#rangeAddress(ABI_usr)
+     andBool (#rangeUInt(256, ABI_wad)
+     andBool (#rangeUInt(256, Allowed)
+     andBool (#rangeUInt(1, Stopped)
+     andBool (#rangeAddress(Owner)
+     andBool (#sizeByteArray(CD) <=Int 1250000000
+     andBool (#notPrecompileAddress(Owner)
+     andBool (VGas >=Int 3000000
+     andBool (#rangeUInt(256, Junk_0)
+     andBool (#rangeUInt(256, Junk_1)))))))))))
+     andBool notBool ( ((Stopped:Int ==Int 0) andBool ((VCallValue:Int ==Int 0))) )
+
+     ensures ?FAILURE =/=K EVMC_SUCCESS
+
+endmodule

--- a/tests/specs/mcd/verification.k
+++ b/tests/specs/mcd/verification.k
@@ -19,6 +19,22 @@ module VERIFICATION
  // --------------------------------------------------------
     rule #notPrecompileAddress ( X ) => 0 ==Int X orBool (10 <=Int X andBool #rangeAddress(X))
 
+    syntax Bool ::= #rangeBool ( Int )
+ // ----------------------------------
+    rule #rangeBool(X) => X ==Int 0 orBool X ==Int 1 [macro]
+
+    syntax Int ::= "pow208"
+ // -----------------------
+    rule pow208 => 411376139330301510538742295639337626245683966408394965837152256 [macro]
+
+    syntax Int ::= #WordPackUInt48UInt48     (       Int , Int ) [function]
+                 | #WordPackAddrUInt8        (       Int , Int ) [function]
+                 | #WordPackAddrUInt48UInt48 ( Int , Int , Int ) [function]
+ // -----------------------------------------------------------------------
+    rule #WordPackUInt48UInt48     (     X , Y ) => Y *Int pow48  +Int X                    requires #rangeUInt(48, X) andBool #rangeUInt(48, Y)
+    rule #WordPackAddrUInt8        (     X , Y ) => Y *Int pow160 +Int X                    requires #rangeAddress(X)  andBool #rangeUInt(8, Y)
+    rule #WordPackAddrUInt48UInt48 ( A , X , Y ) => Y *Int pow208 +Int X *Int pow160 +Int A requires #rangeAddress(A)  andBool #rangeUInt(48, X) andBool #rangeUInt(48, Y)
+
     // ### vat-move-diff
 
     rule (W0 : WS) [ 0     .. WIDTH ] => W0 : (WS [ 0 .. WIDTH -Int 1 ]) requires 0 <Int WIDTH

--- a/tests/specs/mcd/verification.k
+++ b/tests/specs/mcd/verification.k
@@ -35,6 +35,10 @@ module VERIFICATION
     rule #WordPackAddrUInt8        (     X , Y ) => Y *Int pow160 +Int X                    requires #rangeAddress(X)  andBool #rangeUInt(8, Y)
     rule #WordPackAddrUInt48UInt48 ( A , X , Y ) => Y *Int pow208 +Int X *Int pow160 +Int A requires #rangeAddress(A)  andBool #rangeUInt(48, X) andBool #rangeUInt(48, Y)
 
+    syntax Int ::= #string2Word ( String ) [function]
+ // -------------------------------------------------
+    rule #string2Word(S) => #asWord(#padRightToWidth(32, #parseByteStackRaw(S)))
+
     // ### vat-move-diff
 
     rule (W0 : WS) [ 0     .. WIDTH ] => W0 : (WS [ 0 .. WIDTH -Int 1 ]) requires 0 <Int WIDTH

--- a/tests/specs/mcd/verification.k
+++ b/tests/specs/mcd/verification.k
@@ -39,6 +39,11 @@ module VERIFICATION
  // -------------------------------------------------
     rule #string2Word(S) => #asWord(#padRightToWidth(32, #parseByteStackRaw(S)))
 
+    // in binary: 100 1s followed by 160 0s
+    syntax Int ::= "notAddrMask"
+ // ----------------------------
+    rule notAddrMask => 115792089237316195423570985007226406215939081747436879206741300988257197096960 [macro]
+
     // ### vat-move-diff
 
     rule (W0 : WS) [ 0     .. WIDTH ] => W0 : (WS [ 0 .. WIDTH -Int 1 ]) requires 0 <Int WIDTH
@@ -53,5 +58,9 @@ module VERIFICATION
     rule #sizeByteArray(_WS [ START .. WIDTH ]) => WIDTH requires 0 <=Int START andBool 0 <=Int WIDTH
 
     rule WS [ START .. WIDTH ] [ 0 .. WIDTH' ]  => WS [ START .. WIDTH' ] requires WIDTH' <=Int WIDTH
+
+    // ### cat-file-addr-pass-rough
+
+    rule notAddrMask &Int ADDR => 0 requires #rangeAddress(ADDR)
 
 endmodule


### PR DESCRIPTION
These proofs add in some needed syntax for many of the MKR proofs to even parse/run, including:

-   #rangeBool
-   pow208
-   #WordPack*
-   #string2Word
-   notAddrMast