### PR TITLE
Remove unsigned/signed, add rangeBool, tighter definition of `sgn` and `abs`.

### DIFF
--- a/edsl.md
+++ b/edsl.md
@@ -231,7 +231,7 @@ where `F1 : F2 : F3 : F4` is the (two's complement) byte-array representation of
       requires #rangeUInt(256, DATA)
 
     rule #getValue(   #bool( DATA )) => DATA
-      requires #range(0 <= DATA <= 1)
+      requires #rangeBool(DATA)
 
     syntax Int ::= #ceil32 ( Int ) [function, functional, smt-hook(ceil32), smt-prelude]
  // ------------------------------------------------------------------------------------

--- a/edsl.md
+++ b/edsl.md
@@ -194,15 +194,6 @@ where `F1 : F2 : F3 : F4` is the (two's complement) byte-array representation of
       [anywhere, simplification]
 ```
 
-- #unsigned : sInt256 -> uInt256  (i.e., [minSInt256..maxSInt256] -> [minUInt256..maxUInt256])
-
-```k
-    syntax Int ::= #unsigned ( Int ) [function]
- // -------------------------------------------
-    rule [#unsigned.positive]: #unsigned(DATA) => DATA             requires 0 <=Int DATA andBool DATA <=Int maxSInt256
-    rule [#unsigned.negative]: #unsigned(DATA) => pow256 +Int DATA requires minSInt256 <=Int DATA andBool DATA <Int 0
-```
-
 ```k
     syntax Int ::= #getValue ( TypedArg ) [function]
  // ------------------------------------------------
@@ -224,11 +215,17 @@ where `F1 : F2 : F3 : F4` is the (two's complement) byte-array representation of
     rule #getValue(  #uint8( DATA )) => DATA
       requires #rangeUInt(8, DATA)
 
-    rule #getValue( #int256( DATA )) => #unsigned(DATA)
-      requires #rangeSInt(256, DATA)
+    rule #getValue( #int256( DATA )) => DATA
+      requires #rangeSInt(256, DATA) andBool 0 <=Int DATA andBool DATA <=Int maxSInt256
 
-    rule #getValue( #int128( DATA )) => #unsigned(DATA)
-      requires #rangeSInt(128, DATA)
+    rule #getValue( #int256( DATA )) => DATA +Int pow256
+      requires #rangeSInt(256, DATA) andBool minSInt256 <=Int DATA andBool DATA <Int 0
+
+    rule #getValue( #int128( DATA )) => DATA
+      requires #rangeSInt(128, DATA) andBool 0 <=Int DATA andBool DATA <=Int maxSInt256
+
+    rule #getValue( #int128( DATA )) => DATA +Int pow256
+      requires #rangeSInt(128, DATA) andBool minSInt256 <=Int DATA andBool DATA <Int 0
 
     rule #getValue(#bytes32( DATA )) => DATA
       requires #rangeUInt(256, DATA)

--- a/edsl.md
+++ b/edsl.md
@@ -216,16 +216,16 @@ where `F1 : F2 : F3 : F4` is the (two's complement) byte-array representation of
       requires #rangeUInt(8, DATA)
 
     rule #getValue( #int256( DATA )) => DATA
-      requires #rangeSInt(256, DATA) andBool 0 <=Int DATA andBool DATA <=Int maxSInt256
+      requires #rangeSInt(256, DATA) andBool 0 <=Int DATA
 
     rule #getValue( #int256( DATA )) => DATA +Int pow256
-      requires #rangeSInt(256, DATA) andBool minSInt256 <=Int DATA andBool DATA <Int 0
+      requires #rangeSInt(256, DATA) andBool DATA <Int 0
 
     rule #getValue( #int128( DATA )) => DATA
-      requires #rangeSInt(128, DATA) andBool 0 <=Int DATA andBool DATA <=Int maxSInt256
+      requires #rangeSInt(128, DATA) andBool 0 <=Int DATA
 
     rule #getValue( #int128( DATA )) => DATA +Int pow256
-      requires #rangeSInt(128, DATA) andBool minSInt256 <=Int DATA andBool DATA <Int 0
+      requires #rangeSInt(128, DATA) andBool DATA <Int 0
 
     rule #getValue(#bytes32( DATA )) => DATA
       requires #rangeUInt(256, DATA)

--- a/edsl.md
+++ b/edsl.md
@@ -194,6 +194,15 @@ where `F1 : F2 : F3 : F4` is the (two's complement) byte-array representation of
       [anywhere, simplification]
 ```
 
+- #unsigned : sInt256 -> uInt256  (i.e., [minSInt256..maxSInt256] -> [minUInt256..maxUInt256])
+
+```k
+    syntax Int ::= #unsigned ( Int ) [function]
+ // -------------------------------------------
+    rule [#unsigned.positive]: #unsigned(DATA) => DATA             requires 0 <=Int DATA andBool DATA <=Int maxSInt256
+    rule [#unsigned.negative]: #unsigned(DATA) => pow256 +Int DATA requires minSInt256 <=Int DATA andBool DATA <Int 0
+```
+
 ```k
     syntax Int ::= #getValue ( TypedArg ) [function]
  // ------------------------------------------------

--- a/evm-types.md
+++ b/evm-types.md
@@ -90,13 +90,15 @@ These can be used for pattern-matching on the LHS of rules as well (`macro` attr
 -   Range of types
 
 ```k
-    syntax Bool ::= #rangeSInt    ( Int , Int )
+    syntax Bool ::= #rangeBool    ( Int )
+                  | #rangeSInt    ( Int , Int )
                   | #rangeUInt    ( Int , Int )
                   | #rangeSFixed  ( Int , Int , Int )
                   | #rangeUFixed  ( Int , Int , Int )
                   | #rangeAddress ( Int )
                   | #rangeBytes   ( Int , Int )
  // -------------------------------------------
+    rule #rangeBool    (            X ) => X ==Int 0 orBool X ==Int 1                         [macro]
     rule #rangeSInt    ( 128 ,      X ) => #range ( minSInt128      <= X <= maxSInt128      ) [macro]
     rule #rangeSInt    ( 256 ,      X ) => #range ( minSInt256      <= X <= maxSInt256      ) [macro]
     rule #rangeUInt    (   8 ,      X ) => #range ( minUInt8        <= X <  256             ) [macro]

--- a/evm-types.md
+++ b/evm-types.md
@@ -159,11 +159,11 @@ Primitives provide the basic conversion from K's sorts `Int` and `Bool` to EVM's
  // -------------------------------------------------
     rule sgn(I) => -1 requires pow255 <=Int I andBool I <Int pow256
     rule sgn(I) =>  1 requires 0 <=Int I andBool I <Int pow255
-    rule sgn(_) =>  0 [owise]
+    rule sgn(I) =>  0 requires I <Int 0 orBool pow256 <=Int I
 
     rule abs(I) => 0 -Word I requires sgn(I) ==Int -1
     rule abs(I) => I         requires sgn(I) ==Int  1
-    rule abs(_) => 0         [owise]
+    rule abs(I) => 0         requires sgn(I) ==Int  0
 ```
 
 Word Operations

--- a/evm-types.md
+++ b/evm-types.md
@@ -155,7 +155,7 @@ Primitives provide the basic conversion from K's sorts `Int` and `Bool` to EVM's
     syntax Int ::= sgn ( Int ) [function, functional]
                  | abs ( Int ) [function, functional]
  // -------------------------------------------------
-    rule sgn(I) => -1 requires I >=Int pow255
+    rule sgn(I) => -1 requires pow255 <=Int I
     rule sgn(I) => 1  requires I <Int pow255
 
     rule abs(I) => 0 -Word I requires sgn(I) ==Int -1
@@ -166,21 +166,14 @@ Primitives provide the basic conversion from K's sorts `Int` and `Bool` to EVM's
 - #unsigned : sInt256 -> uInt256  (i.e., [minSInt256..maxSInt256] -> [minUInt256..maxUInt256])
 
 ```k
-    syntax Int ::= #signed ( Int ) [function]
- // -----------------------------------------
-    rule [#signed.positive]: #signed(DATA) => DATA
-      requires 0 <=Int DATA andBool DATA <=Int maxSInt256
-
-    rule [#signed.negative]: #signed(DATA) => DATA -Int pow256
-      requires maxSInt256 <Int DATA andBool DATA <=Int maxUInt256
-
-    syntax Int ::= #unsigned ( Int ) [function]
+    syntax Int ::= #signed   ( Int ) [function]
+                 | #unsigned ( Int ) [function]
  // -------------------------------------------
-    rule [#unsigned.positive]: #unsigned(DATA) => DATA
-      requires 0 <=Int DATA andBool DATA <=Int maxSInt256
+    rule [#signed.positive]: #signed(DATA) => DATA             requires 0 <=Int DATA andBool DATA <=Int maxSInt256
+    rule [#signed.negative]: #signed(DATA) => DATA -Int pow256 requires maxSInt256 <Int DATA andBool DATA <=Int maxUInt256
 
-    rule [#unsigned.negative]: #unsigned(DATA) => pow256 +Int DATA
-      requires minSInt256 <=Int DATA andBool DATA <Int 0
+    rule [#unsigned.positive]: #unsigned(DATA) => DATA             requires 0 <=Int DATA andBool DATA <=Int maxSInt256
+    rule [#unsigned.negative]: #unsigned(DATA) => pow256 +Int DATA requires minSInt256 <=Int DATA andBool DATA <Int 0
 ```
 
 Word Operations

--- a/evm-types.md
+++ b/evm-types.md
@@ -164,20 +164,6 @@ Primitives provide the basic conversion from K's sorts `Int` and `Bool` to EVM's
     rule abs(_) => 0         [owise]
 ```
 
--   #signed : uInt256 -> sInt256  (i.e., [minUInt256..maxUInt256] -> [minSInt256..maxSInt256])
-- #unsigned : sInt256 -> uInt256  (i.e., [minSInt256..maxSInt256] -> [minUInt256..maxUInt256])
-
-```k
-    syntax Int ::= #signed   ( Int ) [function]
-                 | #unsigned ( Int ) [function]
- // -------------------------------------------
-    rule [#signed.positive]: #signed(DATA) => DATA             requires 0 <=Int DATA andBool DATA <=Int maxSInt256
-    rule [#signed.negative]: #signed(DATA) => DATA -Int pow256 requires maxSInt256 <Int DATA andBool DATA <=Int maxUInt256
-
-    rule [#unsigned.positive]: #unsigned(DATA) => DATA             requires 0 <=Int DATA andBool DATA <=Int maxSInt256
-    rule [#unsigned.negative]: #unsigned(DATA) => pow256 +Int DATA requires minSInt256 <=Int DATA andBool DATA <Int 0
-```
-
 Word Operations
 ---------------
 

--- a/evm-types.md
+++ b/evm-types.md
@@ -155,11 +155,13 @@ Primitives provide the basic conversion from K's sorts `Int` and `Bool` to EVM's
     syntax Int ::= sgn ( Int ) [function, functional]
                  | abs ( Int ) [function, functional]
  // -------------------------------------------------
-    rule sgn(I) => -1 requires pow255 <=Int I
-    rule sgn(I) => 1  requires I <Int pow255
+    rule sgn(I) => -1 requires pow255 <=Int I andBool I <Int pow256
+    rule sgn(I) =>  1 requires 0 <=Int I andBool I <Int pow255
+    rule sgn(_) =>  0 [owise]
 
     rule abs(I) => 0 -Word I requires sgn(I) ==Int -1
-    rule abs(I) => I         requires sgn(I) ==Int 1
+    rule abs(I) => I         requires sgn(I) ==Int  1
+    rule abs(_) => 0         [owise]
 ```
 
 -   #signed : uInt256 -> sInt256  (i.e., [minUInt256..maxUInt256] -> [minSInt256..maxSInt256])

--- a/tests/specs/bihu/concrete-rules.txt
+++ b/tests/specs/bihu/concrete-rules.txt
@@ -15,8 +15,6 @@ EVM-TYPES.powmod.zero
 EVM-TYPES.signextend.invalid
 EVM-TYPES.signextend.negative
 EVM-TYPES.signextend.positive
-EVM-TYPES.#unsigned.negative
-EVM-TYPES.#unsigned.positive
 SERIALIZATION.keccak
 SERIALIZATION.#newAddr
 SERIALIZATION.#newAddrCreate2

--- a/tests/specs/bihu/concrete-rules.txt
+++ b/tests/specs/bihu/concrete-rules.txt
@@ -12,8 +12,6 @@ EVM-TYPES.#padRightToWidth
 EVM-TYPES.#padToWidth
 EVM-TYPES.powmod.nonzero
 EVM-TYPES.powmod.zero
-EVM-TYPES.#signed.negative
-EVM-TYPES.#signed.positive
 EVM-TYPES.signextend.invalid
 EVM-TYPES.signextend.negative
 EVM-TYPES.signextend.positive

--- a/tests/specs/concrete-rules.txt
+++ b/tests/specs/concrete-rules.txt
@@ -22,8 +22,6 @@ EVM-TYPES.#range
 EVM-TYPES.signextend.invalid
 EVM-TYPES.signextend.negative
 EVM-TYPES.signextend.positive
-EVM-TYPES.#unsigned.negative
-EVM-TYPES.#unsigned.positive
 SERIALIZATION.keccak
 SERIALIZATION.#newAddr
 SERIALIZATION.#newAddrCreate2

--- a/tests/specs/concrete-rules.txt
+++ b/tests/specs/concrete-rules.txt
@@ -19,8 +19,6 @@ EVM-TYPES.padToWidthNonEmpty
 EVM-TYPES.powmod.nonzero
 EVM-TYPES.powmod.zero
 EVM-TYPES.#range
-EVM-TYPES.#signed.negative
-EVM-TYPES.#signed.positive
 EVM-TYPES.signextend.invalid
 EVM-TYPES.signextend.negative
 EVM-TYPES.signextend.positive

--- a/tests/specs/erc20/concrete-rules.txt
+++ b/tests/specs/erc20/concrete-rules.txt
@@ -22,8 +22,6 @@ EVM-TYPES.#range
 EVM-TYPES.signextend.invalid
 EVM-TYPES.signextend.negative
 EVM-TYPES.signextend.positive
-EVM-TYPES.#unsigned.negative
-EVM-TYPES.#unsigned.positive
 SERIALIZATION.keccak
 SERIALIZATION.#newAddr
 SERIALIZATION.#newAddrCreate2

--- a/tests/specs/erc20/concrete-rules.txt
+++ b/tests/specs/erc20/concrete-rules.txt
@@ -19,8 +19,6 @@ EVM-TYPES.padToWidthNonEmpty
 EVM-TYPES.powmod.nonzero
 EVM-TYPES.powmod.zero
 EVM-TYPES.#range
-EVM-TYPES.#signed.negative
-EVM-TYPES.#signed.positive
 EVM-TYPES.signextend.invalid
 EVM-TYPES.signextend.negative
 EVM-TYPES.signextend.positive

--- a/tests/specs/mcd/concrete-rules.txt
+++ b/tests/specs/mcd/concrete-rules.txt
@@ -14,8 +14,6 @@ EVM-TYPES.#rangeAux.rec
 EVM-TYPES.signextend.invalid
 EVM-TYPES.signextend.negative
 EVM-TYPES.signextend.positive
-EVM-TYPES.#unsigned.negative
-EVM-TYPES.#unsigned.positive
 SERIALIZATION.keccak
 SERIALIZATION.#newAddr
 SERIALIZATION.#newAddrCreate2

--- a/tests/specs/mcd/concrete-rules.txt
+++ b/tests/specs/mcd/concrete-rules.txt
@@ -11,8 +11,6 @@ EVM-TYPES.powmod.nonzero
 EVM-TYPES.powmod.zero
 EVM-TYPES.#range
 EVM-TYPES.#rangeAux.rec
-EVM-TYPES.#signed.negative
-EVM-TYPES.#signed.positive
 EVM-TYPES.signextend.invalid
 EVM-TYPES.signextend.negative
 EVM-TYPES.signextend.positive

--- a/tests/specs/mcd/verification.k
+++ b/tests/specs/mcd/verification.k
@@ -19,10 +19,6 @@ module VERIFICATION-SYNTAX
  // --------------------------------------------------------
     rule #notPrecompileAddress ( X ) => 0 ==Int X orBool (10 <=Int X andBool #rangeAddress(X))
 
-    syntax Bool ::= #rangeBool ( Int )
- // ----------------------------------
-    rule #rangeBool(X) => X ==Int 0 orBool X ==Int 1 [macro]
-
     syntax Int ::= "pow208"
  // -----------------------
     rule pow208 => 411376139330301510538742295639337626245683966408394965837152256 [macro]


### PR DESCRIPTION
This PR does 3 things:

-   `#unsigned/#signed` are removed. `#signed` is never used anywhere, and `#unsigned` is only used in `#getValue`, so the uses are just inlined.
-   `#rangeBool` is added with a simpler predicate for being boolean than `#rangeUInt(1, _)`, and is used in `edsl.md`.
-   `abs` and `sgn` have tighter bounds and go to `0` on nonsense cases.