### PR TITLE
MKR regression tests: dai-symbol-pass

### DIFF
--- a/evm.md
+++ b/evm.md
@@ -1330,8 +1330,8 @@ The various `CALL*` (and other inter-contract control flow) operations will be d
 
 ```{.k .nobytes}
     rule #computeValidJumpDests(.WordStack, _, RESULT) => List2Set(RESULT)
-    rule #computeValidJumpDests(91 : WS, I, RESULT) => #computeValidJumpDests(WS, I +Int 1, ListItem(I) RESULT)
-    rule #computeValidJumpDests(W : WS, I, RESULT) => #computeValidJumpDests(#drop(#widthOpCode(W), W : WS), I +Int #widthOpCode(W), RESULT) requires W =/=Int 91
+    rule #computeValidJumpDests(91 : WS   , I, RESULT) => #computeValidJumpDests(WS                            , I +Int 1              , ListItem(I) RESULT)
+    rule #computeValidJumpDests( W : WS   , I, RESULT) => #computeValidJumpDests(#drop(#widthOpCode(W), W : WS), I +Int #widthOpCode(W),             RESULT) requires W =/=Int 91
 ```
 
 ```{.k .bytes}

--- a/kevm
+++ b/kevm
@@ -18,7 +18,7 @@ k_release_dir="${K_RELEASE:-$kevm_dir/deps/k/k-distribution/target/release/k}"
 export PATH="${defn_dir}/web3/build:$k_release_dir/lib/native/linux:$k_release_dir/lib/native/linux64:$k_release_dir/bin/:$PATH"
 export LD_LIBRARY_PATH="$k_release_dir/lib/native/linux64:$lib_dir:${LD_LIBRARY_PATH:-}"
 
-export K_OPTS="${K_OPTS:--Xmx16G -Xss500m}"
+export K_OPTS="${K_OPTS:--Xmx16G -Xss128m}"
 
 KLAB_OUT="${KLAB_OUT:-$build_dir/klab}"
 KLAB_NODE_STACK_SIZE="${KLAB_NODE_STACK_SIZE:-300000}"

--- a/kevm
+++ b/kevm
@@ -18,7 +18,7 @@ k_release_dir="${K_RELEASE:-$kevm_dir/deps/k/k-distribution/target/release/k}"
 export PATH="${defn_dir}/web3/build:$k_release_dir/lib/native/linux:$k_release_dir/lib/native/linux64:$k_release_dir/bin/:$PATH"
 export LD_LIBRARY_PATH="$k_release_dir/lib/native/linux64:$lib_dir:${LD_LIBRARY_PATH:-}"
 
-export K_OPTS="${K_OPTS:--Xmx16G -Xss4m}"
+export K_OPTS="${K_OPTS:--Xmx16G -Xss500m}"
 
 KLAB_OUT="${KLAB_OUT:-$build_dir/klab}"
 KLAB_NODE_STACK_SIZE="${KLAB_NODE_STACK_SIZE:-300000}"

--- a/kevm
+++ b/kevm
@@ -18,7 +18,7 @@ k_release_dir="${K_RELEASE:-$kevm_dir/deps/k/k-distribution/target/release/k}"
 export PATH="${defn_dir}/web3/build:$k_release_dir/lib/native/linux:$k_release_dir/lib/native/linux64:$k_release_dir/bin/:$PATH"
 export LD_LIBRARY_PATH="$k_release_dir/lib/native/linux64:$lib_dir:${LD_LIBRARY_PATH:-}"
 
-export K_OPTS="${K_OPTS:--Xmx16G -Xss128m}"
+export K_OPTS="${K_OPTS:--Xmx16G -Xss512m}"
 
 KLAB_OUT="${KLAB_OUT:-$build_dir/klab}"
 KLAB_NODE_STACK_SIZE="${KLAB_NODE_STACK_SIZE:-300000}"

--- a/kevm
+++ b/kevm
@@ -18,10 +18,6 @@ k_release_dir="${K_RELEASE:-$kevm_dir/deps/k/k-distribution/target/release/k}"
 export PATH="${defn_dir}/web3/build:$k_release_dir/lib/native/linux:$k_release_dir/lib/native/linux64:$k_release_dir/bin/:$PATH"
 export LD_LIBRARY_PATH="$k_release_dir/lib/native/linux64:$lib_dir:${LD_LIBRARY_PATH:-}"
 
-test_logs="$build_dir/logs"
-mkdir -p "$test_logs"
-test_log="$test_logs/tests.log"
-
 KLAB_OUT="${KLAB_OUT:-$build_dir/klab}"
 KLAB_NODE_STACK_SIZE="${KLAB_NODE_STACK_SIZE:-300000}"
 export KLAB_OUT

--- a/kevm
+++ b/kevm
@@ -61,7 +61,7 @@ run_prove() {
     ! $repl       || additional_proof_args+=(--debugger --debug-script kast.kscript)
     ! $bug_report || additional_proof_args+=(--haskell-backend-command "kore-exec --bug-report kevm-bug")
 
-    export K_OPTS=${K_OPTS:--Xmx16G}
+    export K_OPTS="${K_OPTS:--Xmx16G -Xss500m}"
     ! $debug || set -x
     kprove --directory "$backend_dir" "$run_file" --def-module "$def_module" "${additional_proof_args[@]}" "$@"
 }

--- a/kevm
+++ b/kevm
@@ -18,6 +18,8 @@ k_release_dir="${K_RELEASE:-$kevm_dir/deps/k/k-distribution/target/release/k}"
 export PATH="${defn_dir}/web3/build:$k_release_dir/lib/native/linux:$k_release_dir/lib/native/linux64:$k_release_dir/bin/:$PATH"
 export LD_LIBRARY_PATH="$k_release_dir/lib/native/linux64:$lib_dir:${LD_LIBRARY_PATH:-}"
 
+export K_OPTS="${K_OPTS:--Xmx16G -Xss4m}"
+
 KLAB_OUT="${KLAB_OUT:-$build_dir/klab}"
 KLAB_NODE_STACK_SIZE="${KLAB_NODE_STACK_SIZE:-300000}"
 export KLAB_OUT
@@ -28,7 +30,6 @@ export KLAB_OUT
 # User Commands
 
 run_krun() {
-    export K_OPTS=-Xss500m
     krun --directory "$backend_dir"                                      \
         -cSCHEDULE="$cSCHEDULE"                   -pSCHEDULE='printf %s' \
         -cMODE="$cMODE"                           -pMODE='printf %s'     \
@@ -57,7 +58,6 @@ run_prove() {
     ! $repl       || additional_proof_args+=(--debugger --debug-script kast.kscript)
     ! $bug_report || additional_proof_args+=(--haskell-backend-command "kore-exec --bug-report kevm-bug")
 
-    export K_OPTS="${K_OPTS:--Xmx16G -Xss500m}"
     ! $debug || set -x
     kprove --directory "$backend_dir" "$run_file" --def-module "$def_module" "${additional_proof_args[@]}" "$@"
 }
@@ -65,7 +65,6 @@ run_prove() {
 run_search() {
     local search_pattern
     search_pattern="$1" ; shift
-    export K_OPTS=-Xmx8G
     run_krun --search --pattern "$search_pattern" "$@"
 }
 

--- a/tests/failing-symbolic.haskell
+++ b/tests/failing-symbolic.haskell
@@ -55,6 +55,7 @@ tests/specs/imp-specs/imp-specs-test-spec.k
 tests/specs/mcd/cat-exhaustiveness-spec.k
 tests/specs/mcd/cat-file-addr-pass-rough-spec.k
 tests/specs/mcd/dai-adduu-fail-rough-spec.k
+tests/specs/mcd/dai-symbol-pass-spec.k
 tests/specs/mcd/dstoken-approve-fail-rough-spec.k
 tests/specs/mcd/vat-deny-diff-fail-rough-spec.k
 tests/specs/mcd/vat-move-diff-spec.k

--- a/tests/specs/lemmas.k
+++ b/tests/specs/lemmas.k
@@ -84,44 +84,44 @@ module LEMMAS-JAVA [symbolic, kast]
     imports EDSL
     imports K-REFLECTION
 
-    rule BUF [ L .. _W ] => .ByteArray requires L >=Int #sizeByteArray(BUF)  [simplification]
+    rule BUF [ L .. _W ] => .ByteArray requires L >=Int #sizeByteArray(BUF)
 
-    rule #asWord( BUF => #drop(1, BUF) ) requires BUF [ 0 ] ==Int 0  [simplification]
+    rule #asWord( BUF => #drop(1, BUF) ) requires BUF [ 0 ] ==Int 0
 
-    rule #sizeByteArray(_W : WS)        => 1 +Int #sizeByteArray(WS)                      [simplification]
-    rule #sizeByteArray(#drop(N, BUF)) => maxInt(#sizeByteArray(BUF) -Int N, 0)           [simplification]
+    rule #sizeByteArray(_W : WS)       => 1 +Int #sizeByteArray(WS)
+    rule #sizeByteArray(#drop(N, BUF)) => maxInt(#sizeByteArray(BUF) -Int N, 0)
 
-    rule #take(N, BUF)           => BUF                                              requires N ==Int #sizeByteArray(BUF)   [simplification]
-    rule #take(N, BUF1 ++ _BUF2) => #take(N, BUF1)                                   requires N <=Int #sizeByteArray(BUF1)  [simplification]
-    rule #take(N, BUF1 ++  BUF2) => BUF1 ++ #take(N -Int #sizeByteArray(BUF1), BUF2) requires N  >Int #sizeByteArray(BUF1)  [simplification]
+    rule #take(N, BUF)           => BUF                                              requires N ==Int #sizeByteArray(BUF)
+    rule #take(N, BUF1 ++ _BUF2) => #take(N, BUF1)                                   requires N <=Int #sizeByteArray(BUF1)
+    rule #take(N, BUF1 ++  BUF2) => BUF1 ++ #take(N -Int #sizeByteArray(BUF1), BUF2) requires N  >Int #sizeByteArray(BUF1)
 
-    rule #drop(N, BUF)          => .ByteArray                               requires N >=Int #sizeByteArray(BUF)   [simplification]
-    rule #drop(N, BUF1 ++ BUF2) => #drop(N -Int #sizeByteArray(BUF1), BUF2) requires N >=Int #sizeByteArray(BUF1)  [simplification]
-    rule #drop(N, BUF1 ++ BUF2) => #drop(N, BUF1) ++ BUF2                   requires N  <Int #sizeByteArray(BUF1)  [simplification]
+    rule #drop(N, BUF)          => .ByteArray                               requires N >=Int #sizeByteArray(BUF)
+    rule #drop(N, BUF1 ++ BUF2) => #drop(N -Int #sizeByteArray(BUF1), BUF2) requires N >=Int #sizeByteArray(BUF1)
+    rule #drop(N, BUF1 ++ BUF2) => #drop(N, BUF1) ++ BUF2                   requires N  <Int #sizeByteArray(BUF1)
 
-    rule #asWord(#buf(_N, BUF)) => BUF  [simplification]
+    rule #asWord(#buf(_N, BUF)) => BUF
 
-    rule #asWord(BUF) /Int 26959946667150639794667015087019630673637144422540572481103610249216 => #asWord(#take(4, BUF))  [simplification]
+    rule #asWord(BUF) /Int 26959946667150639794667015087019630673637144422540572481103610249216 => #asWord(#take(4, BUF))
 
-    rule #range(_M, _N, K) => .ByteArray requires notBool K >Int 0  [simplification]
+    rule #range(_M, _N, K) => .ByteArray requires notBool K >Int 0
 
     rule #range(M [ N := BUF:ByteArray ], L, K) => #range(M, L, minInt(K, N -Int L)) ++ #range(M [ N := BUF ], N, K -Int minInt(K, N -Int L))
       requires K >Int 0
        andBool L <Int N
-      [simplification]
+
 
     rule #range(M [ N := BUF ], L, K) => BUF [ L -Int N .. minInt(K, #sizeByteArray(BUF) -Int (L -Int N)) ] ++ #range(M, N +Int #sizeByteArray(BUF), K -Int minInt(K, #sizeByteArray(BUF) -Int (L -Int N)))
       requires K  >Int 0
        andBool L >=Int N
        andBool L  <Int N +Int #sizeByteArray(BUF)
-      [simplification]
+
 
     rule #range(M [ N := BUF ], L, K) => #range(M, L, K)
       requires K  >Int 0
        andBool L >=Int N +Int #sizeByteArray(BUF)
-      [simplification]
 
-    rule keccak(BUF1 ++ BUF2) => hash2(#asWord(BUF1), #asWord(BUF2)) requires #sizeByteArray(BUF1) ==Int 32 andBool #sizeByteArray(BUF2) ==Int 32  [simplification]
+
+    rule keccak(BUF1 ++ BUF2) => hash2(#asWord(BUF1), #asWord(BUF2)) requires #sizeByteArray(BUF1) ==Int 32 andBool #sizeByteArray(BUF2) ==Int 32
 
     syntax Bool ::= #isRegularWordStack ( WordStack ) [function]
  // -------------------------------------------------------
@@ -133,11 +133,11 @@ module LEMMAS-JAVA [symbolic, kast]
       requires D ==Int 256 ^Int log256Int(D) andBool D >=Int 0
        andBool #sizeByteArray(WS) >=Int log256Int(D)
        andBool #noOverflow(WS)
-      [simplification]
+
 
     rule #buf(N, #asWord(WS)) => WS
       requires #noOverflow(WS) andBool N ==Int #sizeByteArray(WS)
-      [simplification]
+
 
     syntax Bool ::= #noOverflow    ( ByteArray ) [function]
                   | #noOverflowAux ( ByteArray ) [function]
@@ -162,98 +162,98 @@ module LEMMAS-JAVA [symbolic, kast]
        andBool 0 <=Int V2 andBool V2 <Int pow256
       [concrete]
 
-    rule keccakIntList(V:Int .IntList) => hash1(V)               [simplification]
-    rule keccakIntList(V1:Int V2:Int .IntList) => hash2(V1, V2)  [simplification]
+    rule keccakIntList(V:Int .IntList) => hash1(V)
+    rule keccakIntList(V1:Int V2:Int .IntList) => hash2(V1, V2)
 
     // for terms came from bytecode not via #hashedLocation
     rule keccak(WS) => keccakIntList(byteStack2IntList(WS))
       requires ( notBool #isConcrete(WS) )
        andBool ( #sizeByteArray(WS) ==Int 32 orBool #sizeByteArray(WS) ==Int 64 )
-      [simplification]
 
-    rule 1 *Int N => N  [simplification]
-    rule N *Int 1 => N  [simplification]
-    rule 0 *Int _ => 0  [simplification]
-    rule _ *Int 0 => 0  [simplification]
 
-    rule 0 |Int N => N  [simplification]
-    rule N |Int 0 => N  [simplification]
-    rule N |Int N => N  [simplification]
+    rule 1 *Int N => N
+    rule N *Int 1 => N
+    rule 0 *Int _ => 0
+    rule _ *Int 0 => 0
 
-    rule  0 &Int _N => 0  [simplification]
-    rule _N &Int  0 => 0  [simplification]
-    rule  N &Int  N => N  [simplification]
+    rule 0 |Int N => N
+    rule N |Int 0 => N
+    rule N |Int N => N
+
+    rule  0 &Int _N => 0
+    rule _N &Int  0 => 0
+    rule  N &Int  N => N
 
     //orienting symbolic term to be first, converting -Int to +Int for concrete values.
-    rule I +Int B => B          +Int I when #isConcrete(I) andBool notBool #isConcrete(B)  [simplification]
-    rule A -Int I => A +Int (0 -Int I) when notBool #isConcrete(A) andBool #isConcrete(I)  [simplification]
+    rule I +Int B => B          +Int I when #isConcrete(I) andBool notBool #isConcrete(B)
+    rule A -Int I => A +Int (0 -Int I) when notBool #isConcrete(A) andBool #isConcrete(I)
 
-    rule (A +Int I2) +Int I3 => A +Int (I2 +Int I3) when notBool #isConcrete(A) andBool #isConcrete(I2) andBool #isConcrete(I3)  [simplification]
+    rule (A +Int I2) +Int I3 => A +Int (I2 +Int I3) when notBool #isConcrete(A) andBool #isConcrete(I2) andBool #isConcrete(I3)
 
-    rule I1 +Int (B +Int I3) => B +Int (I1 +Int I3) when #isConcrete(I1) andBool notBool #isConcrete(B) andBool #isConcrete(I3)  [simplification]
-    rule I1 -Int (B +Int I3) => (I1 -Int I3) -Int B when #isConcrete(I1) andBool notBool #isConcrete(B) andBool #isConcrete(I3)  [simplification]
-    rule (I1 -Int B) +Int I3 => (I1 +Int I3) -Int B when #isConcrete(I1) andBool notBool #isConcrete(B) andBool #isConcrete(I3)  [simplification]
+    rule I1 +Int (B +Int I3) => B +Int (I1 +Int I3) when #isConcrete(I1) andBool notBool #isConcrete(B) andBool #isConcrete(I3)
+    rule I1 -Int (B +Int I3) => (I1 -Int I3) -Int B when #isConcrete(I1) andBool notBool #isConcrete(B) andBool #isConcrete(I3)
+    rule (I1 -Int B) +Int I3 => (I1 +Int I3) -Int B when #isConcrete(I1) andBool notBool #isConcrete(B) andBool #isConcrete(I3)
 
-    rule I1 +Int (I2 +Int C) => (I1 +Int I2) +Int C when #isConcrete(I1) andBool #isConcrete(I2) andBool notBool #isConcrete(C)  [simplification]
-    rule I1 +Int (I2 -Int C) => (I1 +Int I2) -Int C when #isConcrete(I1) andBool #isConcrete(I2) andBool notBool #isConcrete(C)  [simplification]
-    rule I1 -Int (I2 +Int C) => (I1 -Int I2) -Int C when #isConcrete(I1) andBool #isConcrete(I2) andBool notBool #isConcrete(C)  [simplification]
-    rule I1 -Int (I2 -Int C) => (I1 -Int I2) +Int C when #isConcrete(I1) andBool #isConcrete(I2) andBool notBool #isConcrete(C)  [simplification]
+    rule I1 +Int (I2 +Int C) => (I1 +Int I2) +Int C when #isConcrete(I1) andBool #isConcrete(I2) andBool notBool #isConcrete(C)
+    rule I1 +Int (I2 -Int C) => (I1 +Int I2) -Int C when #isConcrete(I1) andBool #isConcrete(I2) andBool notBool #isConcrete(C)
+    rule I1 -Int (I2 +Int C) => (I1 -Int I2) -Int C when #isConcrete(I1) andBool #isConcrete(I2) andBool notBool #isConcrete(C)
+    rule I1 -Int (I2 -Int C) => (I1 -Int I2) +Int C when #isConcrete(I1) andBool #isConcrete(I2) andBool notBool #isConcrete(C)
 
-    rule I1 &Int (I2 &Int C) => (I1 &Int I2) &Int C when #isConcrete(I1) andBool #isConcrete(I2) andBool notBool #isConcrete(C)  [simplification]
+    rule I1 &Int (I2 &Int C) => (I1 &Int I2) &Int C when #isConcrete(I1) andBool #isConcrete(I2) andBool notBool #isConcrete(C)
 
     // 0xffff...f &Int N = N
     rule MASK &Int N => N  requires MASK ==Int (2 ^Int (log2Int(MASK) +Int 1)) -Int 1 // MASK = 0xffff...f
                             andBool 0 <=Int N andBool N <=Int MASK
-      [simplification]
+
 
     // N &Int 0xffff...f = N
     rule N &Int MASK => N  requires MASK ==Int (2 ^Int (log2Int(MASK) +Int 1)) -Int 1 // MASK = 0xffff...f
                             andBool 0 <=Int N andBool N <=Int MASK
-      [simplification]
+
 
     // for gas calculation
-    rule A -Int (#if C #then B1 #else B2 #fi) => #if C #then (A -Int B1) #else (A -Int B2) #fi  [simplification]
+    rule A -Int (#if C #then B1 #else B2 #fi) => #if C #then (A -Int B1) #else (A -Int B2) #fi
 
-    rule (#if C #then B1 #else B2 #fi) +Int A => #if C #then (B1 +Int A) #else (B2 +Int A) #fi  [simplification]
+    rule (#if C #then B1 #else B2 #fi) +Int A => #if C #then (B1 +Int A) #else (B2 +Int A) #fi
 
-    rule bool2Word(A) |Int bool2Word(B) => bool2Word(A  orBool B)  [simplification]
-    rule bool2Word(A) &Int bool2Word(B) => bool2Word(A andBool B)  [simplification]
+    rule bool2Word(A) |Int bool2Word(B) => bool2Word(A  orBool B)
+    rule bool2Word(A) &Int bool2Word(B) => bool2Word(A andBool B)
 
-    rule 1 |Int bool2Word(_B) => 1             [simplification]
-    rule 1 &Int bool2Word( B) => bool2Word(B)  [simplification]
+    rule 1 |Int bool2Word(_B) => 1
+    rule 1 &Int bool2Word( B) => bool2Word(B)
 
-    rule bool2Word(_B) |Int 1 => 1             [simplification]
-    rule bool2Word( B) &Int 1 => bool2Word(B)  [simplification]
+    rule bool2Word(_B) |Int 1 => 1
+    rule bool2Word( B) &Int 1 => bool2Word(B)
 
-    rule bool2Word(A) =/=K 0 => A           [simplification]
-    rule bool2Word(A) =/=K 1 => notBool(A)  [simplification]
+    rule bool2Word(A) =/=K 0 => A
+    rule bool2Word(A) =/=K 1 => notBool(A)
 
-    rule 0 <=Int X &Int Y             => true requires 0 <=Int X andBool X <Int pow256 andBool 0 <=Int Y andBool Y <Int pow256  [simplification]
-    rule         X &Int Y <Int pow256 => true requires 0 <=Int X andBool X <Int pow256 andBool 0 <=Int Y andBool Y <Int pow256  [simplification]
+    rule 0 <=Int X &Int Y             => true requires 0 <=Int X andBool X <Int pow256 andBool 0 <=Int Y andBool Y <Int pow256
+    rule         X &Int Y <Int pow256 => true requires 0 <=Int X andBool X <Int pow256 andBool 0 <=Int Y andBool Y <Int pow256
 
-    rule 0 <=Int #asWord(_WS)         => true  [simplification]
-    rule #asWord(_WS) <Int pow256     => true  [simplification]
+    rule 0 <=Int #asWord(_WS)         => true
+    rule #asWord(_WS) <Int pow256     => true
 
-    rule 0 <=Int hash1(_)             => true  [simplification]
-    rule         hash1(_) <Int pow256 => true  [simplification]
+    rule 0 <=Int hash1(_)             => true
+    rule         hash1(_) <Int pow256 => true
 
-    rule 0 <=Int hash2(_,_)             => true  [simplification]
-    rule         hash2(_,_) <Int pow256 => true  [simplification]
+    rule 0 <=Int hash2(_,_)             => true
+    rule         hash2(_,_) <Int pow256 => true
 
-    rule 0 <=Int keccakIntList(_)             => true  [simplification]
-    rule         keccakIntList(_) <Int pow256 => true  [simplification]
+    rule 0 <=Int keccakIntList(_)             => true
+    rule         keccakIntList(_) <Int pow256 => true
 
-    rule X <=Int maxUInt256 => X <Int pow256  [simplification]
-    rule X <=Int maxUInt160 => X <Int pow160  [simplification]
-    rule X <=Int 255        => X <Int 256     [simplification]
+    rule X <=Int maxUInt256 => X <Int pow256
+    rule X <=Int maxUInt160 => X <Int pow160
+    rule X <=Int 255        => X <Int 256
 
     //Simplification of bool2Word() ==Int CONCRETE, #buf() ==K CONCRETE
-    rule I                   ==K bool2Word( B:Bool ) => bool2Word(B) ==Int I    requires #isConcrete(I)  [simplification]
-    rule bool2Word( B:Bool ) ==K I                   => B ==K word2Bool(I)      requires #isConcrete(I)  [simplification]
+    rule I                   ==K bool2Word( B:Bool ) => bool2Word(B) ==Int I    requires #isConcrete(I)
+    rule bool2Word( B:Bool ) ==K I                   => B ==K word2Bool(I)      requires #isConcrete(I)
 
-    rule BA:ByteArray     ==K #buf( 32, DATA ) => #buf( 32, DATA ) ==K BA       requires #isConcrete(BA) [simplification]
+    rule BA:ByteArray     ==K #buf( 32, DATA ) => #buf( 32, DATA ) ==K BA       requires #isConcrete(BA)
     rule #buf( 32, DATA ) ==K BA:ByteArray     => DATA ==Int #asInteger(BA)
-      requires #sizeByteArray(BA) <=Int 32                                      andBool  #isConcrete(BA) [simplification]
+      requires #sizeByteArray(BA) <=Int 32                                      andBool  #isConcrete(BA)
 
 endmodule
 

--- a/tests/specs/lemmas.k
+++ b/tests/specs/lemmas.k
@@ -84,26 +84,26 @@ module LEMMAS-JAVA [symbolic, kast]
     imports EDSL
     imports K-REFLECTION
 
-    rule BUF [ L .. W ] => .ByteArray requires L >=Int #sizeByteArray(BUF)  [simplification]
+    rule BUF [ L .. _W ] => .ByteArray requires L >=Int #sizeByteArray(BUF)  [simplification]
 
     rule #asWord( BUF => #drop(1, BUF) ) requires BUF [ 0 ] ==Int 0  [simplification]
 
-    rule #sizeByteArray(W : WS)        => 1 +Int #sizeByteArray(WS)                       [simplification]
+    rule #sizeByteArray(_W : WS)        => 1 +Int #sizeByteArray(WS)                      [simplification]
     rule #sizeByteArray(#drop(N, BUF)) => maxInt(#sizeByteArray(BUF) -Int N, 0)           [simplification]
 
-    rule #take(N, BUF)          => BUF                                              requires N ==Int #sizeByteArray(BUF)   [simplification]
-    rule #take(N, BUF1 ++ BUF2) => #take(N, BUF1)                                   requires N <=Int #sizeByteArray(BUF1)  [simplification]
-    rule #take(N, BUF1 ++ BUF2) => BUF1 ++ #take(N -Int #sizeByteArray(BUF1), BUF2) requires N  >Int #sizeByteArray(BUF1)  [simplification]
+    rule #take(N, BUF)           => BUF                                              requires N ==Int #sizeByteArray(BUF)   [simplification]
+    rule #take(N, BUF1 ++ _BUF2) => #take(N, BUF1)                                   requires N <=Int #sizeByteArray(BUF1)  [simplification]
+    rule #take(N, BUF1 ++  BUF2) => BUF1 ++ #take(N -Int #sizeByteArray(BUF1), BUF2) requires N  >Int #sizeByteArray(BUF1)  [simplification]
 
     rule #drop(N, BUF)          => .ByteArray                               requires N >=Int #sizeByteArray(BUF)   [simplification]
     rule #drop(N, BUF1 ++ BUF2) => #drop(N -Int #sizeByteArray(BUF1), BUF2) requires N >=Int #sizeByteArray(BUF1)  [simplification]
     rule #drop(N, BUF1 ++ BUF2) => #drop(N, BUF1) ++ BUF2                   requires N  <Int #sizeByteArray(BUF1)  [simplification]
 
-    rule #asWord(#buf(N, BUF)) => BUF  [simplification]
+    rule #asWord(#buf(_N, BUF)) => BUF  [simplification]
 
     rule #asWord(BUF) /Int 26959946667150639794667015087019630673637144422540572481103610249216 => #asWord(#take(4, BUF))  [simplification]
 
-    rule #range(M, N, K) => .ByteArray requires notBool K >Int 0  [simplification]
+    rule #range(_M, _N, K) => .ByteArray requires notBool K >Int 0  [simplification]
 
     rule #range(M [ N := BUF:ByteArray ], L, K) => #range(M, L, minInt(K, N -Int L)) ++ #range(M [ N := BUF ], N, K -Int minInt(K, N -Int L))
       requires K >Int 0
@@ -125,7 +125,7 @@ module LEMMAS-JAVA [symbolic, kast]
 
     syntax Bool ::= #isRegularWordStack ( WordStack ) [function]
  // -------------------------------------------------------
-    rule #isRegularWordStack(N : WS => WS)
+    rule #isRegularWordStack(_N : WS => WS)
     rule #isRegularWordStack(.WordStack) => true
 
     // for Solidity
@@ -180,9 +180,9 @@ module LEMMAS-JAVA [symbolic, kast]
     rule N |Int 0 => N  [simplification]
     rule N |Int N => N  [simplification]
 
-    rule 0 &Int N => 0  [simplification]
-    rule N &Int 0 => 0  [simplification]
-    rule N &Int N => N  [simplification]
+    rule  0 &Int _N => 0  [simplification]
+    rule _N &Int  0 => 0  [simplification]
+    rule  N &Int  N => N  [simplification]
 
     //orienting symbolic term to be first, converting -Int to +Int for concrete values.
     rule I +Int B => B          +Int I when #isConcrete(I) andBool notBool #isConcrete(B)  [simplification]
@@ -219,11 +219,11 @@ module LEMMAS-JAVA [symbolic, kast]
     rule bool2Word(A) |Int bool2Word(B) => bool2Word(A  orBool B)  [simplification]
     rule bool2Word(A) &Int bool2Word(B) => bool2Word(A andBool B)  [simplification]
 
-    rule 1 |Int bool2Word(B) => 1             [simplification]
-    rule 1 &Int bool2Word(B) => bool2Word(B)  [simplification]
+    rule 1 |Int bool2Word(_B) => 1             [simplification]
+    rule 1 &Int bool2Word( B) => bool2Word(B)  [simplification]
 
-    rule bool2Word(B) |Int 1 => 1             [simplification]
-    rule bool2Word(B) &Int 1 => bool2Word(B)  [simplification]
+    rule bool2Word(_B) |Int 1 => 1             [simplification]
+    rule bool2Word( B) &Int 1 => bool2Word(B)  [simplification]
 
     rule bool2Word(A) =/=K 0 => A           [simplification]
     rule bool2Word(A) =/=K 1 => notBool(A)  [simplification]
@@ -231,8 +231,8 @@ module LEMMAS-JAVA [symbolic, kast]
     rule 0 <=Int X &Int Y             => true requires 0 <=Int X andBool X <Int pow256 andBool 0 <=Int Y andBool Y <Int pow256  [simplification]
     rule         X &Int Y <Int pow256 => true requires 0 <=Int X andBool X <Int pow256 andBool 0 <=Int Y andBool Y <Int pow256  [simplification]
 
-    rule 0 <=Int #asWord(WS)          => true  [simplification]
-    rule #asWord(WS) <Int pow256      => true  [simplification]
+    rule 0 <=Int #asWord(_WS)         => true  [simplification]
+    rule #asWord(_WS) <Int pow256     => true  [simplification]
 
     rule 0 <=Int hash1(_)             => true  [simplification]
     rule         hash1(_) <Int pow256 => true  [simplification]

--- a/tests/specs/mcd/dai-symbol-pass-spec.k
+++ b/tests/specs/mcd/dai-symbol-pass-spec.k
@@ -14,7 +14,7 @@ module DAI-SYMBOL-PASS-SPEC
           <output> _ => #asByteStackInWidthaux(32, 31, 32, #enc(#string("DAI"))) </output>
           <statusCode> _ => EVMC_SUCCESS </statusCode>
           <endPC> _ => ?_ </endPC>
-          <callStack> VCallStack </callStack>
+          <callStack> _VCallStack </callStack>
           <interimStates> _ </interimStates>
           <touchedAccounts> _ => ?_ </touchedAccounts>
           <callState>
@@ -25,7 +25,7 @@ module DAI-SYMBOL-PASS-SPEC
             <callData> #abiCallData("symbol", .TypedArgs) ++ CD => ?_ </callData>
             <callValue> VCallValue </callValue>
             <wordStack> .WordStack => ?_ </wordStack>
-            <localMem> .Map => ?_ </localMem>
+            <localMem> .Memory => ?_ </localMem>
             <pc> 0 => ?_ </pc>
             <gas> VGas => VGas -Int (672) </gas>
             <memoryUsed> 0 => ?_ </memoryUsed>
@@ -34,7 +34,7 @@ module DAI-SYMBOL-PASS-SPEC
             <callDepth> VCallDepth </callDepth>
           </callState>
           <substate>
-            <selfDestruct> VSelfDestruct </selfDestruct>
+            <selfDestruct> _VSelfDestruct </selfDestruct>
             <log> _ => ?_ </log>
             <refund> _ => ?_ </refund>
           </substate>
@@ -50,7 +50,7 @@ module DAI-SYMBOL-PASS-SPEC
             <receiptsRoot> _ </receiptsRoot>
             <logsBloom> _ </logsBloom>
             <difficulty> _ </difficulty>
-            <number> BLOCK_NUMBER </number>
+            <number> _BLOCK_NUMBER </number>
             <gasLimit> _ </gasLimit>
             <gasUsed> _ </gasUsed>
             <timestamp> TIME </timestamp>
@@ -87,12 +87,12 @@ module DAI-SYMBOL-PASS-SPEC
 
                 _:Map
                </origStorage>
-              <nonce> Nonce_Dai => ?_ </nonce>
+              <nonce> _Nonce_Dai => ?_ </nonce>
             </account>
             <account>
               <acctID> 1 </acctID>
               <balance> ECREC_BAL </balance>
-              <code> .WordStack </code>
+              <code> .ByteArray </code>
               <storage> _:Map </storage>
               <origStorage> _ </origStorage>
               <nonce> _ </nonce>
@@ -100,7 +100,7 @@ module DAI-SYMBOL-PASS-SPEC
             <account>
               <acctID> 2 </acctID>
               <balance> SHA256_BAL </balance>
-              <code> .WordStack </code>
+              <code> .ByteArray </code>
               <storage> _:Map </storage>
               <origStorage> _ </origStorage>
               <nonce> _ </nonce>
@@ -108,7 +108,7 @@ module DAI-SYMBOL-PASS-SPEC
             <account>
               <acctID> 3 </acctID>
               <balance> RIP160_BAL </balance>
-              <code> .WordStack </code>
+              <code> .ByteArray </code>
               <storage> _:Map </storage>
               <origStorage> _ </origStorage>
               <nonce> _ </nonce>
@@ -116,7 +116,7 @@ module DAI-SYMBOL-PASS-SPEC
             <account>
               <acctID> 4 </acctID>
               <balance> ID_BAL </balance>
-              <code> .WordStack </code>
+              <code> .ByteArray </code>
               <storage> _:Map </storage>
               <origStorage> _ </origStorage>
               <nonce> _ </nonce>
@@ -124,7 +124,7 @@ module DAI-SYMBOL-PASS-SPEC
             <account>
               <acctID> 5 </acctID>
               <balance> MODEXP_BAL </balance>
-              <code> .WordStack </code>
+              <code> .ByteArray </code>
               <storage> _:Map </storage>
               <origStorage> _ </origStorage>
               <nonce> _ </nonce>
@@ -132,7 +132,7 @@ module DAI-SYMBOL-PASS-SPEC
             <account>
               <acctID> 6 </acctID>
               <balance> ECADD_BAL </balance>
-              <code> .WordStack </code>
+              <code> .ByteArray </code>
               <storage> _:Map </storage>
               <origStorage> _ </origStorage>
               <nonce> _ </nonce>
@@ -140,7 +140,7 @@ module DAI-SYMBOL-PASS-SPEC
             <account>
               <acctID> 7 </acctID>
               <balance> ECMUL_BAL </balance>
-              <code> .WordStack </code>
+              <code> .ByteArray </code>
               <storage> _:Map </storage>
               <origStorage> _ </origStorage>
               <nonce> _ </nonce>
@@ -148,7 +148,7 @@ module DAI-SYMBOL-PASS-SPEC
             <account>
               <acctID> 8 </acctID>
               <balance> ECPAIRING_BAL </balance>
-              <code> .WordStack </code>
+              <code> .ByteArray </code>
               <storage> _:Map </storage>
               <origStorage> _ </origStorage>
               <nonce> _ </nonce>
@@ -156,7 +156,7 @@ module DAI-SYMBOL-PASS-SPEC
             <account>
               <acctID> 9 </acctID>
               <balance> BLAKE2_BAL </balance>
-              <code> .WordStack </code>
+              <code> .ByteArray </code>
               <storage> _:Map </storage>
               <origStorage> _ </origStorage>
               <nonce> _ </nonce>

--- a/tests/specs/mcd/dai-symbol-pass-spec.k
+++ b/tests/specs/mcd/dai-symbol-pass-spec.k
@@ -1,0 +1,194 @@
+requires "verification.k"
+
+module DAI-SYMBOL-PASS-SPEC
+  imports VERIFICATION
+
+    // Dai_symbol
+    rule [Dai.symbol.pass]:
+      <k> #execute ~> CONTINUATION => #halt ~> CONTINUATION </k>
+      <exit-code> 1 </exit-code>
+      <mode> NORMAL </mode>
+      <schedule> ISTANBUL </schedule>
+      <ethereum>
+        <evm>
+          <output> _ => #asByteStackInWidthaux(32, 31, 32, #enc(#string("DAI"))) </output>
+          <statusCode> _ => EVMC_SUCCESS </statusCode>
+          <endPC> _ => ?_ </endPC>
+          <callStack> VCallStack </callStack>
+          <interimStates> _ </interimStates>
+          <touchedAccounts> _ => ?_ </touchedAccounts>
+          <callState>
+            <program> Dai_bin_runtime </program>
+            <jumpDests> #computeValidJumpDests(Dai_bin_runtime) </jumpDests>
+            <id> ACCT_ID </id>
+            <caller> CALLER_ID </caller>
+            <callData> #abiCallData("symbol", .TypedArgs) ++ CD => ?_ </callData>
+            <callValue> VCallValue </callValue>
+            <wordStack> .WordStack => ?_ </wordStack>
+            <localMem> .Map => ?_ </localMem>
+            <pc> 0 => ?_ </pc>
+            <gas> VGas => VGas -Int (672) </gas>
+            <memoryUsed> 0 => ?_ </memoryUsed>
+            <callGas> _ => ?_ </callGas>
+            <static> _ </static>
+            <callDepth> VCallDepth </callDepth>
+          </callState>
+          <substate>
+            <selfDestruct> VSelfDestruct </selfDestruct>
+            <log> _ => ?_ </log>
+            <refund> _ => ?_ </refund>
+          </substate>
+          <gasPrice> _ </gasPrice>
+          <origin> ORIGIN_ID </origin>
+          <blockhashes> _ </blockhashes>
+          <block>
+            <previousHash> _ </previousHash>
+            <ommersHash> _ </ommersHash>
+            <coinbase> _ </coinbase>
+            <stateRoot> _ </stateRoot>
+            <transactionsRoot> _ </transactionsRoot>
+            <receiptsRoot> _ </receiptsRoot>
+            <logsBloom> _ </logsBloom>
+            <difficulty> _ </difficulty>
+            <number> BLOCK_NUMBER </number>
+            <gasLimit> _ </gasLimit>
+            <gasUsed> _ </gasUsed>
+            <timestamp> TIME </timestamp>
+            <extraData> _ </extraData>
+            <mixHash> _ </mixHash>
+            <blockNonce> _ </blockNonce>
+            <ommerBlockHeaders> _ </ommerBlockHeaders>
+          </block>
+        </evm>
+        <network>
+          <chainID> VChainId </chainID>
+          <activeAccounts> SetItem(ACCT_ID)
+          SetItem(1)
+          SetItem(2)
+          SetItem(3)
+          SetItem(4)
+          SetItem(5)
+          SetItem(6)
+          SetItem(7)
+          SetItem(8)
+          SetItem(9) _ </activeAccounts>
+          <accounts>
+            <account>
+              <acctID> ACCT_ID </acctID>
+              <balance> ACCT_ID_balance </balance>
+              <code> Dai_bin_runtime </code>
+              <storage>
+               .Map
+
+                _:Map
+               </storage>
+              <origStorage>
+               .Map
+
+                _:Map
+               </origStorage>
+              <nonce> Nonce_Dai => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> 1 </acctID>
+              <balance> ECREC_BAL </balance>
+              <code> .WordStack </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 2 </acctID>
+              <balance> SHA256_BAL </balance>
+              <code> .WordStack </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 3 </acctID>
+              <balance> RIP160_BAL </balance>
+              <code> .WordStack </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 4 </acctID>
+              <balance> ID_BAL </balance>
+              <code> .WordStack </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 5 </acctID>
+              <balance> MODEXP_BAL </balance>
+              <code> .WordStack </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 6 </acctID>
+              <balance> ECADD_BAL </balance>
+              <code> .WordStack </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 7 </acctID>
+              <balance> ECMUL_BAL </balance>
+              <code> .WordStack </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 8 </acctID>
+              <balance> ECPAIRING_BAL </balance>
+              <code> .WordStack </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 9 </acctID>
+              <balance> BLAKE2_BAL </balance>
+              <code> .WordStack </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+           ...
+          </accounts>
+          <txOrder> _ </txOrder>
+          <txPending> _ </txPending>
+          <messages> _ </messages>
+        </network>
+      </ethereum>
+    requires #rangeAddress(ACCT_ID)
+     andBool ACCT_ID =/=Int 0
+     andBool #notPrecompileAddress(ACCT_ID)
+     andBool #rangeAddress(CALLER_ID)
+     andBool #rangeAddress(ORIGIN_ID)
+     andBool #rangeUInt(256, TIME)
+     andBool #rangeUInt(256, ACCT_ID_balance)
+     andBool #rangeUInt(256, ECREC_BAL)
+     andBool #rangeUInt(256, SHA256_BAL)
+     andBool #rangeUInt(256, RIP160_BAL)
+     andBool #rangeUInt(256, ID_BAL)
+     andBool #rangeUInt(256, MODEXP_BAL)
+     andBool #rangeUInt(256, ECADD_BAL)
+     andBool #rangeUInt(256, ECMUL_BAL)
+     andBool #rangeUInt(256, ECPAIRING_BAL)
+     andBool #rangeUInt(256, BLAKE2_BAL)
+     andBool VCallDepth <=Int 1024
+     andBool #rangeUInt(256, VCallValue)
+     andBool #rangeUInt(256, VChainId)
+     andBool (#sizeByteArray(CD) <=Int 1250000000
+     andBool (2300 <Int VGas -Int (672)
+     andBool ((VCallValue ==Int 0))))
+
+endmodule

--- a/tests/specs/mcd/verification.k
+++ b/tests/specs/mcd/verification.k
@@ -9,7 +9,7 @@ module HASKELL-HASH2 [symbolic, kore]
  // -----------------------------------------
 endmodule
 
-module VERIFICATION
+module VERIFICATION-SYNTAX
     imports LEMMAS
     imports DSS-BIN-RUNTIME
     imports DSS-STORAGE
@@ -62,6 +62,11 @@ module VERIFICATION
  // ------------------------------------------------------------------------------------
     rule nthbyteof(V, I, N) => nthbyteof(V /Int 256, I, N -Int 1) when N  >Int (I +Int 1) [concrete]
     rule nthbyteof(V, I, N) =>           V modInt 256             when N ==Int (I +Int 1) [concrete]
+
+endmodule
+
+module VERIFICATION
+    imports VERIFICATION-SYNTAX
 
     // ### vat-move-diff
 

--- a/tests/specs/mcd/verification.k
+++ b/tests/specs/mcd/verification.k
@@ -50,6 +50,19 @@ module VERIFICATION
     rule #Ray => 1000000000000000000000000000                   [macro]
     rule #Rad => 1000000000000000000000000000000000000000000000 [macro]
 
+    syntax WordStack ::= #asByteStackInWidth    ( Int, Int )                 [function]
+                       | #asByteStackInWidthaux ( Int, Int, Int, WordStack ) [function]
+ // -----------------------------------------------------------------------------------
+    rule #asByteStackInWidth(X, N) => #asByteStackInWidthaux(X, N -Int 1, N, .WordStack)
+
+    rule #asByteStackInWidthaux(X, I, N, WS) => #asByteStackInWidthaux(X, I -Int 1, N, nthbyteof(X, I, N) : WS) when I >Int 0
+    rule #asByteStackInWidthaux(X, 0, N, WS) => nthbyteof(X, 0, N) : WS
+
+    syntax Int ::= nthbyteof ( Int , Int , Int ) [function, smtlib(smt_nthbyteof), proj]
+ // ------------------------------------------------------------------------------------
+    rule nthbyteof(V, I, N) => nthbyteof(V /Int 256, I, N -Int 1) when N  >Int (I +Int 1) [concrete]
+    rule nthbyteof(V, I, N) =>           V modInt 256             when N ==Int (I +Int 1) [concrete]
+
     // ### vat-move-diff
 
     rule (W0 : WS) [ 0     .. WIDTH ] => W0 : (WS [ 0 .. WIDTH -Int 1 ]) requires 0 <Int WIDTH

--- a/tests/specs/mcd/verification.k
+++ b/tests/specs/mcd/verification.k
@@ -3,7 +3,7 @@ requires "bin_runtime.k"
 requires "storage.k"
 
 module HASKELL-HASH2 [symbolic, kore]
-    imports EDSL
+    imports INT
 
     syntax Int ::= hash2(Int, Int) [function]
  // -----------------------------------------

--- a/tests/specs/mcd/verification.k
+++ b/tests/specs/mcd/verification.k
@@ -50,10 +50,10 @@ module VERIFICATION
     rule #Ray => 1000000000000000000000000000                   [macro]
     rule #Rad => 1000000000000000000000000000000000000000000000 [macro]
 
-    syntax WordStack ::= #asByteStackInWidth    ( Int, Int )                 [function]
-                       | #asByteStackInWidthaux ( Int, Int, Int, WordStack ) [function]
+    syntax ByteArray ::= #asByteStackInWidth    ( Int, Int )                 [function]
+                       | #asByteStackInWidthaux ( Int, Int, Int, ByteArray ) [function]
  // -----------------------------------------------------------------------------------
-    rule #asByteStackInWidth(X, N) => #asByteStackInWidthaux(X, N -Int 1, N, .WordStack)
+    rule #asByteStackInWidth(X, N) => #asByteStackInWidthaux(X, N -Int 1, N, .ByteArray)
 
     rule #asByteStackInWidthaux(X, I, N, WS) => #asByteStackInWidthaux(X, I -Int 1, N, nthbyteof(X, I, N) : WS) when I >Int 0
     rule #asByteStackInWidthaux(X, 0, N, WS) => nthbyteof(X, 0, N) : WS


### PR DESCRIPTION
This PR:

-   Adds the `asByteStackInWidth` abstraction (which uses the `nythbyteof` abstraction), which is used in 3 MKR rough proofs. 
-   Clears some of the warnings that have been popping up regarding variable names in `lemmas.k`, and removes the `simplification` attribute from Java-only lemmas.
-   Separates the MCD `VERIFICATION` module from a `VERIFICATION-SYNTAX` module.
-   Sets the `-Xss` stack size to 512m globally for Java, which is 4x the K default of 32m. Before we were setting 500m for `krun`, but nothing for kprove. This avoids the flaky infinite recursion we see with `#sizeWordStack` sometimes.