### PR TITLE
MKR regression tests: dstoken-transferfrom-fail-rough, dsvalue-read-pass, cat-ilks-pass, flipper-tau-pass, and end-subuu-pass

### DIFF
--- a/tests/failing-symbolic.haskell
+++ b/tests/failing-symbolic.haskell
@@ -60,6 +60,8 @@ tests/specs/mcd/dai-symbol-pass-spec.k
 tests/specs/mcd/dstoken-approve-fail-rough-spec.k
 tests/specs/mcd/dstoken-transferfrom-fail-rough-spec.k
 tests/specs/mcd/dsvalue-read-pass-spec.k
+tests/specs/mcd/end-subuu-pass-spec.k
+tests/specs/mcd/flipper-tau-pass-spec.k
 tests/specs/mcd/vat-deny-diff-fail-rough-spec.k
 tests/specs/mcd/vat-move-diff-spec.k
 tests/specs/opcodes/create-spec.k

--- a/tests/failing-symbolic.haskell
+++ b/tests/failing-symbolic.haskell
@@ -57,6 +57,7 @@ tests/specs/mcd/cat-file-addr-pass-rough-spec.k
 tests/specs/mcd/dai-adduu-fail-rough-spec.k
 tests/specs/mcd/dai-symbol-pass-spec.k
 tests/specs/mcd/dstoken-approve-fail-rough-spec.k
+tests/specs/mcd/dstoken-transferfrom-fail-rough-spec.k
 tests/specs/mcd/vat-deny-diff-fail-rough-spec.k
 tests/specs/mcd/vat-move-diff-spec.k
 tests/specs/opcodes/create-spec.k

--- a/tests/failing-symbolic.haskell
+++ b/tests/failing-symbolic.haskell
@@ -54,6 +54,7 @@ tests/specs/erc20/hkg/transfer-success-2-spec.k
 tests/specs/imp-specs/imp-specs-test-spec.k
 tests/specs/mcd/cat-exhaustiveness-spec.k
 tests/specs/mcd/cat-file-addr-pass-rough-spec.k
+tests/specs/mcd/cat-ilks-pass-spec.k
 tests/specs/mcd/dai-adduu-fail-rough-spec.k
 tests/specs/mcd/dai-symbol-pass-spec.k
 tests/specs/mcd/dstoken-approve-fail-rough-spec.k

--- a/tests/failing-symbolic.haskell
+++ b/tests/failing-symbolic.haskell
@@ -58,6 +58,7 @@ tests/specs/mcd/dai-adduu-fail-rough-spec.k
 tests/specs/mcd/dai-symbol-pass-spec.k
 tests/specs/mcd/dstoken-approve-fail-rough-spec.k
 tests/specs/mcd/dstoken-transferfrom-fail-rough-spec.k
+tests/specs/mcd/dsvalue-read-pass-spec.k
 tests/specs/mcd/vat-deny-diff-fail-rough-spec.k
 tests/specs/mcd/vat-move-diff-spec.k
 tests/specs/opcodes/create-spec.k

--- a/tests/specs/mcd/cat-ilks-pass-spec.k
+++ b/tests/specs/mcd/cat-ilks-pass-spec.k
@@ -14,7 +14,7 @@ module CAT-ILKS-PASS-SPEC
           <output> _ => #buf(32, Flip) ++ #buf(32, Chop) ++ #buf(32, Lump) </output>
           <statusCode> _ => EVMC_SUCCESS </statusCode>
           <endPC> _ => ?_ </endPC>
-          <callStack> VCallStack </callStack>
+          <callStack> _VCallStack </callStack>
           <interimStates> _ </interimStates>
           <touchedAccounts> _ => ?_ </touchedAccounts>
           <callState>
@@ -25,7 +25,7 @@ module CAT-ILKS-PASS-SPEC
             <callData> #abiCallData("ilks", #bytes32(ABI_ilk)) ++ CD => ?_ </callData>
             <callValue> VCallValue </callValue>
             <wordStack> .WordStack => ?_ </wordStack>
-            <localMem> .Map => ?_ </localMem>
+            <localMem> .Memory => ?_ </localMem>
             <pc> 0 => ?_ </pc>
             <gas> VGas => VGas -Int (2977) </gas>
             <memoryUsed> 0 => ?_ </memoryUsed>
@@ -34,7 +34,7 @@ module CAT-ILKS-PASS-SPEC
             <callDepth> VCallDepth </callDepth>
           </callState>
           <substate>
-            <selfDestruct> VSelfDestruct </selfDestruct>
+            <selfDestruct> _VSelfDestruct </selfDestruct>
             <log> _ => ?_ </log>
             <refund> _ => ?_ </refund>
           </substate>
@@ -50,7 +50,7 @@ module CAT-ILKS-PASS-SPEC
             <receiptsRoot> _ </receiptsRoot>
             <logsBloom> _ </logsBloom>
             <difficulty> _ </difficulty>
-            <number> BLOCK_NUMBER </number>
+            <number> _BLOCK_NUMBER </number>
             <gasLimit> _ </gasLimit>
             <gasUsed> _ </gasUsed>
             <timestamp> TIME </timestamp>
@@ -84,7 +84,7 @@ module CAT-ILKS-PASS-SPEC
             <account>
               <acctID> 1 </acctID>
               <balance> ECREC_BAL </balance>
-              <code> .WordStack </code>
+              <code> .ByteArray </code>
               <storage> _:Map </storage>
               <origStorage> _ </origStorage>
               <nonce> _ </nonce>
@@ -92,7 +92,7 @@ module CAT-ILKS-PASS-SPEC
             <account>
               <acctID> 2 </acctID>
               <balance> SHA256_BAL </balance>
-              <code> .WordStack </code>
+              <code> .ByteArray </code>
               <storage> _:Map </storage>
               <origStorage> _ </origStorage>
               <nonce> _ </nonce>
@@ -100,7 +100,7 @@ module CAT-ILKS-PASS-SPEC
             <account>
               <acctID> 3 </acctID>
               <balance> RIP160_BAL </balance>
-              <code> .WordStack </code>
+              <code> .ByteArray </code>
               <storage> _:Map </storage>
               <origStorage> _ </origStorage>
               <nonce> _ </nonce>
@@ -108,7 +108,7 @@ module CAT-ILKS-PASS-SPEC
             <account>
               <acctID> 4 </acctID>
               <balance> ID_BAL </balance>
-              <code> .WordStack </code>
+              <code> .ByteArray </code>
               <storage> _:Map </storage>
               <origStorage> _ </origStorage>
               <nonce> _ </nonce>
@@ -116,7 +116,7 @@ module CAT-ILKS-PASS-SPEC
             <account>
               <acctID> 5 </acctID>
               <balance> MODEXP_BAL </balance>
-              <code> .WordStack </code>
+              <code> .ByteArray </code>
               <storage> _:Map </storage>
               <origStorage> _ </origStorage>
               <nonce> _ </nonce>
@@ -124,7 +124,7 @@ module CAT-ILKS-PASS-SPEC
             <account>
               <acctID> 6 </acctID>
               <balance> ECADD_BAL </balance>
-              <code> .WordStack </code>
+              <code> .ByteArray </code>
               <storage> _:Map </storage>
               <origStorage> _ </origStorage>
               <nonce> _ </nonce>
@@ -132,7 +132,7 @@ module CAT-ILKS-PASS-SPEC
             <account>
               <acctID> 7 </acctID>
               <balance> ECMUL_BAL </balance>
-              <code> .WordStack </code>
+              <code> .ByteArray </code>
               <storage> _:Map </storage>
               <origStorage> _ </origStorage>
               <nonce> _ </nonce>
@@ -140,7 +140,7 @@ module CAT-ILKS-PASS-SPEC
             <account>
               <acctID> 8 </acctID>
               <balance> ECPAIRING_BAL </balance>
-              <code> .WordStack </code>
+              <code> .ByteArray </code>
               <storage> _:Map </storage>
               <origStorage> _ </origStorage>
               <nonce> _ </nonce>
@@ -148,7 +148,7 @@ module CAT-ILKS-PASS-SPEC
             <account>
               <acctID> 9 </acctID>
               <balance> BLAKE2_BAL </balance>
-              <code> .WordStack </code>
+              <code> .ByteArray </code>
               <storage> _:Map </storage>
               <origStorage> _ </origStorage>
               <nonce> _ </nonce>

--- a/tests/specs/mcd/cat-ilks-pass-spec.k
+++ b/tests/specs/mcd/cat-ilks-pass-spec.k
@@ -1,0 +1,207 @@
+requires "verification.k"
+
+module CAT-ILKS-PASS-SPEC
+  imports VERIFICATION
+
+    // Cat_ilks
+    rule [Cat.ilks.pass]:
+      <k> #execute ~> CONTINUATION => #halt ~> CONTINUATION </k>
+      <exit-code> 1 </exit-code>
+      <mode> NORMAL </mode>
+      <schedule> ISTANBUL </schedule>
+      <ethereum>
+        <evm>
+          <output> _ => #buf(32, Flip) ++ #buf(32, Chop) ++ #buf(32, Lump) </output>
+          <statusCode> _ => EVMC_SUCCESS </statusCode>
+          <endPC> _ => ?_ </endPC>
+          <callStack> VCallStack </callStack>
+          <interimStates> _ </interimStates>
+          <touchedAccounts> _ => ?_ </touchedAccounts>
+          <callState>
+            <program> Cat_bin_runtime </program>
+            <jumpDests> #computeValidJumpDests(Cat_bin_runtime) </jumpDests>
+            <id> ACCT_ID </id>
+            <caller> CALLER_ID </caller>
+            <callData> #abiCallData("ilks", #bytes32(ABI_ilk)) ++ CD => ?_ </callData>
+            <callValue> VCallValue </callValue>
+            <wordStack> .WordStack => ?_ </wordStack>
+            <localMem> .Map => ?_ </localMem>
+            <pc> 0 => ?_ </pc>
+            <gas> VGas => VGas -Int (2977) </gas>
+            <memoryUsed> 0 => ?_ </memoryUsed>
+            <callGas> _ => ?_ </callGas>
+            <static> _ </static>
+            <callDepth> VCallDepth </callDepth>
+          </callState>
+          <substate>
+            <selfDestruct> VSelfDestruct </selfDestruct>
+            <log> _ => ?_ </log>
+            <refund> _ => ?_ </refund>
+          </substate>
+          <gasPrice> _ </gasPrice>
+          <origin> ORIGIN_ID </origin>
+          <blockhashes> _ </blockhashes>
+          <block>
+            <previousHash> _ </previousHash>
+            <ommersHash> _ </ommersHash>
+            <coinbase> _ </coinbase>
+            <stateRoot> _ </stateRoot>
+            <transactionsRoot> _ </transactionsRoot>
+            <receiptsRoot> _ </receiptsRoot>
+            <logsBloom> _ </logsBloom>
+            <difficulty> _ </difficulty>
+            <number> BLOCK_NUMBER </number>
+            <gasLimit> _ </gasLimit>
+            <gasUsed> _ </gasUsed>
+            <timestamp> TIME </timestamp>
+            <extraData> _ </extraData>
+            <mixHash> _ </mixHash>
+            <blockNonce> _ </blockNonce>
+            <ommerBlockHeaders> _ </ommerBlockHeaders>
+          </block>
+        </evm>
+        <network>
+          <chainID> VChainId </chainID>
+          <activeAccounts> SetItem(ACCT_ID)
+          SetItem(1)
+          SetItem(2)
+          SetItem(3)
+          SetItem(4)
+          SetItem(5)
+          SetItem(6)
+          SetItem(7)
+          SetItem(8)
+          SetItem(9) _ </activeAccounts>
+          <accounts>
+            <account>
+              <acctID> ACCT_ID </acctID>
+              <balance> ACCT_ID_balance </balance>
+              <code> Cat_bin_runtime </code>
+              <storage>
+               .Map
+              [#Cat.ilks[ABI_ilk].flip <- (Flip) => Flip]
+              [#Cat.ilks[ABI_ilk].chop <- (Chop) => Chop]
+              [#Cat.ilks[ABI_ilk].lump <- (Lump) => Lump]
+                _:Map
+               </storage>
+              <origStorage>
+               .Map
+              [#Cat.ilks[ABI_ilk].flip <- (Junk_0)]
+              [#Cat.ilks[ABI_ilk].chop <- (Junk_1)]
+              [#Cat.ilks[ABI_ilk].lump <- (Junk_2)]
+                _:Map
+               </origStorage>
+              <nonce> Nonce_Cat => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> 1 </acctID>
+              <balance> ECREC_BAL </balance>
+              <code> .WordStack </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 2 </acctID>
+              <balance> SHA256_BAL </balance>
+              <code> .WordStack </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 3 </acctID>
+              <balance> RIP160_BAL </balance>
+              <code> .WordStack </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 4 </acctID>
+              <balance> ID_BAL </balance>
+              <code> .WordStack </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 5 </acctID>
+              <balance> MODEXP_BAL </balance>
+              <code> .WordStack </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 6 </acctID>
+              <balance> ECADD_BAL </balance>
+              <code> .WordStack </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 7 </acctID>
+              <balance> ECMUL_BAL </balance>
+              <code> .WordStack </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 8 </acctID>
+              <balance> ECPAIRING_BAL </balance>
+              <code> .WordStack </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 9 </acctID>
+              <balance> BLAKE2_BAL </balance>
+              <code> .WordStack </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+           ...
+          </accounts>
+          <txOrder> _ </txOrder>
+          <txPending> _ </txPending>
+          <messages> _ </messages>
+        </network>
+      </ethereum>
+    requires #rangeAddress(ACCT_ID)
+     andBool ACCT_ID =/=Int 0
+     andBool #notPrecompileAddress(ACCT_ID)
+     andBool #rangeAddress(CALLER_ID)
+     andBool #rangeAddress(ORIGIN_ID)
+     andBool #rangeUInt(256, TIME)
+     andBool #rangeUInt(256, ACCT_ID_balance)
+     andBool #rangeUInt(256, ECREC_BAL)
+     andBool #rangeUInt(256, SHA256_BAL)
+     andBool #rangeUInt(256, RIP160_BAL)
+     andBool #rangeUInt(256, ID_BAL)
+     andBool #rangeUInt(256, MODEXP_BAL)
+     andBool #rangeUInt(256, ECADD_BAL)
+     andBool #rangeUInt(256, ECMUL_BAL)
+     andBool #rangeUInt(256, ECPAIRING_BAL)
+     andBool #rangeUInt(256, BLAKE2_BAL)
+     andBool VCallDepth <=Int 1024
+     andBool #rangeUInt(256, VCallValue)
+     andBool #rangeUInt(256, VChainId)
+
+     andBool (#rangeBytes(32, ABI_ilk)
+     andBool (#rangeUInt(256, Chop)
+     andBool (#rangeAddress(Flip)
+     andBool (#rangeUInt(256, Lump)
+     andBool (#sizeByteArray(CD) <=Int 1250000000
+     andBool (#notPrecompileAddress(Flip)
+     andBool (2300 <Int VGas -Int (2977)
+     andBool (#rangeUInt(256, Junk_0)
+     andBool (#rangeUInt(256, Junk_1)
+     andBool (#rangeUInt(256, Junk_2)
+     andBool ((VCallValue ==Int 0))))))))))))
+
+endmodule

--- a/tests/specs/mcd/cat-ilks-pass-spec.k
+++ b/tests/specs/mcd/cat-ilks-pass-spec.k
@@ -195,8 +195,13 @@ module CAT-ILKS-PASS-SPEC
      andBool #lookup(ACCT_ID_STORAGE, #Cat.ilks[ABI_ilk].flip) ==Int Flip
      andBool #lookup(ACCT_ID_STORAGE, #Cat.ilks[ABI_ilk].chop) ==Int Chop
      andBool #lookup(ACCT_ID_STORAGE, #Cat.ilks[ABI_ilk].lump) ==Int Lump
+
      andBool #lookup(ACCT_ID_ORIG_STORAGE, #Cat.ilks[ABI_ilk].flip) ==Int Junk_0
      andBool #lookup(ACCT_ID_ORIG_STORAGE, #Cat.ilks[ABI_ilk].chop) ==Int Junk_1
      andBool #lookup(ACCT_ID_ORIG_STORAGE, #Cat.ilks[ABI_ilk].lump) ==Int Junk_2
+
+     andBool #Cat.ilks[ABI_ilk].flip =/=Int #Cat.ilks[ABI_ilk].chop
+     andBool #Cat.ilks[ABI_ilk].flip =/=Int #Cat.ilks[ABI_ilk].lump
+     andBool #Cat.ilks[ABI_ilk].chop =/=Int #Cat.ilks[ABI_ilk].lump
 
 endmodule

--- a/tests/specs/mcd/cat-ilks-pass-spec.k
+++ b/tests/specs/mcd/cat-ilks-pass-spec.k
@@ -77,21 +77,9 @@ module CAT-ILKS-PASS-SPEC
               <acctID> ACCT_ID </acctID>
               <balance> ACCT_ID_balance </balance>
               <code> Cat_bin_runtime </code>
-              <storage>
-               .Map
-              [#Cat.ilks[ABI_ilk].flip <- (Flip) => Flip]
-              [#Cat.ilks[ABI_ilk].chop <- (Chop) => Chop]
-              [#Cat.ilks[ABI_ilk].lump <- (Lump) => Lump]
-                _:Map
-               </storage>
-              <origStorage>
-               .Map
-              [#Cat.ilks[ABI_ilk].flip <- (Junk_0)]
-              [#Cat.ilks[ABI_ilk].chop <- (Junk_1)]
-              [#Cat.ilks[ABI_ilk].lump <- (Junk_2)]
-                _:Map
-               </origStorage>
-              <nonce> Nonce_Cat => ?_ </nonce>
+              <storage> ACCT_ID_STORAGE => ACCT_ID_STORAGE    </storage>
+              <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
+              <nonce> _Nonce_Cat => ?_ </nonce>
             </account>
             <account>
               <acctID> 1 </acctID>
@@ -203,5 +191,12 @@ module CAT-ILKS-PASS-SPEC
      andBool (#rangeUInt(256, Junk_1)
      andBool (#rangeUInt(256, Junk_2)
      andBool ((VCallValue ==Int 0))))))))))))
+
+     andBool #lookup(ACCT_ID_STORAGE, #Cat.ilks[ABI_ilk].flip) ==Int Flip
+     andBool #lookup(ACCT_ID_STORAGE, #Cat.ilks[ABI_ilk].chop) ==Int Chop
+     andBool #lookup(ACCT_ID_STORAGE, #Cat.ilks[ABI_ilk].lump) ==Int Lump
+     andBool #lookup(ACCT_ID_ORIG_STORAGE, #Cat.ilks[ABI_ilk].flip) ==Int Junk_0
+     andBool #lookup(ACCT_ID_ORIG_STORAGE, #Cat.ilks[ABI_ilk].chop) ==Int Junk_1
+     andBool #lookup(ACCT_ID_ORIG_STORAGE, #Cat.ilks[ABI_ilk].lump) ==Int Junk_2
 
 endmodule

--- a/tests/specs/mcd/dstoken-transferfrom-fail-rough-spec.k
+++ b/tests/specs/mcd/dstoken-transferfrom-fail-rough-spec.k
@@ -197,7 +197,7 @@ module DSTOKEN-TRANSFERFROM-FAIL-ROUGH-SPEC
      andBool (#rangeUInt(256, Junk_3)))))))))))))))))
      andBool notBool ( #rangeUInt(256, Gem_s:Int -Int ABI_wad:Int)
                andBool #rangeUInt(256, Gem_d:Int +Int ABI_wad:Int)
-               andBool ((Allowance:Int ==Int maxUInt256 orBool ABI_src:Int ==Int CALLER_ID:Int) orBool (ABI_wad:Int <=Int Allowance:Int))
+               andBool (Allowance:Int ==Int maxUInt256 orBool ABI_src:Int ==Int CALLER_ID:Int orBool ABI_wad:Int <=Int Allowance:Int)
                andBool VCallValue:Int ==Int 0
                andBool Stopped:Int ==Int 0
                      )

--- a/tests/specs/mcd/dstoken-transferfrom-fail-rough-spec.k
+++ b/tests/specs/mcd/dstoken-transferfrom-fail-rough-spec.k
@@ -77,22 +77,8 @@ module DSTOKEN-TRANSFERFROM-FAIL-ROUGH-SPEC
               <acctID> ACCT_ID </acctID>
               <balance> ACCT_ID_balance </balance>
               <code> DSToken_bin_runtime </code>
-              <storage>
-               .Map
-              [#DSToken.allowance[ABI_src][CALLER_ID] <- (Allowance) => ?_]
-              [#DSToken.balances[ABI_src] <- (Gem_s) => ?_]
-              [#DSToken.balances[ABI_dst] <- (Gem_d) => ?_]
-              [#DSToken.owner_stopped <- (#WordPackAddrUInt8(Owner, Stopped)) => ?_]
-                _:Map
-               </storage>
-              <origStorage>
-               .Map
-              [#DSToken.allowance[ABI_src][CALLER_ID] <- (Junk_0)]
-              [#DSToken.balances[ABI_src] <- (Junk_1)]
-              [#DSToken.balances[ABI_dst] <- (Junk_2)]
-              [#DSToken.owner_stopped <- (Junk_3)]
-                _:Map
-               </origStorage>
+              <storage> STORAGE => ?_STORAGE </storage>
+              <origStorage> ORIGSTORAGE </origStorage>
               <nonce> _Nonce_DSToken => ?_ </nonce>
             </account>
             <account>
@@ -215,6 +201,16 @@ module DSTOKEN-TRANSFERFROM-FAIL-ROUGH-SPEC
                andBool VCallValue:Int ==Int 0
                andBool Stopped:Int ==Int 0
                      )
+
+     andBool #lookup(STORAGE, #DSToken.allowance[ABI_src][CALLER_ID]) ==Int Allowance
+     andBool #lookup(STORAGE, #DSToken.balances[ABI_src]            ) ==Int Gem_s
+     andBool #lookup(STORAGE, #DSToken.balances[ABI_dst]            ) ==Int Gem_d
+     andBool #lookup(STORAGE, #DSToken.owner_stopped                ) ==Int #WordPackAddrUInt8(Owner, Stopped)
+
+     andBool #lookup(ORIGSTORAGE, #DSToken.allowance[ABI_src][CALLER_ID]) ==Int Junk_0
+     andBool #lookup(ORIGSTORAGE, #DSToken.balances[ABI_src]            ) ==Int Junk_1
+     andBool #lookup(ORIGSTORAGE, #DSToken.balances[ABI_dst]            ) ==Int Junk_2
+     andBool #lookup(ORIGSTORAGE, #DSToken.owner_stopped                ) ==Int Junk_3
 
      ensures ?FAILURE =/=K EVMC_SUCCESS
 

--- a/tests/specs/mcd/dstoken-transferfrom-fail-rough-spec.k
+++ b/tests/specs/mcd/dstoken-transferfrom-fail-rough-spec.k
@@ -209,7 +209,12 @@ module DSTOKEN-TRANSFERFROM-FAIL-ROUGH-SPEC
      andBool (#rangeUInt(256, Junk_1)
      andBool (#rangeUInt(256, Junk_2)
      andBool (#rangeUInt(256, Junk_3)))))))))))))))))
-     andBool notBool ( (((#rangeUInt(256, Gem_s:Int -Int ABI_wad:Int))) andBool (((#rangeUInt(256, Gem_d:Int +Int ABI_wad:Int))) andBool (((Allowance:Int ==Int maxUInt256 orBool ABI_src:Int ==Int CALLER_ID:Int) orBool (ABI_wad:Int <=Int Allowance:Int)) andBool ((VCallValue:Int ==Int 0) andBool ((Stopped:Int ==Int 0)))))) )
+     andBool notBool ( #rangeUInt(256, Gem_s:Int -Int ABI_wad:Int)
+               andBool #rangeUInt(256, Gem_d:Int +Int ABI_wad:Int)
+               andBool ((Allowance:Int ==Int maxUInt256 orBool ABI_src:Int ==Int CALLER_ID:Int) orBool (ABI_wad:Int <=Int Allowance:Int))
+               andBool VCallValue:Int ==Int 0
+               andBool Stopped:Int ==Int 0
+                     )
 
      ensures ?FAILURE =/=K EVMC_SUCCESS
 

--- a/tests/specs/mcd/dstoken-transferfrom-fail-rough-spec.k
+++ b/tests/specs/mcd/dstoken-transferfrom-fail-rough-spec.k
@@ -1,0 +1,216 @@
+requires "verification.k"
+
+module DSTOKEN-TRANSFERFROM-FAIL-ROUGH-SPEC
+    imports VERIFICATION
+
+    // DSToken_transferFrom
+    rule [DSToken.transferFrom.fail.rough]:
+      <k> #execute ~> CONTINUATION => #halt ~> CONTINUATION </k>
+      <exit-code> 1 </exit-code>
+      <mode> NORMAL </mode>
+      <schedule> ISTANBUL </schedule>
+      <ethereum>
+        <evm>
+          <output> _ => ?_ </output>
+          <statusCode> _ => ?FAILURE:EndStatusCode </statusCode>
+          <endPC> _ => ?_ </endPC>
+          <callStack> _VCallStack </callStack>
+          <interimStates> _ </interimStates>
+          <touchedAccounts> _ => ?_ </touchedAccounts>
+          <callState>
+            <program> DSToken_bin_runtime </program>
+            <jumpDests> #computeValidJumpDests(DSToken_bin_runtime) </jumpDests>
+            <id> ACCT_ID </id>
+            <caller> CALLER_ID </caller>
+            <callData> #abiCallData("transferFrom", #address(ABI_src), #address(ABI_dst), #uint256(ABI_wad)) ++ CD => ?_ </callData>
+            <callValue> VCallValue </callValue>
+            <wordStack> .WordStack => ?_ </wordStack>
+            <localMem> .Memory => ?_ </localMem>
+            <pc> 0 => ?_ </pc>
+            <gas> VGas => ?_ </gas>
+            <memoryUsed> 0 => ?_ </memoryUsed>
+            <callGas> _ => ?_ </callGas>
+            <static> false </static>
+            <callDepth> VCallDepth => ?_ </callDepth>
+          </callState>
+          <substate>
+            <selfDestruct> _VSelfDestruct </selfDestruct>
+            <log> _ => ?_ </log>
+            <refund> _ => ?_ </refund>
+          </substate>
+          <gasPrice> _ </gasPrice>
+          <origin> ORIGIN_ID </origin>
+          <blockhashes> _ </blockhashes>
+          <block>
+            <previousHash> _ </previousHash>
+            <ommersHash> _ </ommersHash>
+            <coinbase> _ </coinbase>
+            <stateRoot> _ </stateRoot>
+            <transactionsRoot> _ </transactionsRoot>
+            <receiptsRoot> _ </receiptsRoot>
+            <logsBloom> _ </logsBloom>
+            <difficulty> _ </difficulty>
+            <number> _BLOCK_NUMBER </number>
+            <gasLimit> _ </gasLimit>
+            <gasUsed> _ </gasUsed>
+            <timestamp> TIME </timestamp>
+            <extraData> _ </extraData>
+            <mixHash> _ </mixHash>
+            <blockNonce> _ </blockNonce>
+            <ommerBlockHeaders> _ </ommerBlockHeaders>
+          </block>
+        </evm>
+        <network>
+          <chainID> VChainId </chainID>
+          <activeAccounts> SetItem(ACCT_ID)
+          SetItem(1)
+          SetItem(2)
+          SetItem(3)
+          SetItem(4)
+          SetItem(5)
+          SetItem(6)
+          SetItem(7)
+          SetItem(8)
+          SetItem(9) _ </activeAccounts>
+          <accounts>
+            <account>
+              <acctID> ACCT_ID </acctID>
+              <balance> ACCT_ID_balance </balance>
+              <code> DSToken_bin_runtime </code>
+              <storage>
+               .Map
+              [#DSToken.allowance[ABI_src][CALLER_ID] <- (Allowance) => ?_]
+              [#DSToken.balances[ABI_src] <- (Gem_s) => ?_]
+              [#DSToken.balances[ABI_dst] <- (Gem_d) => ?_]
+              [#DSToken.owner_stopped <- (#WordPackAddrUInt8(Owner, Stopped)) => ?_]
+                _:Map
+               </storage>
+              <origStorage>
+               .Map
+              [#DSToken.allowance[ABI_src][CALLER_ID] <- (Junk_0)]
+              [#DSToken.balances[ABI_src] <- (Junk_1)]
+              [#DSToken.balances[ABI_dst] <- (Junk_2)]
+              [#DSToken.owner_stopped <- (Junk_3)]
+                _:Map
+               </origStorage>
+              <nonce> _Nonce_DSToken => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> 1 </acctID>
+              <balance> ECREC_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 2 </acctID>
+              <balance> SHA256_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 3 </acctID>
+              <balance> RIP160_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 4 </acctID>
+              <balance> ID_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 5 </acctID>
+              <balance> MODEXP_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 6 </acctID>
+              <balance> ECADD_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 7 </acctID>
+              <balance> ECMUL_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 8 </acctID>
+              <balance> ECPAIRING_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 9 </acctID>
+              <balance> BLAKE2_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+           ...
+          </accounts>
+          <txOrder> _ </txOrder>
+          <txPending> _ </txPending>
+          <messages> _ </messages>
+        </network>
+      </ethereum>
+    requires #rangeAddress(ACCT_ID)
+     andBool ACCT_ID =/=Int 0
+     andBool #notPrecompileAddress(ACCT_ID)
+     andBool #rangeAddress(CALLER_ID)
+     andBool #rangeAddress(ORIGIN_ID)
+     andBool #rangeUInt(256, TIME)
+     andBool #rangeUInt(256, ACCT_ID_balance)
+     andBool #rangeUInt(256, ECREC_BAL)
+     andBool #rangeUInt(256, SHA256_BAL)
+     andBool #rangeUInt(256, RIP160_BAL)
+     andBool #rangeUInt(256, ID_BAL)
+     andBool #rangeUInt(256, MODEXP_BAL)
+     andBool #rangeUInt(256, ECADD_BAL)
+     andBool #rangeUInt(256, ECMUL_BAL)
+     andBool #rangeUInt(256, ECPAIRING_BAL)
+     andBool #rangeUInt(256, BLAKE2_BAL)
+     andBool VCallDepth <=Int 1024
+     andBool #rangeUInt(256, VCallValue)
+     andBool #rangeUInt(256, VChainId)
+     andBool (#rangeAddress(ABI_src)
+     andBool (#rangeAddress(ABI_dst)
+     andBool (#rangeUInt(256, ABI_wad)
+     andBool (#rangeUInt(256, Gem_s)
+     andBool (#rangeUInt(256, Gem_d)
+     andBool (#rangeUInt(256, Allowance)
+     andBool (#rangeAddress(Owner)
+     andBool (#rangeBool(Stopped)
+     andBool ((#sizeByteArray(CD) <=Int 1250000000)
+     andBool ((#notPrecompileAddress(Owner))
+     andBool ((ABI_src =/=Int ABI_dst)
+     andBool (VGas >=Int 3000000
+     andBool (#rangeUInt(256, Junk_0)
+     andBool (#rangeUInt(256, Junk_1)
+     andBool (#rangeUInt(256, Junk_2)
+     andBool (#rangeUInt(256, Junk_3)))))))))))))))))
+     andBool notBool ( (((#rangeUInt(256, Gem_s:Int -Int ABI_wad:Int))) andBool (((#rangeUInt(256, Gem_d:Int +Int ABI_wad:Int))) andBool (((Allowance:Int ==Int maxUInt256 orBool ABI_src:Int ==Int CALLER_ID:Int) orBool (ABI_wad:Int <=Int Allowance:Int)) andBool ((VCallValue:Int ==Int 0) andBool ((Stopped:Int ==Int 0)))))) )
+
+     ensures ?FAILURE =/=K EVMC_SUCCESS
+
+endmodule

--- a/tests/specs/mcd/dstoken-transferfrom-fail-rough-spec.k
+++ b/tests/specs/mcd/dstoken-transferfrom-fail-rough-spec.k
@@ -212,6 +212,13 @@ module DSTOKEN-TRANSFERFROM-FAIL-ROUGH-SPEC
      andBool #lookup(ORIGSTORAGE, #DSToken.balances[ABI_dst]            ) ==Int Junk_2
      andBool #lookup(ORIGSTORAGE, #DSToken.owner_stopped                ) ==Int Junk_3
 
+     andBool #DSToken.allowance[ABI_src][CALLER_ID] =/=Int #DSToken.balances[ABI_src]
+     andBool #DSToken.allowance[ABI_src][CALLER_ID] =/=Int #DSToken.balances[ABI_dst]
+     andBool #DSToken.allowance[ABI_src][CALLER_ID] =/=Int #DSToken.owner_stopped
+     andBool #DSToken.balances[ABI_src]             =/=Int #DSToken.balances[ABI_dst]
+     andBool #DSToken.balances[ABI_src]             =/=Int #DSToken.owner_stopped
+     andBool #DSToken.balances[ABI_dst]             =/=Int #DSToken.owner_stopped
+
      ensures ?FAILURE =/=K EVMC_SUCCESS
 
 endmodule

--- a/tests/specs/mcd/dsvalue-read-pass-spec.k
+++ b/tests/specs/mcd/dsvalue-read-pass-spec.k
@@ -189,9 +189,13 @@ module DSVALUE-READ-PASS-SPEC
      andBool (#rangeUInt(256, Junk_1)
      andBool ((VCallValue ==Int 0)
      andBool ((Ok ==Int 1)))))))))))
-     andBool #lookup(ACCT_ID_STORAGE, 1) ==Int #WordPackAddrUInt8(Owner, Ok)
-     andBool #lookup(ACCT_ID_STORAGE, 2) ==Int Value
-     andBool #lookup(ACCT_ID_ORIG_STORAGE, 1) ==Int Junk_0
-     andBool #lookup(ACCT_ID_ORIG_STORAGE, 2) ==Int Junk_1
+
+     andBool #lookup(ACCT_ID_STORAGE, #DSValue.owner_has) ==Int #WordPackAddrUInt8(Owner, Ok)
+     andBool #lookup(ACCT_ID_STORAGE, #DSValue.val)       ==Int Value
+
+     andBool #lookup(ACCT_ID_ORIG_STORAGE, #DSValue.owner_has) ==Int Junk_0
+     andBool #lookup(ACCT_ID_ORIG_STORAGE, #DSValue.val)       ==Int Junk_1
+
+     andBool #DSValue.owner_has =/=Int #DSValue.val
 
 endmodule

--- a/tests/specs/mcd/dsvalue-read-pass-spec.k
+++ b/tests/specs/mcd/dsvalue-read-pass-spec.k
@@ -1,0 +1,197 @@
+requires "verification.k"
+
+module DSVALUE-READ-PASS-SPEC
+    imports VERIFICATION
+
+    // DSValue_read
+    rule [DSValue.read.pass]:
+      <k> #execute ~> CONTINUATION => #halt ~> CONTINUATION </k>
+      <exit-code> 1 </exit-code>
+      <mode> NORMAL </mode>
+      <schedule> ISTANBUL </schedule>
+      <ethereum>
+        <evm>
+          <output> _ => #buf(32, Value) </output>
+          <statusCode> _ => EVMC_SUCCESS </statusCode>
+          <endPC> _ => ?_ </endPC>
+          <callStack> _VCallStack </callStack>
+          <interimStates> _ </interimStates>
+          <touchedAccounts> _ => ?_ </touchedAccounts>
+          <callState>
+            <program> DSValue_bin_runtime </program>
+            <jumpDests> #computeValidJumpDests(DSValue_bin_runtime) </jumpDests>
+            <id> ACCT_ID </id>
+            <caller> CALLER_ID </caller>
+            <callData> #abiCallData("read", .TypedArgs) ++ CD => ?_ </callData>
+            <callValue> VCallValue </callValue>
+            <wordStack> .WordStack => ?_ </wordStack>
+            <localMem> .Memory => ?_ </localMem>
+            <pc> 0 => ?_ </pc>
+            <gas> VGas => VGas -Int (2043) </gas>
+            <memoryUsed> 0 => ?_ </memoryUsed>
+            <callGas> _ => ?_ </callGas>
+            <static> _ </static>
+            <callDepth> VCallDepth </callDepth>
+          </callState>
+          <substate>
+            <selfDestruct> _VSelfDestruct </selfDestruct>
+            <log> _ => ?_ </log>
+            <refund> _ => ?_ </refund>
+          </substate>
+          <gasPrice> _ </gasPrice>
+          <origin> ORIGIN_ID </origin>
+          <blockhashes> _ </blockhashes>
+          <block>
+            <previousHash> _ </previousHash>
+            <ommersHash> _ </ommersHash>
+            <coinbase> _ </coinbase>
+            <stateRoot> _ </stateRoot>
+            <transactionsRoot> _ </transactionsRoot>
+            <receiptsRoot> _ </receiptsRoot>
+            <logsBloom> _ </logsBloom>
+            <difficulty> _ </difficulty>
+            <number> _BLOCK_NUMBER </number>
+            <gasLimit> _ </gasLimit>
+            <gasUsed> _ </gasUsed>
+            <timestamp> TIME </timestamp>
+            <extraData> _ </extraData>
+            <mixHash> _ </mixHash>
+            <blockNonce> _ </blockNonce>
+            <ommerBlockHeaders> _ </ommerBlockHeaders>
+          </block>
+        </evm>
+        <network>
+          <chainID> VChainId </chainID>
+          <activeAccounts> SetItem(ACCT_ID)
+          SetItem(1)
+          SetItem(2)
+          SetItem(3)
+          SetItem(4)
+          SetItem(5)
+          SetItem(6)
+          SetItem(7)
+          SetItem(8)
+          SetItem(9) _ </activeAccounts>
+          <accounts>
+            <account>
+              <acctID> ACCT_ID </acctID>
+              <balance> ACCT_ID_balance </balance>
+              <code> DSValue_bin_runtime </code>
+              <storage> ACCT_ID_STORAGE => ACCT_ID_STORAGE  [ 2 <- Value ] </storage>
+              <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
+              <nonce> _Nonce_DSValue => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> 1 </acctID>
+              <balance> ECREC_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 2 </acctID>
+              <balance> SHA256_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 3 </acctID>
+              <balance> RIP160_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 4 </acctID>
+              <balance> ID_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 5 </acctID>
+              <balance> MODEXP_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 6 </acctID>
+              <balance> ECADD_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 7 </acctID>
+              <balance> ECMUL_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 8 </acctID>
+              <balance> ECPAIRING_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 9 </acctID>
+              <balance> BLAKE2_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+           ...
+          </accounts>
+          <txOrder> _ </txOrder>
+          <txPending> _ </txPending>
+          <messages> _ </messages>
+        </network>
+      </ethereum>
+    requires #rangeAddress(ACCT_ID)
+     andBool ACCT_ID =/=Int 0
+     andBool #notPrecompileAddress(ACCT_ID)
+     andBool #rangeAddress(CALLER_ID)
+     andBool #rangeAddress(ORIGIN_ID)
+     andBool #rangeUInt(256, TIME)
+     andBool #rangeUInt(256, ACCT_ID_balance)
+     andBool #rangeUInt(256, ECREC_BAL)
+     andBool #rangeUInt(256, SHA256_BAL)
+     andBool #rangeUInt(256, RIP160_BAL)
+     andBool #rangeUInt(256, ID_BAL)
+     andBool #rangeUInt(256, MODEXP_BAL)
+     andBool #rangeUInt(256, ECADD_BAL)
+     andBool #rangeUInt(256, ECMUL_BAL)
+     andBool #rangeUInt(256, ECPAIRING_BAL)
+     andBool #rangeUInt(256, BLAKE2_BAL)
+     andBool VCallDepth <=Int 1024
+     andBool #rangeUInt(256, VCallValue)
+     andBool #rangeUInt(256, VChainId)
+     andBool (#rangeAddress(Owner)
+     andBool (#rangeBytes(32, Value)
+     andBool (#rangeBool(Ok)
+     andBool (#sizeByteArray(CD) <=Int 1250000000
+     andBool (#notPrecompileAddress(Owner)
+     andBool (2300 <Int VGas -Int (2043)
+     andBool (#rangeUInt(256, Junk_0)
+     andBool (#rangeUInt(256, Junk_1)
+     andBool ((VCallValue ==Int 0)
+     andBool ((Ok ==Int 1)))))))))))
+     andBool #lookup(ACCT_ID_STORAGE, 1) ==Int #WordPackAddrUInt8(Owner, Ok)
+     andBool #lookup(ACCT_ID_STORAGE, 2) ==Int Value
+     andBool #lookup(ACCT_ID_ORIG_STORAGE, 1) ==Int Junk_0
+     andBool #lookup(ACCT_ID_ORIG_STORAGE, 2) ==Int Junk_1
+
+endmodule

--- a/tests/specs/mcd/end-subuu-pass-spec.k
+++ b/tests/specs/mcd/end-subuu-pass-spec.k
@@ -1,0 +1,197 @@
+requires "verification.k"
+
+module END-SUBUU-PASS-SPEC
+  imports VERIFICATION
+
+    // End_subuu
+    rule [End.subuu.pass]:
+      <k> #execute ~> CONTINUATION => #execute ~> CONTINUATION </k>
+      <exit-code> 1 </exit-code>
+      <mode> NORMAL </mode>
+      <schedule> ISTANBUL </schedule>
+      <ethereum>
+        <evm>
+          <output> VOutput => VOutput </output>
+          <statusCode> _ => ?_ </statusCode>
+          <endPC> _ => ?_ </endPC>
+          <callStack> _VCallStack </callStack>
+          <interimStates> _ </interimStates>
+          <touchedAccounts> _ => ?_ </touchedAccounts>
+          <callState>
+            <program> End_bin_runtime </program>
+            <jumpDests> #computeValidJumpDests(End_bin_runtime) </jumpDests>
+            <id> ACCT_ID </id>
+            <caller> CALLER_ID </caller>
+            <callData> _ => ?_ </callData>
+            <callValue> VCallValue </callValue>
+            <wordStack> ABI_y : ABI_x : JMPTO : WS  =>  JMPTO : ABI_x -Int ABI_y : WS </wordStack>
+            <localMem> _ </localMem>
+            <pc> 14664 => 14689 </pc>
+            <gas> VGas => VGas -Int (54) </gas>
+            <memoryUsed> VMemoryUsed </memoryUsed>
+            <callGas> _ => ?_ </callGas>
+            <static> _ </static>
+            <callDepth> VCallDepth </callDepth>
+          </callState>
+          <substate>
+            <selfDestruct> _VSelfDestruct </selfDestruct>
+            <log> _ => ?_ </log>
+            <refund> _ => ?_ </refund>
+          </substate>
+          <gasPrice> _ </gasPrice>
+          <origin> ORIGIN_ID </origin>
+          <blockhashes> _ </blockhashes>
+          <block>
+            <previousHash> _ </previousHash>
+            <ommersHash> _ </ommersHash>
+            <coinbase> _ </coinbase>
+            <stateRoot> _ </stateRoot>
+            <transactionsRoot> _ </transactionsRoot>
+            <receiptsRoot> _ </receiptsRoot>
+            <logsBloom> _ </logsBloom>
+            <difficulty> _ </difficulty>
+            <number> _BLOCK_NUMBER </number>
+            <gasLimit> _ </gasLimit>
+            <gasUsed> _ </gasUsed>
+            <timestamp> TIME </timestamp>
+            <extraData> _ </extraData>
+            <mixHash> _ </mixHash>
+            <blockNonce> _ </blockNonce>
+            <ommerBlockHeaders> _ </ommerBlockHeaders>
+          </block>
+        </evm>
+        <network>
+          <chainID> VChainId </chainID>
+          <activeAccounts> SetItem(ACCT_ID)
+          SetItem(1)
+          SetItem(2)
+          SetItem(3)
+          SetItem(4)
+          SetItem(5)
+          SetItem(6)
+          SetItem(7)
+          SetItem(8)
+          SetItem(9) _ </activeAccounts>
+          <accounts>
+            <account>
+              <acctID> ACCT_ID </acctID>
+              <balance> ACCT_ID_balance </balance>
+              <code> End_bin_runtime </code>
+              <storage>
+               .Map
+
+                _:Map
+               </storage>
+              <origStorage>
+               .Map
+
+                _:Map
+               </origStorage>
+              <nonce> _Nonce_End => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> 1 </acctID>
+              <balance> ECREC_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 2 </acctID>
+              <balance> SHA256_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 3 </acctID>
+              <balance> RIP160_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 4 </acctID>
+              <balance> ID_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 5 </acctID>
+              <balance> MODEXP_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 6 </acctID>
+              <balance> ECADD_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 7 </acctID>
+              <balance> ECMUL_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 8 </acctID>
+              <balance> ECPAIRING_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 9 </acctID>
+              <balance> BLAKE2_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+           ...
+          </accounts>
+          <txOrder> _ </txOrder>
+          <txPending> _ </txPending>
+          <messages> _ </messages>
+        </network>
+      </ethereum>
+    requires #rangeAddress(ACCT_ID)
+     andBool ACCT_ID =/=Int 0
+     andBool #notPrecompileAddress(ACCT_ID)
+     andBool #rangeAddress(CALLER_ID)
+     andBool #rangeAddress(ORIGIN_ID)
+     andBool #rangeUInt(256, TIME)
+     andBool #rangeUInt(256, ACCT_ID_balance)
+     andBool #rangeUInt(256, ECREC_BAL)
+     andBool #rangeUInt(256, SHA256_BAL)
+     andBool #rangeUInt(256, RIP160_BAL)
+     andBool #rangeUInt(256, ID_BAL)
+     andBool #rangeUInt(256, MODEXP_BAL)
+     andBool #rangeUInt(256, ECADD_BAL)
+     andBool #rangeUInt(256, ECMUL_BAL)
+     andBool #rangeUInt(256, ECPAIRING_BAL)
+     andBool #rangeUInt(256, BLAKE2_BAL)
+     andBool VCallDepth <=Int 1024
+     andBool #rangeUInt(256, VCallValue)
+     andBool #rangeUInt(256, VChainId)
+     andBool (#rangeUInt(256, ABI_x)
+     andBool (#rangeUInt(256, ABI_y)
+     andBool ((#sizeWordStack(WS) <=Int 100)
+     andBool (#rangeUInt(256, VMemoryUsed)
+     andBool (2300 <Int VGas -Int (54)
+     andBool ((#rangeUInt(256, ABI_x -Int ABI_y))))))))
+
+endmodule

--- a/tests/specs/mcd/flipper-tau-pass-spec.k
+++ b/tests/specs/mcd/flipper-tau-pass-spec.k
@@ -1,0 +1,192 @@
+requires "verification.k"
+
+module FLIPPER-TAU-PASS-SPEC
+    imports VERIFICATION
+
+    // Flipper_tau
+    rule [Flipper.tau.pass]:
+      <k> #execute ~> CONTINUATION => #halt ~> CONTINUATION </k>
+      <exit-code> 1 </exit-code>
+      <mode> NORMAL </mode>
+      <schedule> ISTANBUL </schedule>
+      <ethereum>
+        <evm>
+          <output> _ => #buf(32, Tau) </output>
+          <statusCode> _ => EVMC_SUCCESS </statusCode>
+          <endPC> _ => ?_ </endPC>
+          <callStack> _VCallStack </callStack>
+          <interimStates> _ </interimStates>
+          <touchedAccounts> _ => ?_ </touchedAccounts>
+          <callState>
+            <program> Flipper_bin_runtime </program>
+            <jumpDests> #computeValidJumpDests(Flipper_bin_runtime) </jumpDests>
+            <id> ACCT_ID </id>
+            <caller> CALLER_ID </caller>
+            <callData> #abiCallData("tau", .TypedArgs) ++ CD => ?_ </callData>
+            <callValue> VCallValue </callValue>
+            <wordStack> .WordStack => ?_ </wordStack>
+            <localMem> .Memory => ?_ </localMem>
+            <pc> 0 => ?_ </pc>
+            <gas> VGas => VGas -Int (1169) </gas>
+            <memoryUsed> 0 => ?_ </memoryUsed>
+            <callGas> _ => ?_ </callGas>
+            <static> _ </static>
+            <callDepth> VCallDepth </callDepth>
+          </callState>
+          <substate>
+            <selfDestruct> _VSelfDestruct </selfDestruct>
+            <log> _ => ?_ </log>
+            <refund> _ => ?_ </refund>
+          </substate>
+          <gasPrice> _ </gasPrice>
+          <origin> ORIGIN_ID </origin>
+          <blockhashes> _ </blockhashes>
+          <block>
+            <previousHash> _ </previousHash>
+            <ommersHash> _ </ommersHash>
+            <coinbase> _ </coinbase>
+            <stateRoot> _ </stateRoot>
+            <transactionsRoot> _ </transactionsRoot>
+            <receiptsRoot> _ </receiptsRoot>
+            <logsBloom> _ </logsBloom>
+            <difficulty> _ </difficulty>
+            <number> _BLOCK_NUMBER </number>
+            <gasLimit> _ </gasLimit>
+            <gasUsed> _ </gasUsed>
+            <timestamp> TIME </timestamp>
+            <extraData> _ </extraData>
+            <mixHash> _ </mixHash>
+            <blockNonce> _ </blockNonce>
+            <ommerBlockHeaders> _ </ommerBlockHeaders>
+          </block>
+        </evm>
+        <network>
+          <chainID> VChainId </chainID>
+          <activeAccounts> SetItem(ACCT_ID)
+          SetItem(1)
+          SetItem(2)
+          SetItem(3)
+          SetItem(4)
+          SetItem(5)
+          SetItem(6)
+          SetItem(7)
+          SetItem(8)
+          SetItem(9) _ </activeAccounts>
+          <accounts>
+            <account>
+              <acctID> ACCT_ID </acctID>
+              <balance> ACCT_ID_balance </balance>
+              <code> Flipper_bin_runtime </code>
+              <storage> ACCT_ID_STORAGE => ACCT_ID_STORAGE  </storage>
+              <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
+              <nonce> _Nonce_Flipper => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> 1 </acctID>
+              <balance> ECREC_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 2 </acctID>
+              <balance> SHA256_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 3 </acctID>
+              <balance> RIP160_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 4 </acctID>
+              <balance> ID_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 5 </acctID>
+              <balance> MODEXP_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 6 </acctID>
+              <balance> ECADD_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 7 </acctID>
+              <balance> ECMUL_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 8 </acctID>
+              <balance> ECPAIRING_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 9 </acctID>
+              <balance> BLAKE2_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+           ...
+          </accounts>
+          <txOrder> _ </txOrder>
+          <txPending> _ </txPending>
+          <messages> _ </messages>
+        </network>
+      </ethereum>
+    requires #rangeAddress(ACCT_ID)
+     andBool ACCT_ID =/=Int 0
+     andBool #notPrecompileAddress(ACCT_ID)
+     andBool #rangeAddress(CALLER_ID)
+     andBool #rangeAddress(ORIGIN_ID)
+     andBool #rangeUInt(256, TIME)
+     andBool #rangeUInt(256, ACCT_ID_balance)
+     andBool #rangeUInt(256, ECREC_BAL)
+     andBool #rangeUInt(256, SHA256_BAL)
+     andBool #rangeUInt(256, RIP160_BAL)
+     andBool #rangeUInt(256, ID_BAL)
+     andBool #rangeUInt(256, MODEXP_BAL)
+     andBool #rangeUInt(256, ECADD_BAL)
+     andBool #rangeUInt(256, ECMUL_BAL)
+     andBool #rangeUInt(256, ECPAIRING_BAL)
+     andBool #rangeUInt(256, BLAKE2_BAL)
+     andBool VCallDepth <=Int 1024
+     andBool #rangeUInt(256, VCallValue)
+     andBool #rangeUInt(256, VChainId)
+     andBool (#rangeUInt(48, Ttl)
+     andBool (#rangeUInt(48, Tau)
+     andBool (#sizeByteArray(CD) <=Int 1250000000
+     andBool (2300 <Int VGas -Int (1169)
+     andBool (#rangeUInt(256, Junk_0)
+     andBool ((VCallValue ==Int 0)))))))
+
+     andBool #lookup(ACCT_ID_STORAGE, #Flipper.ttl_tau) ==Int #WordPackUInt48UInt48(Ttl, Tau)
+     andBool #lookup(ACCT_ID_ORIG_STORAGE, #Flipper.ttl_tau) ==Int Junk_0
+
+endmodule

--- a/tests/specs/mcd/verification.k
+++ b/tests/specs/mcd/verification.k
@@ -107,6 +107,8 @@ module VERIFICATION
 
     // ### cat-ilks-pass
 
+    rule chop(hash2(I1, I2) +Int N) => hash2(I1, I2) +Int N requires N <Int 3
+
     rule ( BA1:ByteArray ++ BA2:ByteArray ) ++ BA3:ByteArray => BA1 ++ ( BA2 ++ BA3 )
 
 endmodule

--- a/tests/specs/mcd/verification.k
+++ b/tests/specs/mcd/verification.k
@@ -107,7 +107,7 @@ module VERIFICATION
 
     // ### cat-ilks-pass
 
-    rule chop(hash2(I1, I2) +Int N) => hash2(I1, I2) +Int N requires N <Int 3
+    rule chop(hash2(I1, I2) +Int N) => hash2(I1, I2) +Int N requires 0 <=Int N andBool N <Int 3
 
     rule ( BA1:ByteArray ++ BA2:ByteArray ) ++ BA3:ByteArray => BA1 ++ ( BA2 ++ BA3 )
 

--- a/tests/specs/mcd/verification.k
+++ b/tests/specs/mcd/verification.k
@@ -97,4 +97,8 @@ module VERIFICATION
     rule M:Memory [ K <- V ] [ K' <- V' ]             => M [ K' <- V' ] [ K <- V ]       requires K' <Int K
     rule M:Memory [ K := BUF:ByteArray ] [ K' <- V' ] => M [ K' <- V' ] [ K := BUF ]     requires K' <Int K orBool K +Int #sizeByteArray(BUF) <=Int K'
 
+    // ### dstoken-transferfrom-fail-rough
+
+    rule hash2(_, hash2(_, _)) ==K hash2(_, N) => false requires N <=Int 10
+
 endmodule

--- a/tests/specs/mcd/verification.k
+++ b/tests/specs/mcd/verification.k
@@ -99,8 +99,6 @@ module VERIFICATION
 
     // ### dstoken-transferfrom-fail-rough
 
-    rule hash2(_, hash2(_, _)) ==K hash2(_, N) => false requires N <=Int 10
-
     rule chop(N +Int M) <Int N => true requires #rangeUInt(256, N) andBool #rangeUInt(256, M) andBool notBool #rangeUInt(256, N +Int M)
 
     // ### dsvalue-read-pass
@@ -108,11 +106,6 @@ module VERIFICATION
     rule M [ K <- V ] => M requires #lookup(M, K) ==Int V
 
     // ### cat-ilks-pass
-
-    rule chop(hash2(I, I') +Int N) => hash2(I, I') +Int N requires N <Int 3
-
-    rule hash2(_, _) +Int N ==K hash2(_, _) +Int M => false requires N =/=Int M
-    rule hash2(_, _)        ==K hash2(_, _) +Int M => false requires 0 =/=Int M
 
     rule ( BA1:ByteArray ++ BA2:ByteArray ) ++ BA3:ByteArray => BA1 ++ ( BA2 ++ BA3 )
 

--- a/tests/specs/mcd/verification.k
+++ b/tests/specs/mcd/verification.k
@@ -101,6 +101,6 @@ module VERIFICATION
 
     rule hash2(_, hash2(_, _)) ==K hash2(_, N) => false requires N <=Int 10
 
-    rule chop(N +Int M) <Int N => true requires notBool #rangeUInt(256, N +Int M)
+    rule chop(N +Int M) <Int N => true requires #rangeUInt(256, N) andBool #rangeUInt(256, M) andBool notBool #rangeUInt(256, N +Int M)
 
 endmodule

--- a/tests/specs/mcd/verification.k
+++ b/tests/specs/mcd/verification.k
@@ -114,6 +114,6 @@ module VERIFICATION
     rule hash2(_, _) +Int N ==K hash2(_, _) +Int M => false requires N =/=Int M
     rule hash2(_, _)        ==K hash2(_, _) +Int M => false requires 0 =/=Int M
 
-    rule ( BA1:ByteArray ++ BA2:ByteArray ) ++ BA3:ByteArray => BA1:ByteArray ++ ( BA2:ByteArray ++ BA3:ByteArray )
+    rule ( BA1:ByteArray ++ BA2:ByteArray ) ++ BA3:ByteArray => BA1 ++ ( BA2 ++ BA3 )
 
 endmodule

--- a/tests/specs/mcd/verification.k
+++ b/tests/specs/mcd/verification.k
@@ -103,4 +103,8 @@ module VERIFICATION
 
     rule chop(N +Int M) <Int N => true requires #rangeUInt(256, N) andBool #rangeUInt(256, M) andBool notBool #rangeUInt(256, N +Int M)
 
+    // ### dsvalue-read-pass
+
+    rule M [ K <- V ] => M requires #lookup(M, K) ==Int V
+
 endmodule

--- a/tests/specs/mcd/verification.k
+++ b/tests/specs/mcd/verification.k
@@ -107,4 +107,11 @@ module VERIFICATION
 
     rule M [ K <- V ] => M requires #lookup(M, K) ==Int V
 
+    // ### cat-ilks-pass
+
+    rule chop(hash2(I, I') +Int N) => hash2(I, I') +Int N requires N <Int 3
+
+    rule hash2(_, _) +Int N ==K hash2(_, _) +Int M => false requires N =/=Int M
+    rule hash2(_, _)        ==K hash2(_, _) +Int M => false requires 0 =/=Int M
+
 endmodule

--- a/tests/specs/mcd/verification.k
+++ b/tests/specs/mcd/verification.k
@@ -114,4 +114,6 @@ module VERIFICATION
     rule hash2(_, _) +Int N ==K hash2(_, _) +Int M => false requires N =/=Int M
     rule hash2(_, _)        ==K hash2(_, _) +Int M => false requires 0 =/=Int M
 
+    rule ( BA1:ByteArray ++ BA2:ByteArray ) ++ BA3:ByteArray => BA1:ByteArray ++ ( BA2:ByteArray ++ BA3:ByteArray )
+
 endmodule

--- a/tests/specs/mcd/verification.k
+++ b/tests/specs/mcd/verification.k
@@ -101,4 +101,6 @@ module VERIFICATION
 
     rule hash2(_, hash2(_, _)) ==K hash2(_, N) => false requires N <=Int 10
 
+    rule chop(N +Int M) <Int N => true requires notBool #rangeUInt(256, N +Int M)
+
 endmodule

--- a/tests/specs/mcd/verification.k
+++ b/tests/specs/mcd/verification.k
@@ -107,6 +107,8 @@ module VERIFICATION
 
     // ### cat-ilks-pass
 
+    // This lemma is considered "safe enough" because `hash2` is a hash function over a large range and is very unlikely to overflow.
+    // Note that this case comes from a solidity struct being accessed (hence the integer offsets), so it's an assumption built into the Solidity compiler anyway.
     rule chop(hash2(I1, I2) +Int N) => hash2(I1, I2) +Int N requires 0 <=Int N andBool N <Int 3
 
     rule ( BA1:ByteArray ++ BA2:ByteArray ) ++ BA3:ByteArray => BA1 ++ ( BA2 ++ BA3 )


### PR DESCRIPTION
These proofs exhibits a few behaviors:

-   Takes about 6min to parse in its original form, now takes about a minute with (i) the abstract-pre concrete-post storage model, and (ii) removing some parenthesis around the negated path conditions.
-   Exhibits a case where we couldn't simplify out `chop` correctly.
-   Key format differences for some specific equations.
-   Simplify out a write when reading would already produce the same value.
-   Hashes aren't likely to overflow.
-   ByteArray associativity.
-   Deconstructing a `#WordPack...` specified storage location.