### PR TITLE
MKR regression tests: performance of dai-adduu-fail-rough and vat-deny-diff-fail-rough

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,15 @@ RUN    apt-get update           \
             python-sphinx       \
             rapidjson-dev
 
+RUN    git clone 'https://github.com/z3prover/z3' --branch=z3-4.8.7 \
+    && cd z3                                                        \
+    && python scripts/mk_make.py                                    \
+    && cd build                                                     \
+    && make -j8                                                     \
+    && make install                                                 \
+    && cd ../..                                                     \
+    && rm -rf z3
+
 ARG USER_ID=1000
 ARG GROUP_ID=1000
 RUN groupadd -g $GROUP_ID user && useradd -m -u $USER_ID -s /bin/sh -g user user

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,7 +35,7 @@ pipeline {
         stage('Proofs') {
           options {
             lock("proofs-${env.NODE_NAME}")
-            timeout(time: 65, unit: 'MINUTES')
+            timeout(time: 80, unit: 'MINUTES')
           }
           parallel {
             stage('Java')              { steps { sh 'make test-prove -j5 TEST_SYMBOLIC_BACKEND=java'    } }

--- a/tests/failing-symbolic.haskell
+++ b/tests/failing-symbolic.haskell
@@ -54,6 +54,8 @@ tests/specs/erc20/hkg/transfer-success-2-spec.k
 tests/specs/imp-specs/imp-specs-test-spec.k
 tests/specs/mcd/cat-exhaustiveness-spec.k
 tests/specs/mcd/cat-file-addr-pass-rough-spec.k
+tests/specs/mcd/dai-adduu-fail-rough-spec.k
 tests/specs/mcd/dstoken-approve-fail-rough-spec.k
+tests/specs/mcd/vat-deny-diff-fail-rough-spec.k
 tests/specs/mcd/vat-move-diff-spec.k
 tests/specs/opcodes/create-spec.k

--- a/tests/specs/mcd/dai-adduu-fail-rough-spec.k
+++ b/tests/specs/mcd/dai-adduu-fail-rough-spec.k
@@ -14,7 +14,7 @@ module DAI-ADDUU-FAIL-ROUGH-SPEC
           <output> _ => ?_ </output>
           <statusCode> _ => ?FAILURE:EndStatusCode </statusCode>
           <endPC> _ => ?_ </endPC>
-          <callStack> VCallStack </callStack>
+          <callStack> _VCallStack </callStack>
           <interimStates> _ </interimStates>
           <touchedAccounts> _ => ?_ </touchedAccounts>
           <callState>
@@ -24,7 +24,7 @@ module DAI-ADDUU-FAIL-ROUGH-SPEC
             <caller> CALLER_ID </caller>
             <callData> _ => ?_ </callData>
             <callValue> VCallValue </callValue>
-            <wordStack> ABI_y : ABI_x : JMPTO : WS  => ?_ </wordStack>
+            <wordStack> ABI_y : ABI_x : _JMPTO : WS  => ?_ </wordStack>
             <localMem> _ </localMem>
             <pc> 7825 => ?_ </pc>
             <gas> VGas => ?_ </gas>
@@ -34,7 +34,7 @@ module DAI-ADDUU-FAIL-ROUGH-SPEC
             <callDepth> VCallDepth => ?_ </callDepth>
           </callState>
           <substate>
-            <selfDestruct> VSelfDestruct </selfDestruct>
+            <selfDestruct> _VSelfDestruct </selfDestruct>
             <log> _ => ?_ </log>
             <refund> _ => ?_ </refund>
           </substate>
@@ -50,7 +50,7 @@ module DAI-ADDUU-FAIL-ROUGH-SPEC
             <receiptsRoot> _ </receiptsRoot>
             <logsBloom> _ </logsBloom>
             <difficulty> _ </difficulty>
-            <number> BLOCK_NUMBER </number>
+            <number> _BLOCK_NUMBER </number>
             <gasLimit> _ </gasLimit>
             <gasUsed> _ </gasUsed>
             <timestamp> TIME </timestamp>
@@ -87,12 +87,12 @@ module DAI-ADDUU-FAIL-ROUGH-SPEC
 
                 _:Map
                </origStorage>
-              <nonce> Nonce_Dai => ?_ </nonce>
+              <nonce> _Nonce_Dai => ?_ </nonce>
             </account>
             <account>
               <acctID> 1 </acctID>
               <balance> ECREC_BAL </balance>
-              <code> .WordStack </code>
+              <code> .ByteArray </code>
               <storage> _:Map </storage>
               <origStorage> _ </origStorage>
               <nonce> _ </nonce>
@@ -100,7 +100,7 @@ module DAI-ADDUU-FAIL-ROUGH-SPEC
             <account>
               <acctID> 2 </acctID>
               <balance> SHA256_BAL </balance>
-              <code> .WordStack </code>
+              <code> .ByteArray </code>
               <storage> _:Map </storage>
               <origStorage> _ </origStorage>
               <nonce> _ </nonce>
@@ -108,7 +108,7 @@ module DAI-ADDUU-FAIL-ROUGH-SPEC
             <account>
               <acctID> 3 </acctID>
               <balance> RIP160_BAL </balance>
-              <code> .WordStack </code>
+              <code> .ByteArray </code>
               <storage> _:Map </storage>
               <origStorage> _ </origStorage>
               <nonce> _ </nonce>
@@ -116,7 +116,7 @@ module DAI-ADDUU-FAIL-ROUGH-SPEC
             <account>
               <acctID> 4 </acctID>
               <balance> ID_BAL </balance>
-              <code> .WordStack </code>
+              <code> .ByteArray </code>
               <storage> _:Map </storage>
               <origStorage> _ </origStorage>
               <nonce> _ </nonce>
@@ -124,7 +124,7 @@ module DAI-ADDUU-FAIL-ROUGH-SPEC
             <account>
               <acctID> 5 </acctID>
               <balance> MODEXP_BAL </balance>
-              <code> .WordStack </code>
+              <code> .ByteArray </code>
               <storage> _:Map </storage>
               <origStorage> _ </origStorage>
               <nonce> _ </nonce>
@@ -132,7 +132,7 @@ module DAI-ADDUU-FAIL-ROUGH-SPEC
             <account>
               <acctID> 6 </acctID>
               <balance> ECADD_BAL </balance>
-              <code> .WordStack </code>
+              <code> .ByteArray </code>
               <storage> _:Map </storage>
               <origStorage> _ </origStorage>
               <nonce> _ </nonce>
@@ -140,7 +140,7 @@ module DAI-ADDUU-FAIL-ROUGH-SPEC
             <account>
               <acctID> 7 </acctID>
               <balance> ECMUL_BAL </balance>
-              <code> .WordStack </code>
+              <code> .ByteArray </code>
               <storage> _:Map </storage>
               <origStorage> _ </origStorage>
               <nonce> _ </nonce>
@@ -148,7 +148,7 @@ module DAI-ADDUU-FAIL-ROUGH-SPEC
             <account>
               <acctID> 8 </acctID>
               <balance> ECPAIRING_BAL </balance>
-              <code> .WordStack </code>
+              <code> .ByteArray </code>
               <storage> _:Map </storage>
               <origStorage> _ </origStorage>
               <nonce> _ </nonce>
@@ -156,7 +156,7 @@ module DAI-ADDUU-FAIL-ROUGH-SPEC
             <account>
               <acctID> 9 </acctID>
               <balance> BLAKE2_BAL </balance>
-              <code> .WordStack </code>
+              <code> .ByteArray </code>
               <storage> _:Map </storage>
               <origStorage> _ </origStorage>
               <nonce> _ </nonce>

--- a/tests/specs/mcd/dai-adduu-fail-rough-spec.k
+++ b/tests/specs/mcd/dai-adduu-fail-rough-spec.k
@@ -1,0 +1,199 @@
+requires "verification.k"
+
+module DAI-ADDUU-FAIL-ROUGH-SPEC
+    imports VERIFICATION
+
+    // Dai_adduu
+    rule [Dai.adduu.fail.rough]:
+      <k> #execute ~> CONTINUATION => #halt ~> CONTINUATION </k>
+      <exit-code> 1 </exit-code>
+      <mode> NORMAL </mode>
+      <schedule> ISTANBUL </schedule>
+      <ethereum>
+        <evm>
+          <output> _ => ?_ </output>
+          <statusCode> _ => ?FAILURE:EndStatusCode </statusCode>
+          <endPC> _ => ?_ </endPC>
+          <callStack> VCallStack </callStack>
+          <interimStates> _ </interimStates>
+          <touchedAccounts> _ => ?_ </touchedAccounts>
+          <callState>
+            <program> Dai_bin_runtime </program>
+            <jumpDests> #computeValidJumpDests(Dai_bin_runtime) </jumpDests>
+            <id> ACCT_ID </id>
+            <caller> CALLER_ID </caller>
+            <callData> _ => ?_ </callData>
+            <callValue> VCallValue </callValue>
+            <wordStack> ABI_y : ABI_x : JMPTO : WS  => ?_ </wordStack>
+            <localMem> _ </localMem>
+            <pc> 7825 => ?_ </pc>
+            <gas> VGas => ?_ </gas>
+            <memoryUsed> VMemoryUsed </memoryUsed>
+            <callGas> _ => ?_ </callGas>
+            <static> _ </static>
+            <callDepth> VCallDepth => ?_ </callDepth>
+          </callState>
+          <substate>
+            <selfDestruct> VSelfDestruct </selfDestruct>
+            <log> _ => ?_ </log>
+            <refund> _ => ?_ </refund>
+          </substate>
+          <gasPrice> _ </gasPrice>
+          <origin> ORIGIN_ID </origin>
+          <blockhashes> _ </blockhashes>
+          <block>
+            <previousHash> _ </previousHash>
+            <ommersHash> _ </ommersHash>
+            <coinbase> _ </coinbase>
+            <stateRoot> _ </stateRoot>
+            <transactionsRoot> _ </transactionsRoot>
+            <receiptsRoot> _ </receiptsRoot>
+            <logsBloom> _ </logsBloom>
+            <difficulty> _ </difficulty>
+            <number> BLOCK_NUMBER </number>
+            <gasLimit> _ </gasLimit>
+            <gasUsed> _ </gasUsed>
+            <timestamp> TIME </timestamp>
+            <extraData> _ </extraData>
+            <mixHash> _ </mixHash>
+            <blockNonce> _ </blockNonce>
+            <ommerBlockHeaders> _ </ommerBlockHeaders>
+          </block>
+        </evm>
+        <network>
+          <chainID> VChainId </chainID>
+          <activeAccounts> SetItem(ACCT_ID)
+          SetItem(1)
+          SetItem(2)
+          SetItem(3)
+          SetItem(4)
+          SetItem(5)
+          SetItem(6)
+          SetItem(7)
+          SetItem(8)
+          SetItem(9) _ </activeAccounts>
+          <accounts>
+            <account>
+              <acctID> ACCT_ID </acctID>
+              <balance> ACCT_ID_balance </balance>
+              <code> Dai_bin_runtime </code>
+              <storage>
+               .Map
+
+                _:Map
+               </storage>
+              <origStorage>
+               .Map
+
+                _:Map
+               </origStorage>
+              <nonce> Nonce_Dai => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> 1 </acctID>
+              <balance> ECREC_BAL </balance>
+              <code> .WordStack </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 2 </acctID>
+              <balance> SHA256_BAL </balance>
+              <code> .WordStack </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 3 </acctID>
+              <balance> RIP160_BAL </balance>
+              <code> .WordStack </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 4 </acctID>
+              <balance> ID_BAL </balance>
+              <code> .WordStack </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 5 </acctID>
+              <balance> MODEXP_BAL </balance>
+              <code> .WordStack </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 6 </acctID>
+              <balance> ECADD_BAL </balance>
+              <code> .WordStack </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 7 </acctID>
+              <balance> ECMUL_BAL </balance>
+              <code> .WordStack </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 8 </acctID>
+              <balance> ECPAIRING_BAL </balance>
+              <code> .WordStack </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 9 </acctID>
+              <balance> BLAKE2_BAL </balance>
+              <code> .WordStack </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+           ...
+          </accounts>
+          <txOrder> _ </txOrder>
+          <txPending> _ </txPending>
+          <messages> _ </messages>
+        </network>
+      </ethereum>
+    requires #rangeAddress(ACCT_ID)
+     andBool ACCT_ID =/=Int 0
+     andBool #notPrecompileAddress(ACCT_ID)
+     andBool #rangeAddress(CALLER_ID)
+     andBool #rangeAddress(ORIGIN_ID)
+     andBool #rangeUInt(256, TIME)
+     andBool #rangeUInt(256, ACCT_ID_balance)
+     andBool #rangeUInt(256, ECREC_BAL)
+     andBool #rangeUInt(256, SHA256_BAL)
+     andBool #rangeUInt(256, RIP160_BAL)
+     andBool #rangeUInt(256, ID_BAL)
+     andBool #rangeUInt(256, MODEXP_BAL)
+     andBool #rangeUInt(256, ECADD_BAL)
+     andBool #rangeUInt(256, ECMUL_BAL)
+     andBool #rangeUInt(256, ECPAIRING_BAL)
+     andBool #rangeUInt(256, BLAKE2_BAL)
+     andBool VCallDepth <=Int 1024
+     andBool #rangeUInt(256, VCallValue)
+     andBool #rangeUInt(256, VChainId)
+     andBool (#rangeUInt(256, ABI_x)
+     andBool (#rangeUInt(256, ABI_y)
+     andBool ((#sizeWordStack(WS) <=Int 100)
+     andBool (#rangeUInt(256, VMemoryUsed)
+     andBool (VGas >=Int 3000000)))))
+     andBool notBool ( ((#rangeUInt(256, ABI_x:Int +Int ABI_y:Int))) )
+
+     ensures ?FAILURE =/=K EVMC_SUCCESS
+
+endmodule

--- a/tests/specs/mcd/vat-deny-diff-fail-rough-spec.k
+++ b/tests/specs/mcd/vat-deny-diff-fail-rough-spec.k
@@ -14,7 +14,7 @@ module VAT-DENY-DIFF-FAIL-ROUGH-SPEC
           <output> _ => ?_ </output>
           <statusCode> _ => ?FAILURE:EndStatusCode </statusCode>
           <endPC> _ => ?_ </endPC>
-          <callStack> VCallStack </callStack>
+          <callStack> _VCallStack </callStack>
           <interimStates> _ </interimStates>
           <touchedAccounts> _ => ?_ </touchedAccounts>
           <callState>
@@ -25,7 +25,7 @@ module VAT-DENY-DIFF-FAIL-ROUGH-SPEC
             <callData> #abiCallData("deny", #address(ABI_usr)) ++ CD => ?_ </callData>
             <callValue> VCallValue </callValue>
             <wordStack> .WordStack => ?_ </wordStack>
-            <localMem> .Map => ?_ </localMem>
+            <localMem> .Memory => ?_ </localMem>
             <pc> 0 => ?_ </pc>
             <gas> VGas => ?_ </gas>
             <memoryUsed> 0 => ?_ </memoryUsed>
@@ -34,7 +34,7 @@ module VAT-DENY-DIFF-FAIL-ROUGH-SPEC
             <callDepth> VCallDepth => ?_ </callDepth>
           </callState>
           <substate>
-            <selfDestruct> VSelfDestruct </selfDestruct>
+            <selfDestruct> _VSelfDestruct </selfDestruct>
             <log> _ => ?_ </log>
             <refund> _ => ?_ </refund>
           </substate>
@@ -50,7 +50,7 @@ module VAT-DENY-DIFF-FAIL-ROUGH-SPEC
             <receiptsRoot> _ </receiptsRoot>
             <logsBloom> _ </logsBloom>
             <difficulty> _ </difficulty>
-            <number> BLOCK_NUMBER </number>
+            <number> _BLOCK_NUMBER </number>
             <gasLimit> _ </gasLimit>
             <gasUsed> _ </gasUsed>
             <timestamp> TIME </timestamp>
@@ -91,12 +91,12 @@ module VAT-DENY-DIFF-FAIL-ROUGH-SPEC
               [#Vat.live <- (Junk_3)]
                 _:Map
                </origStorage>
-              <nonce> Nonce_Vat => ?_ </nonce>
+              <nonce> _Nonce_Vat => ?_ </nonce>
             </account>
             <account>
               <acctID> 1 </acctID>
               <balance> ECREC_BAL </balance>
-              <code> .WordStack </code>
+              <code> .ByteArray </code>
               <storage> _:Map </storage>
               <origStorage> _ </origStorage>
               <nonce> _ </nonce>
@@ -104,7 +104,7 @@ module VAT-DENY-DIFF-FAIL-ROUGH-SPEC
             <account>
               <acctID> 2 </acctID>
               <balance> SHA256_BAL </balance>
-              <code> .WordStack </code>
+              <code> .ByteArray </code>
               <storage> _:Map </storage>
               <origStorage> _ </origStorage>
               <nonce> _ </nonce>
@@ -112,7 +112,7 @@ module VAT-DENY-DIFF-FAIL-ROUGH-SPEC
             <account>
               <acctID> 3 </acctID>
               <balance> RIP160_BAL </balance>
-              <code> .WordStack </code>
+              <code> .ByteArray </code>
               <storage> _:Map </storage>
               <origStorage> _ </origStorage>
               <nonce> _ </nonce>
@@ -120,7 +120,7 @@ module VAT-DENY-DIFF-FAIL-ROUGH-SPEC
             <account>
               <acctID> 4 </acctID>
               <balance> ID_BAL </balance>
-              <code> .WordStack </code>
+              <code> .ByteArray </code>
               <storage> _:Map </storage>
               <origStorage> _ </origStorage>
               <nonce> _ </nonce>
@@ -128,7 +128,7 @@ module VAT-DENY-DIFF-FAIL-ROUGH-SPEC
             <account>
               <acctID> 5 </acctID>
               <balance> MODEXP_BAL </balance>
-              <code> .WordStack </code>
+              <code> .ByteArray </code>
               <storage> _:Map </storage>
               <origStorage> _ </origStorage>
               <nonce> _ </nonce>
@@ -136,7 +136,7 @@ module VAT-DENY-DIFF-FAIL-ROUGH-SPEC
             <account>
               <acctID> 6 </acctID>
               <balance> ECADD_BAL </balance>
-              <code> .WordStack </code>
+              <code> .ByteArray </code>
               <storage> _:Map </storage>
               <origStorage> _ </origStorage>
               <nonce> _ </nonce>
@@ -144,7 +144,7 @@ module VAT-DENY-DIFF-FAIL-ROUGH-SPEC
             <account>
               <acctID> 7 </acctID>
               <balance> ECMUL_BAL </balance>
-              <code> .WordStack </code>
+              <code> .ByteArray </code>
               <storage> _:Map </storage>
               <origStorage> _ </origStorage>
               <nonce> _ </nonce>
@@ -152,7 +152,7 @@ module VAT-DENY-DIFF-FAIL-ROUGH-SPEC
             <account>
               <acctID> 8 </acctID>
               <balance> ECPAIRING_BAL </balance>
-              <code> .WordStack </code>
+              <code> .ByteArray </code>
               <storage> _:Map </storage>
               <origStorage> _ </origStorage>
               <nonce> _ </nonce>
@@ -160,7 +160,7 @@ module VAT-DENY-DIFF-FAIL-ROUGH-SPEC
             <account>
               <acctID> 9 </acctID>
               <balance> BLAKE2_BAL </balance>
-              <code> .WordStack </code>
+              <code> .ByteArray </code>
               <storage> _:Map </storage>
               <origStorage> _ </origStorage>
               <nonce> _ </nonce>

--- a/tests/specs/mcd/vat-deny-diff-fail-rough-spec.k
+++ b/tests/specs/mcd/vat-deny-diff-fail-rough-spec.k
@@ -1,0 +1,209 @@
+requires "verification.k"
+
+module VAT-DENY-DIFF-FAIL-ROUGH-SPEC
+  imports VERIFICATION
+
+    // Vat_deny-diff
+    rule [Vat.deny-diff.fail.rough]:
+      <k> #execute ~> CONTINUATION => #halt ~> CONTINUATION </k>
+      <exit-code> 1 </exit-code>
+      <mode> NORMAL </mode>
+      <schedule> ISTANBUL </schedule>
+      <ethereum>
+        <evm>
+          <output> _ => ?_ </output>
+          <statusCode> _ => ?FAILURE:EndStatusCode </statusCode>
+          <endPC> _ => ?_ </endPC>
+          <callStack> VCallStack </callStack>
+          <interimStates> _ </interimStates>
+          <touchedAccounts> _ => ?_ </touchedAccounts>
+          <callState>
+            <program> Vat_bin_runtime </program>
+            <jumpDests> #computeValidJumpDests(Vat_bin_runtime) </jumpDests>
+            <id> ACCT_ID </id>
+            <caller> CALLER_ID </caller>
+            <callData> #abiCallData("deny", #address(ABI_usr)) ++ CD => ?_ </callData>
+            <callValue> VCallValue </callValue>
+            <wordStack> .WordStack => ?_ </wordStack>
+            <localMem> .Map => ?_ </localMem>
+            <pc> 0 => ?_ </pc>
+            <gas> VGas => ?_ </gas>
+            <memoryUsed> 0 => ?_ </memoryUsed>
+            <callGas> _ => ?_ </callGas>
+            <static> false </static>
+            <callDepth> VCallDepth => ?_ </callDepth>
+          </callState>
+          <substate>
+            <selfDestruct> VSelfDestruct </selfDestruct>
+            <log> _ => ?_ </log>
+            <refund> _ => ?_ </refund>
+          </substate>
+          <gasPrice> _ </gasPrice>
+          <origin> ORIGIN_ID </origin>
+          <blockhashes> _ </blockhashes>
+          <block>
+            <previousHash> _ </previousHash>
+            <ommersHash> _ </ommersHash>
+            <coinbase> _ </coinbase>
+            <stateRoot> _ </stateRoot>
+            <transactionsRoot> _ </transactionsRoot>
+            <receiptsRoot> _ </receiptsRoot>
+            <logsBloom> _ </logsBloom>
+            <difficulty> _ </difficulty>
+            <number> BLOCK_NUMBER </number>
+            <gasLimit> _ </gasLimit>
+            <gasUsed> _ </gasUsed>
+            <timestamp> TIME </timestamp>
+            <extraData> _ </extraData>
+            <mixHash> _ </mixHash>
+            <blockNonce> _ </blockNonce>
+            <ommerBlockHeaders> _ </ommerBlockHeaders>
+          </block>
+        </evm>
+        <network>
+          <chainID> VChainId </chainID>
+          <activeAccounts> SetItem(ACCT_ID)
+          SetItem(1)
+          SetItem(2)
+          SetItem(3)
+          SetItem(4)
+          SetItem(5)
+          SetItem(6)
+          SetItem(7)
+          SetItem(8)
+          SetItem(9) _ </activeAccounts>
+          <accounts>
+            <account>
+              <acctID> ACCT_ID </acctID>
+              <balance> ACCT_ID_balance </balance>
+              <code> Vat_bin_runtime </code>
+              <storage>
+               .Map
+              [#Vat.wards[CALLER_ID] <- (May) => ?_]
+              [#Vat.wards[ABI_usr] <- (Junk_0) => ?_]
+              [#Vat.live <- (Live) => ?_]
+                _:Map
+               </storage>
+              <origStorage>
+               .Map
+              [#Vat.wards[CALLER_ID] <- (Junk_1)]
+              [#Vat.wards[ABI_usr] <- (Junk_2)]
+              [#Vat.live <- (Junk_3)]
+                _:Map
+               </origStorage>
+              <nonce> Nonce_Vat => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> 1 </acctID>
+              <balance> ECREC_BAL </balance>
+              <code> .WordStack </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 2 </acctID>
+              <balance> SHA256_BAL </balance>
+              <code> .WordStack </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 3 </acctID>
+              <balance> RIP160_BAL </balance>
+              <code> .WordStack </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 4 </acctID>
+              <balance> ID_BAL </balance>
+              <code> .WordStack </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 5 </acctID>
+              <balance> MODEXP_BAL </balance>
+              <code> .WordStack </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 6 </acctID>
+              <balance> ECADD_BAL </balance>
+              <code> .WordStack </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 7 </acctID>
+              <balance> ECMUL_BAL </balance>
+              <code> .WordStack </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 8 </acctID>
+              <balance> ECPAIRING_BAL </balance>
+              <code> .WordStack </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 9 </acctID>
+              <balance> BLAKE2_BAL </balance>
+              <code> .WordStack </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+           ...
+          </accounts>
+          <txOrder> _ </txOrder>
+          <txPending> _ </txPending>
+          <messages> _ </messages>
+        </network>
+      </ethereum>
+    requires #rangeAddress(ACCT_ID)
+    andBool ACCT_ID =/=Int 0
+    andBool #notPrecompileAddress(ACCT_ID)
+    andBool #rangeAddress(CALLER_ID)
+    andBool #rangeAddress(ORIGIN_ID)
+    andBool #rangeUInt(256, TIME)
+    andBool #rangeUInt(256, ACCT_ID_balance)
+    andBool #rangeUInt(256, ECREC_BAL)
+    andBool #rangeUInt(256, SHA256_BAL)
+    andBool #rangeUInt(256, RIP160_BAL)
+    andBool #rangeUInt(256, ID_BAL)
+    andBool #rangeUInt(256, MODEXP_BAL)
+    andBool #rangeUInt(256, ECADD_BAL)
+    andBool #rangeUInt(256, ECMUL_BAL)
+    andBool #rangeUInt(256, ECPAIRING_BAL)
+    andBool #rangeUInt(256, BLAKE2_BAL)
+    andBool VCallDepth <=Int 1024
+    andBool #rangeUInt(256, VCallValue)
+    andBool #rangeUInt(256, VChainId)
+
+    andBool (#rangeAddress(ABI_usr)
+    andBool (#rangeUInt(256, May)
+    andBool (#rangeUInt(256, Live)
+    andBool ((#sizeByteArray(CD) <=Int 1250000000)
+    andBool ((CALLER_ID =/=Int ABI_usr)
+    andBool (VGas >=Int 3000000
+    andBool (#rangeUInt(256, Junk_0)
+    andBool (#rangeUInt(256, Junk_1)
+    andBool (#rangeUInt(256, Junk_2)
+    andBool (#rangeUInt(256, Junk_3)))))))))))
+    andBool notBool ( ((May:Int ==Int 1) andBool ((Live:Int ==Int 1) andBool ((VCallValue:Int ==Int 0)))) )
+
+    ensures ?FAILURE =/=K EVMC_SUCCESS
+
+endmodule

--- a/tests/specs/mcd/verification.k
+++ b/tests/specs/mcd/verification.k
@@ -68,4 +68,11 @@ module VERIFICATION
 
     rule #sizeWordStack(WS, N) => #sizeWordStack(WS, 0) +Int N requires N =/=Int 0
 
+    // ### PERFORMANCE: vat-deny-diff-fail-rough
+    // 27.21m -> 3.16m
+
+    rule M:Memory [ K := (W : WS) ] => M [ K <- W ] [ K +Int 1 := WS ] requires 0 <=Int K
+    rule M:Memory [ K <- V ] [ K' <- V' ] => M [ K' <- V' ] [ K <- V ] requires K' <Int K
+    rule M:Memory [ K := BUF:ByteArray ] [ K' <- V' ] => M [ K' <- V' ] [ K := BUF ] requires K' <Int K orBool K +Int #sizeByteArray(BUF) <=Int K'
+
 endmodule

--- a/tests/specs/mcd/verification.k
+++ b/tests/specs/mcd/verification.k
@@ -77,8 +77,8 @@ module VERIFICATION
     // ### PERFORMANCE: vat-deny-diff-fail-rough
     // 27.21m -> 3.16m
 
-    rule M:Memory [ K := (W : WS) ] => M [ K <- W ] [ K +Int 1 := WS ] requires 0 <=Int K
-    rule M:Memory [ K <- V ] [ K' <- V' ] => M [ K' <- V' ] [ K <- V ] requires K' <Int K
-    rule M:Memory [ K := BUF:ByteArray ] [ K' <- V' ] => M [ K' <- V' ] [ K := BUF ] requires K' <Int K orBool K +Int #sizeByteArray(BUF) <=Int K'
+    rule M:Memory [ K := (W : WS) ]                   => M [ K <- W ] [ K +Int 1 := WS ] requires 0 <=Int K
+    rule M:Memory [ K <- V ] [ K' <- V' ]             => M [ K' <- V' ] [ K <- V ]       requires K' <Int K
+    rule M:Memory [ K := BUF:ByteArray ] [ K' <- V' ] => M [ K' <- V' ] [ K := BUF ]     requires K' <Int K orBool K +Int #sizeByteArray(BUF) <=Int K'
 
 endmodule

--- a/tests/specs/mcd/verification.k
+++ b/tests/specs/mcd/verification.k
@@ -63,4 +63,9 @@ module VERIFICATION
 
     rule notAddrMask &Int ADDR => 0 requires #rangeAddress(ADDR)
 
+    // ### PERFORMANCE: dai-adduu-fail-rough
+    // 99s -> 48s
+
+    rule #sizeWordStack(WS, N) => #sizeWordStack(WS, 0) +Int N requires N =/=Int 0
+
 endmodule

--- a/tests/specs/mcd/verification.k
+++ b/tests/specs/mcd/verification.k
@@ -44,6 +44,12 @@ module VERIFICATION
  // ----------------------------
     rule notAddrMask => 115792089237316195423570985007226406215939081747436879206741300988257197096960 [macro]
 
+    syntax Int ::= "#Wad" | "#Ray" | "#Rad"
+ // ---------------------------------------
+    rule #Wad => 1000000000000000000                            [macro]
+    rule #Ray => 1000000000000000000000000000                   [macro]
+    rule #Rad => 1000000000000000000000000000000000000000000000 [macro]
+
     // ### vat-move-diff
 
     rule (W0 : WS) [ 0     .. WIDTH ] => W0 : (WS [ 0 .. WIDTH -Int 1 ]) requires 0 <Int WIDTH


### PR DESCRIPTION
These two (already passing) proofs are added with the goal of improving performance across the entire K-DSS test-suite. The lemmas added reduce the size of terms which show up during execution, resulting in a nice performance boost.

Across my "fast" test-suite, of proofs which finish in 120s or less, the improvement dropped the overall runtime of the test-suite from 729s => 573s, and had this individual impact on each test (before this PR is log-fast-a722e43, and after this PR is 

```
 Test                           | after time | before time | (after/before) time
--------------------------------+------------+-------------+---------------------
 Dai_PERMIT_TYPEHASH_fail_rough | 46.45      | 82.76       | 0.5612614789753504
 Dai_name_fail_rough            | 46.46      | 77.7        | 0.5979407979407979
 Dai_symbol_fail_rough          | 47.85      | 83.23       | 0.5749128919860627
 Dai_decimals_fail_rough        | 48.11      | 79.67       | 0.603865947031505
 Dai_adduu_fail_rough           | 48.46      | 79.52       | 0.6094064386317908
 Dai_version_fail_rough         | 48.75      | 82.39       | 0.5916980216045636
 Jug_adduu_fail_rough           | 49.14      | 62.25       | 0.7893975903614457
 Pot_adduu_fail_rough           | 49.28      | 68.13       | 0.7233230588580656
 Spotter_muluu_fail_rough       | 50.41      | 61.53       | 0.8192751503331708
 DaiJoin_muluu_fail_rough       | 50.59      | 57.11       | 0.8858343547539836
 Pot_subuu_fail_rough           | 50.97      | 66.59       | 0.7654302447814987
 Dai_subuu_fail_rough           | 51.04      | 87.09       | 0.5860603972901596
 Pot_muluu_fail_rough           | 53.25      | 67.12       | 0.7933551847437424
 Dai_approve_fail_rough         | 57.47      | 90.63       | 0.6341167383868477
 Cat_muluu_fail_rough           | 62.29      | 77.65       | 0.8021893110109465
 Cat_vow_fail_rough             | 69.05      | 90.07       | 0.7666259575885422
 Jug_vat_fail_rough             | 69.65      | 81.89       | 0.8505312003907681
 DaiJoin_deny-diff_pass         | 70.09      | 76.52       | 0.9159696811291167
 Jug_vow_fail_rough             | 70.79      | 83.06       | 0.8522754635203468
 GemJoin_deny-diff_pass         | 71.23      | 80.52       | 0.8846249379036265
 Spotter_deny-diff_pass         | 71.48      | 82.12       | 0.8704335119337555
 Pot_vow_fail_rough             | 71.55      | 85.9        | 0.8329452852153666
 Jug_deny-diff_pass             | 72.11      | 85.03       | 0.8480536281312477
 Dai_deny-diff_pass             | 72.29      | 108.14      | 0.668485296837433
 Dai_allowance_pass             | 72.65      | 107.63      | 0.6749976772275389
 Pot_deny-diff_pass             | 73.24      | 90.81       | 0.8065191058253496
 Cat_vat_fail_rough             | 81.38      | 95.4        | 0.8530398322851152
 Cat_deny-diff_pass             | 83.66      | 97.73       | 0.8560319246904737
 Cat_wards_pass                 | 88.17      | 111.04      | 0.7940381844380403
 DaiJoin_wards_pass             | 88.42      | 93.87       | 0.9419409822094386
 DaiJoin_deny-same_pass         | 94.59      | 98.97       | 0.9557441648984542
 DaiJoin_rely-diff_pass_rough   | 102.89     | 109.65      | 0.9383492932056543
 Cat_deny-same_pass             | 104.29     | 119.73      | 0.8710431804894346
```

So we see that every proof sped up by some amount.