### PR TITLE
MKR regression tests: dstoken-burn-self-fail-rough, flipper-ttl-pass, vat-addui-fail-rough, vat-mului-pass

### DIFF
--- a/evm-types.md
+++ b/evm-types.md
@@ -154,9 +154,9 @@ Primitives provide the basic conversion from K's sorts `Int` and `Bool` to EVM's
 -   `abs` gives the twos-complement interperetation of the magnitude of a word.
 
 ```k
-    syntax Int ::= sgn ( Int ) [function, functional, smtlib(sgn)]
-                 | abs ( Int ) [function, functional, smtlib(abs)]
- // --------------------------------------------------------------
+    syntax Int ::= sgn ( Int ) [function, functional]
+                 | abs ( Int ) [function, functional]
+ // -------------------------------------------------
     rule sgn(I) => -1 requires pow255 <=Int I andBool I <Int pow256
     rule sgn(I) =>  1 requires 0 <=Int I andBool I <Int pow255
     rule sgn(I) =>  0 requires I <Int 0 orBool pow256 <=Int I

--- a/evm-types.md
+++ b/evm-types.md
@@ -232,8 +232,8 @@ The helper `powmod` is a totalization of the operator `_^%Int__` (which comes wi
     syntax Int ::= Int "/sWord" Int [function]
                  | Int "%sWord" Int [function]
  // ------------------------------------------
-    rule W0 /sWord W1 => #sgnInterp(sgn(W0) *Int sgn(W1) , abs(W0) /Word abs(W1))
-    rule W0 %sWord W1 => #sgnInterp(sgn(W0)              , abs(W0) %Word abs(W1))
+    rule [divSWord]: W0 /sWord W1 => #sgnInterp(sgn(W0) *Int sgn(W1) , abs(W0) /Word abs(W1))
+    rule [modSWord]: W0 %sWord W1 => #sgnInterp(sgn(W0)              , abs(W0) %Word abs(W1))
 
     syntax Int ::= #sgnInterp ( Int , Int ) [function, functional]
  // --------------------------------------------------------------

--- a/evm-types.md
+++ b/evm-types.md
@@ -154,9 +154,9 @@ Primitives provide the basic conversion from K's sorts `Int` and `Bool` to EVM's
 -   `abs` gives the twos-complement interperetation of the magnitude of a word.
 
 ```k
-    syntax Int ::= sgn ( Int ) [function, functional]
-                 | abs ( Int ) [function, functional]
- // -------------------------------------------------
+    syntax Int ::= sgn ( Int ) [function, functional, smtlib(sgn)]
+                 | abs ( Int ) [function, functional, smtlib(abs)]
+ // --------------------------------------------------------------
     rule sgn(I) => -1 requires pow255 <=Int I andBool I <Int pow256
     rule sgn(I) =>  1 requires 0 <=Int I andBool I <Int pow255
     rule sgn(I) =>  0 requires I <Int 0 orBool pow256 <=Int I

--- a/tests/failing-symbolic.haskell
+++ b/tests/failing-symbolic.haskell
@@ -58,10 +58,13 @@ tests/specs/mcd/cat-ilks-pass-spec.k
 tests/specs/mcd/dai-adduu-fail-rough-spec.k
 tests/specs/mcd/dai-symbol-pass-spec.k
 tests/specs/mcd/dstoken-approve-fail-rough-spec.k
+tests/specs/mcd/dstoken-burn-self-fail-rough-spec.k
 tests/specs/mcd/dstoken-transferfrom-fail-rough-spec.k
 tests/specs/mcd/dsvalue-read-pass-spec.k
 tests/specs/mcd/end-subuu-pass-spec.k
 tests/specs/mcd/flipper-tau-pass-spec.k
+tests/specs/mcd/flipper-ttl-pass-spec.k
+tests/specs/mcd/vat-addui-fail-rough-spec.k
 tests/specs/mcd/vat-deny-diff-fail-rough-spec.k
 tests/specs/mcd/vat-move-diff-spec.k
 tests/specs/opcodes/create-spec.k

--- a/tests/failing-symbolic.haskell
+++ b/tests/failing-symbolic.haskell
@@ -67,4 +67,5 @@ tests/specs/mcd/flipper-ttl-pass-spec.k
 tests/specs/mcd/vat-addui-fail-rough-spec.k
 tests/specs/mcd/vat-deny-diff-fail-rough-spec.k
 tests/specs/mcd/vat-move-diff-spec.k
+tests/specs/mcd/vat-mului-pass-spec.k
 tests/specs/opcodes/create-spec.k

--- a/tests/specs/mcd/concrete-rules.txt
+++ b/tests/specs/mcd/concrete-rules.txt
@@ -5,6 +5,7 @@ EVM-TYPES.#asByteStack
 EVM-TYPES.#asByteStackAux.recursive
 EVM-TYPES.#asWord.recursive
 EVM-TYPES.ByteArray.range
+EVM-TYPES.divSWord
 EVM-TYPES.mapWriteBytes.recursive
 EVM-TYPES.#padToWidth
 EVM-TYPES.powmod.nonzero

--- a/tests/specs/mcd/dstoken-burn-self-fail-rough-spec.k
+++ b/tests/specs/mcd/dstoken-burn-self-fail-rough-spec.k
@@ -1,0 +1,219 @@
+requires "verification.k"
+
+module DSTOKEN-BURN-SELF-FAIL-ROUGH-SPEC
+    imports VERIFICATION
+
+    // DSToken_burn-self
+    rule [DSToken.burn-self.fail.rough]:
+      <k> #execute ~> CONTINUATION => #halt ~> CONTINUATION </k>
+      <exit-code> 1 </exit-code>
+      <mode> NORMAL </mode>
+      <schedule> ISTANBUL </schedule>
+      <ethereum>
+        <evm>
+          <output> _ => ?_ </output>
+          <statusCode> _ => ?FAILURE:EndStatusCode </statusCode>
+          <endPC> _ => ?_ </endPC>
+          <callStack> _VCallStack </callStack>
+          <interimStates> _ </interimStates>
+          <touchedAccounts> _ => ?_ </touchedAccounts>
+          <callState>
+            <program> DSToken_bin_runtime </program>
+            <jumpDests> #computeValidJumpDests(DSToken_bin_runtime) </jumpDests>
+            <id> ACCT_ID </id>
+            <caller> CALLER_ID </caller>
+            <callData> #abiCallData("burn", #address(ABI_src), #uint256(ABI_wad)) ++ CD => ?_ </callData>
+            <callValue> VCallValue </callValue>
+            <wordStack> .WordStack => ?_ </wordStack>
+            <localMem> .Memory => ?_ </localMem>
+            <pc> 0 => ?_ </pc>
+            <gas> VGas => ?_ </gas>
+            <memoryUsed> 0 => ?_ </memoryUsed>
+            <callGas> _ => ?_ </callGas>
+            <static> false </static>
+            <callDepth> VCallDepth => ?_ </callDepth>
+          </callState>
+          <substate>
+            <selfDestruct> _VSelfDestruct </selfDestruct>
+            <log> _ => ?_ </log>
+            <refund> _Vrefund => ?_ </refund>
+          </substate>
+          <gasPrice> _ </gasPrice>
+          <origin> ORIGIN_ID </origin>
+          <blockhashes> _ </blockhashes>
+          <block>
+            <previousHash> _ </previousHash>
+            <ommersHash> _ </ommersHash>
+            <coinbase> _ </coinbase>
+            <stateRoot> _ </stateRoot>
+            <transactionsRoot> _ </transactionsRoot>
+            <receiptsRoot> _ </receiptsRoot>
+            <logsBloom> _ </logsBloom>
+            <difficulty> _ </difficulty>
+            <number> _BLOCK_NUMBER </number>
+            <gasLimit> _ </gasLimit>
+            <gasUsed> _ </gasUsed>
+            <timestamp> TIME </timestamp>
+            <extraData> _ </extraData>
+            <mixHash> _ </mixHash>
+            <blockNonce> _ </blockNonce>
+            <ommerBlockHeaders> _ </ommerBlockHeaders>
+          </block>
+        </evm>
+        <network>
+          <chainID> VChainId </chainID>
+          <activeAccounts> SetItem(ACCT_ID)
+          SetItem(1)
+          SetItem(2)
+          SetItem(3)
+          SetItem(4)
+          SetItem(5)
+          SetItem(6)
+          SetItem(7)
+          SetItem(8)
+          SetItem(9) _ </activeAccounts>
+          <accounts>
+            <account>
+              <acctID> ACCT_ID </acctID>
+              <balance> ACCT_ID_balance </balance>
+              <code> DSToken_bin_runtime </code>
+              <storage> ACCT_ID_STORAGE => ?_ACCT_ID_STORAGE </storage>
+              <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
+              <nonce> _Nonce_DSToken => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> 1 </acctID>
+              <balance> ECREC_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 2 </acctID>
+              <balance> SHA256_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 3 </acctID>
+              <balance> RIP160_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 4 </acctID>
+              <balance> ID_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 5 </acctID>
+              <balance> MODEXP_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 6 </acctID>
+              <balance> ECADD_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 7 </acctID>
+              <balance> ECMUL_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 8 </acctID>
+              <balance> ECPAIRING_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 9 </acctID>
+              <balance> BLAKE2_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+           ...
+          </accounts>
+          <txOrder> _ </txOrder>
+          <txPending> _ </txPending>
+          <messages> _ </messages>
+        </network>
+      </ethereum>
+    requires #rangeAddress(ACCT_ID)
+     andBool ACCT_ID =/=Int 0
+     andBool #notPrecompileAddress(ACCT_ID)
+     andBool #rangeAddress(CALLER_ID)
+     andBool #rangeAddress(ORIGIN_ID)
+     andBool #rangeUInt(256, TIME)
+     andBool #rangeUInt(256, ACCT_ID_balance)
+     andBool #rangeUInt(256, ECREC_BAL)
+     andBool #rangeUInt(256, SHA256_BAL)
+     andBool #rangeUInt(256, RIP160_BAL)
+     andBool #rangeUInt(256, ID_BAL)
+     andBool #rangeUInt(256, MODEXP_BAL)
+     andBool #rangeUInt(256, ECADD_BAL)
+     andBool #rangeUInt(256, ECMUL_BAL)
+     andBool #rangeUInt(256, ECPAIRING_BAL)
+     andBool #rangeUInt(256, BLAKE2_BAL)
+     andBool VCallDepth <=Int 1024
+     andBool #rangeUInt(256, VCallValue)
+     andBool #rangeUInt(256, VChainId)
+
+     andBool (#rangeAddress(ABI_src)
+     andBool (#rangeUInt(256, ABI_wad)
+     andBool (#rangeUInt(256, Gem_s)
+     andBool (#rangeUInt(256, Supply)
+     andBool (#rangeUInt(256, Allowance)
+     andBool (#rangeBool(Stoppedd)
+     andBool (#rangeAddress(Owner)
+     andBool ((#sizeByteArray(CD) <=Int 1250000000)
+     andBool ((#notPrecompileAddress(Owner))
+     andBool ((CALLER_ID ==Int Owner)
+     andBool ((CALLER_ID =/=Int ACCT_ID)
+     andBool ((CALLER_ID ==Int ABI_src)
+     andBool (VGas >=Int 3000000
+     andBool (#rangeUInt(256, Junk_0)
+     andBool (#rangeUInt(256, Junk_1)
+     andBool (#rangeUInt(256, Junk_2)
+     andBool (#rangeUInt(256, Junk_3))))))))))))))))))
+
+     andBool #lookup(ACCT_ID_STORAGE, #DSToken.allowance[ABI_src][CALLER_ID]) ==Int Allowance
+     andBool #lookup(ACCT_ID_STORAGE, #DSToken.balances[ABI_src]) ==Int Gem_s
+     andBool #lookup(ACCT_ID_STORAGE, #DSToken.supply) ==Int Supply
+     andBool #lookup(ACCT_ID_STORAGE, #DSToken.owner_stopped) ==Int #WordPackAddrUInt8(Owner, Stoppedd)
+     andBool #lookup(ACCT_ID_ORIG_STORAGE, #DSToken.allowance[ABI_src][CALLER_ID]) ==Int Junk_0
+     andBool #lookup(ACCT_ID_ORIG_STORAGE, #DSToken.balances[ABI_src]) ==Int Junk_1
+     andBool #lookup(ACCT_ID_ORIG_STORAGE, #DSToken.supply) ==Int Junk_2
+     andBool #lookup(ACCT_ID_ORIG_STORAGE, #DSToken.owner_stopped) ==Int Junk_3
+     andBool #DSToken.allowance[ABI_src][CALLER_ID] =/=Int #DSToken.balances[ABI_src]
+     andBool #DSToken.allowance[ABI_src][CALLER_ID] =/=Int #DSToken.supply
+     andBool #DSToken.allowance[ABI_src][CALLER_ID] =/=Int #DSToken.owner_stopped
+     andBool #DSToken.balances[ABI_src] =/=Int #DSToken.supply
+     andBool #DSToken.balances[ABI_src] =/=Int #DSToken.owner_stopped
+     andBool #DSToken.supply =/=Int #DSToken.owner_stopped
+     andBool notBool ( (((#rangeUInt(256, Gem_s:Int  -Int ABI_wad:Int))) andBool (((#rangeUInt(256, Supply:Int -Int ABI_wad:Int))) andBool ((VCallValue:Int ==Int 0) andBool ((Stoppedd:Int ==Int 0))))) )
+
+     ensures ?FAILURE =/=K EVMC_SUCCESS
+
+endmodule

--- a/tests/specs/mcd/flipper-ttl-pass-spec.k
+++ b/tests/specs/mcd/flipper-ttl-pass-spec.k
@@ -1,0 +1,193 @@
+requires "verification.k"
+
+module FLIPPER-TTL-PASS-SPEC
+    imports VERIFICATION
+
+    // Flipper_ttl
+    rule [Flipper.ttl.pass]:
+      <k> #execute ~> CONTINUATION => #halt ~> CONTINUATION </k>
+      <exit-code> 1 </exit-code>
+      <mode> NORMAL </mode>
+      <schedule> ISTANBUL </schedule>
+      <ethereum>
+        <evm>
+          <output> _ => #buf(32, Ttl) </output>
+          <statusCode> _ => EVMC_SUCCESS </statusCode>
+          <endPC> _ => ?_ </endPC>
+          <callStack> _VCallStack </callStack>
+          <interimStates> _ </interimStates>
+          <touchedAccounts> _ => ?_ </touchedAccounts>
+          <callState>
+            <program> Flipper_bin_runtime </program>
+            <jumpDests> #computeValidJumpDests(Flipper_bin_runtime) </jumpDests>
+            <id> ACCT_ID </id>
+            <caller> CALLER_ID </caller>
+            <callData> #abiCallData("ttl", .TypedArgs) ++ CD => ?_ </callData>
+            <callValue> VCallValue </callValue>
+            <wordStack> .WordStack => ?_ </wordStack>
+            <localMem> .Memory => ?_ </localMem>
+            <pc> 0 => ?_ </pc>
+            <gas> VGas => VGas -Int (1120) </gas>
+            <memoryUsed> 0 => ?_ </memoryUsed>
+            <callGas> _ => ?_ </callGas>
+            <static> _ </static>
+            <callDepth> VCallDepth </callDepth>
+          </callState>
+          <substate>
+            <selfDestruct> _VSelfDestruct </selfDestruct>
+            <log> _ => ?_ </log>
+            <refund> _ => ?_ </refund>
+          </substate>
+          <gasPrice> _ </gasPrice>
+          <origin> ORIGIN_ID </origin>
+          <blockhashes> _ </blockhashes>
+          <block>
+            <previousHash> _ </previousHash>
+            <ommersHash> _ </ommersHash>
+            <coinbase> _ </coinbase>
+            <stateRoot> _ </stateRoot>
+            <transactionsRoot> _ </transactionsRoot>
+            <receiptsRoot> _ </receiptsRoot>
+            <logsBloom> _ </logsBloom>
+            <difficulty> _ </difficulty>
+            <number> _BLOCK_NUMBER </number>
+            <gasLimit> _ </gasLimit>
+            <gasUsed> _ </gasUsed>
+            <timestamp> TIME </timestamp>
+            <extraData> _ </extraData>
+            <mixHash> _ </mixHash>
+            <blockNonce> _ </blockNonce>
+            <ommerBlockHeaders> _ </ommerBlockHeaders>
+          </block>
+        </evm>
+        <network>
+          <chainID> VChainId </chainID>
+          <activeAccounts> SetItem(ACCT_ID)
+          SetItem(1)
+          SetItem(2)
+          SetItem(3)
+          SetItem(4)
+          SetItem(5)
+          SetItem(6)
+          SetItem(7)
+          SetItem(8)
+          SetItem(9) _ </activeAccounts>
+          <accounts>
+            <account>
+              <acctID> ACCT_ID </acctID>
+              <balance> ACCT_ID_balance </balance>
+              <code> Flipper_bin_runtime </code>
+              <storage> ACCT_ID_STORAGE => ACCT_ID_STORAGE  </storage>
+              <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
+              <nonce> _Nonce_Flipper => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> 1 </acctID>
+              <balance> ECREC_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 2 </acctID>
+              <balance> SHA256_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 3 </acctID>
+              <balance> RIP160_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 4 </acctID>
+              <balance> ID_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 5 </acctID>
+              <balance> MODEXP_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 6 </acctID>
+              <balance> ECADD_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 7 </acctID>
+              <balance> ECMUL_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 8 </acctID>
+              <balance> ECPAIRING_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 9 </acctID>
+              <balance> BLAKE2_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+           ...
+          </accounts>
+          <txOrder> _ </txOrder>
+          <txPending> _ </txPending>
+          <messages> _ </messages>
+        </network>
+      </ethereum>
+    requires #rangeAddress(ACCT_ID)
+     andBool ACCT_ID =/=Int 0
+     andBool #notPrecompileAddress(ACCT_ID)
+     andBool #rangeAddress(CALLER_ID)
+     andBool #rangeAddress(ORIGIN_ID)
+     andBool #rangeUInt(256, TIME)
+     andBool #rangeUInt(256, ACCT_ID_balance)
+     andBool #rangeUInt(256, ECREC_BAL)
+     andBool #rangeUInt(256, SHA256_BAL)
+     andBool #rangeUInt(256, RIP160_BAL)
+     andBool #rangeUInt(256, ID_BAL)
+     andBool #rangeUInt(256, MODEXP_BAL)
+     andBool #rangeUInt(256, ECADD_BAL)
+     andBool #rangeUInt(256, ECMUL_BAL)
+     andBool #rangeUInt(256, ECPAIRING_BAL)
+     andBool #rangeUInt(256, BLAKE2_BAL)
+     andBool VCallDepth <=Int 1024
+     andBool #rangeUInt(256, VCallValue)
+     andBool #rangeUInt(256, VChainId)
+
+     andBool (#rangeUInt(48, Ttl)
+     andBool (#rangeUInt(48, Tau)
+     andBool (#sizeByteArray(CD) <=Int 1250000000
+     andBool (2300 <Int VGas -Int (1120)
+     andBool (#rangeUInt(256, Junk_0)
+     andBool ((VCallValue ==Int 0)))))))
+
+     andBool #lookup(ACCT_ID_STORAGE, #Flipper.ttl_tau) ==Int #WordPackUInt48UInt48(Ttl, Tau)
+     andBool #lookup(ACCT_ID_ORIG_STORAGE, #Flipper.ttl_tau) ==Int Junk_0
+
+endmodule

--- a/tests/specs/mcd/vat-addui-fail-rough-spec.k
+++ b/tests/specs/mcd/vat-addui-fail-rough-spec.k
@@ -1,0 +1,193 @@
+requires "verification.k"
+
+module VAT-ADDUI-FAIL-ROUGH-SPEC
+    imports VERIFICATION
+
+    // Vat_addui
+    rule [Vat.addui.fail.rough]:
+      <k> #execute ~> CONTINUATION => #halt ~> CONTINUATION </k>
+      <exit-code> 1 </exit-code>
+      <mode> NORMAL </mode>
+      <schedule> ISTANBUL </schedule>
+      <ethereum>
+        <evm>
+          <output> _ => ?_ </output>
+          <statusCode> _ => ?FAILURE:EndStatusCode </statusCode>
+          <endPC> _ => ?_ </endPC>
+          <callStack> _VCallStack </callStack>
+          <interimStates> _ </interimStates>
+          <touchedAccounts> _ => ?_ </touchedAccounts>
+          <callState>
+            <program> Vat_bin_runtime </program>
+            <jumpDests> #computeValidJumpDests(Vat_bin_runtime) </jumpDests>
+            <id> ACCT_ID </id>
+            <caller> CALLER_ID </caller>
+            <callData> _ => ?_ </callData>
+            <callValue> VCallValue </callValue>
+            <wordStack> #unsigned(ABI_y) : ABI_x : JMPTO : WS  => ?_ </wordStack>
+            <localMem> _ </localMem>
+            <pc> 13112 => ?_ </pc>
+            <gas> VGas => ?_ </gas>
+            <memoryUsed> VMemoryUsed </memoryUsed>
+            <callGas> _ => ?_ </callGas>
+            <static> _ </static>
+            <callDepth> VCallDepth => ?_ </callDepth>
+          </callState>
+          <substate>
+            <selfDestruct> _VSelfDestruct </selfDestruct>
+            <log> _ => ?_ </log>
+            <refund> _Vrefund => ?_ </refund>
+          </substate>
+          <gasPrice> _ </gasPrice>
+          <origin> ORIGIN_ID </origin>
+          <blockhashes> _ </blockhashes>
+          <block>
+            <previousHash> _ </previousHash>
+            <ommersHash> _ </ommersHash>
+            <coinbase> _ </coinbase>
+            <stateRoot> _ </stateRoot>
+            <transactionsRoot> _ </transactionsRoot>
+            <receiptsRoot> _ </receiptsRoot>
+            <logsBloom> _ </logsBloom>
+            <difficulty> _ </difficulty>
+            <number> _BLOCK_NUMBER </number>
+            <gasLimit> _ </gasLimit>
+            <gasUsed> _ </gasUsed>
+            <timestamp> TIME </timestamp>
+            <extraData> _ </extraData>
+            <mixHash> _ </mixHash>
+            <blockNonce> _ </blockNonce>
+            <ommerBlockHeaders> _ </ommerBlockHeaders>
+          </block>
+        </evm>
+        <network>
+          <chainID> VChainId </chainID>
+          <activeAccounts> SetItem(ACCT_ID)
+          SetItem(1)
+          SetItem(2)
+          SetItem(3)
+          SetItem(4)
+          SetItem(5)
+          SetItem(6)
+          SetItem(7)
+          SetItem(8)
+          SetItem(9) _ </activeAccounts>
+          <accounts>
+            <account>
+              <acctID> ACCT_ID </acctID>
+              <balance> ACCT_ID_balance </balance>
+              <code> Vat_bin_runtime </code>
+              <storage> ACCT_ID_STORAGE => ?_ACCT_ID_STORAGE </storage>
+              <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
+              <nonce> _Nonce_Vat => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> 1 </acctID>
+              <balance> ECREC_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 2 </acctID>
+              <balance> SHA256_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 3 </acctID>
+              <balance> RIP160_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 4 </acctID>
+              <balance> ID_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 5 </acctID>
+              <balance> MODEXP_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 6 </acctID>
+              <balance> ECADD_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 7 </acctID>
+              <balance> ECMUL_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 8 </acctID>
+              <balance> ECPAIRING_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 9 </acctID>
+              <balance> BLAKE2_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+           ...
+          </accounts>
+          <txOrder> _ </txOrder>
+          <txPending> _ </txPending>
+          <messages> _ </messages>
+        </network>
+      </ethereum>
+    requires #rangeAddress(ACCT_ID)
+     andBool ACCT_ID =/=Int 0
+     andBool #notPrecompileAddress(ACCT_ID)
+     andBool #rangeAddress(CALLER_ID)
+     andBool #rangeAddress(ORIGIN_ID)
+     andBool #rangeUInt(256, TIME)
+     andBool #rangeUInt(256, ACCT_ID_balance)
+     andBool #rangeUInt(256, ECREC_BAL)
+     andBool #rangeUInt(256, SHA256_BAL)
+     andBool #rangeUInt(256, RIP160_BAL)
+     andBool #rangeUInt(256, ID_BAL)
+     andBool #rangeUInt(256, MODEXP_BAL)
+     andBool #rangeUInt(256, ECADD_BAL)
+     andBool #rangeUInt(256, ECMUL_BAL)
+     andBool #rangeUInt(256, ECPAIRING_BAL)
+     andBool #rangeUInt(256, BLAKE2_BAL)
+     andBool VCallDepth <=Int 1024
+     andBool #rangeUInt(256, VCallValue)
+     andBool #rangeUInt(256, VChainId)
+
+     andBool (#rangeUInt(256, ABI_x)
+     andBool (#rangeSInt(256, ABI_y)
+     andBool ((#sizeWordStack(WS) <=Int 1015)
+     andBool (#rangeUInt(256, VMemoryUsed)
+     andBool (VGas >=Int 3000000)))))
+
+     andBool notBool ( ((#rangeUInt(256, ABI_x:Int +Int ABI_y:Int))) )
+
+     ensures ?FAILURE =/=K EVMC_SUCCESS
+
+endmodule

--- a/tests/specs/mcd/vat-addui-fail-rough-spec.k
+++ b/tests/specs/mcd/vat-addui-fail-rough-spec.k
@@ -24,7 +24,7 @@ module VAT-ADDUI-FAIL-ROUGH-SPEC
             <caller> CALLER_ID </caller>
             <callData> _ => ?_ </callData>
             <callValue> VCallValue </callValue>
-            <wordStack> #unsigned(ABI_y) : ABI_x : JMPTO : WS  => ?_ </wordStack>
+            <wordStack> chop(ABI_y) : ABI_x : JMPTO : WS  => ?_ </wordStack>
             <localMem> _ </localMem>
             <pc> 13112 => ?_ </pc>
             <gas> VGas => ?_ </gas>

--- a/tests/specs/mcd/vat-mului-pass-spec.k
+++ b/tests/specs/mcd/vat-mului-pass-spec.k
@@ -24,7 +24,7 @@ module VAT-MULUI-PASS-SPEC
             <caller> CALLER_ID </caller>
             <callData> _ => ?_ </callData>
             <callValue> VCallValue </callValue>
-            <wordStack> #unsigned(ABI_y) : ABI_x : JMPTO : WS  =>  JMPTO : #unsigned(ABI_x *Int ABI_y) : WS </wordStack>
+            <wordStack> chop(ABI_y) : ABI_x : JMPTO : WS  =>  JMPTO : chop(ABI_x *Int ABI_y) : WS </wordStack>
             <localMem> _ </localMem>
             <pc> 13175 => 13233 </pc>
             <gas> VGas => VGas -Int ((#if ( ABI_y ==K 0 ) #then ( 96 ) #else ( 132 ) #fi)) </gas>

--- a/tests/specs/mcd/vat-mului-pass-spec.k
+++ b/tests/specs/mcd/vat-mului-pass-spec.k
@@ -1,0 +1,191 @@
+requires "verification.k"
+
+module VAT-MULUI-PASS-SPEC
+    imports VERIFICATION
+
+    // Vat_mului
+    rule [Vat.mului.pass]:
+      <k> #execute ~> CONTINUATION => #execute ~> CONTINUATION </k>
+      <exit-code> 1 </exit-code>
+      <mode> NORMAL </mode>
+      <schedule> ISTANBUL </schedule>
+      <ethereum>
+        <evm>
+          <output> VOutput => VOutput </output>
+          <statusCode> _ => ?_ </statusCode>
+          <endPC> _ => ?_ </endPC>
+          <callStack> _VCallStack </callStack>
+          <interimStates> _ </interimStates>
+          <touchedAccounts> _ => ?_ </touchedAccounts>
+          <callState>
+            <program> Vat_bin_runtime </program>
+            <jumpDests> #computeValidJumpDests(Vat_bin_runtime) </jumpDests>
+            <id> ACCT_ID </id>
+            <caller> CALLER_ID </caller>
+            <callData> _ => ?_ </callData>
+            <callValue> VCallValue </callValue>
+            <wordStack> #unsigned(ABI_y) : ABI_x : JMPTO : WS  =>  JMPTO : #unsigned(ABI_x *Int ABI_y) : WS </wordStack>
+            <localMem> _ </localMem>
+            <pc> 13175 => 13233 </pc>
+            <gas> VGas => VGas -Int ((#if ( ABI_y ==K 0 ) #then ( 96 ) #else ( 132 ) #fi)) </gas>
+            <memoryUsed> VMemoryUsed </memoryUsed>
+            <callGas> _ => ?_ </callGas>
+            <static> _ </static>
+            <callDepth> VCallDepth </callDepth>
+          </callState>
+          <substate>
+            <selfDestruct> _VSelfDestruct </selfDestruct>
+            <log> _ => ?_ </log>
+            <refund> _Vrefund => ?_ </refund>
+          </substate>
+          <gasPrice> _ </gasPrice>
+          <origin> ORIGIN_ID </origin>
+          <blockhashes> _ </blockhashes>
+          <block>
+            <previousHash> _ </previousHash>
+            <ommersHash> _ </ommersHash>
+            <coinbase> _ </coinbase>
+            <stateRoot> _ </stateRoot>
+            <transactionsRoot> _ </transactionsRoot>
+            <receiptsRoot> _ </receiptsRoot>
+            <logsBloom> _ </logsBloom>
+            <difficulty> _ </difficulty>
+            <number> _BLOCK_NUMBER </number>
+            <gasLimit> _ </gasLimit>
+            <gasUsed> _ </gasUsed>
+            <timestamp> TIME </timestamp>
+            <extraData> _ </extraData>
+            <mixHash> _ </mixHash>
+            <blockNonce> _ </blockNonce>
+            <ommerBlockHeaders> _ </ommerBlockHeaders>
+          </block>
+        </evm>
+        <network>
+          <chainID> VChainId </chainID>
+          <activeAccounts> SetItem(ACCT_ID)
+          SetItem(1)
+          SetItem(2)
+          SetItem(3)
+          SetItem(4)
+          SetItem(5)
+          SetItem(6)
+          SetItem(7)
+          SetItem(8)
+          SetItem(9) _ </activeAccounts>
+          <accounts>
+            <account>
+              <acctID> ACCT_ID </acctID>
+              <balance> ACCT_ID_balance </balance>
+              <code> Vat_bin_runtime </code>
+              <storage> ACCT_ID_STORAGE => ACCT_ID_STORAGE  </storage>
+              <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
+              <nonce> _Nonce_Vat => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> 1 </acctID>
+              <balance> ECREC_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 2 </acctID>
+              <balance> SHA256_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 3 </acctID>
+              <balance> RIP160_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 4 </acctID>
+              <balance> ID_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 5 </acctID>
+              <balance> MODEXP_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 6 </acctID>
+              <balance> ECADD_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 7 </acctID>
+              <balance> ECMUL_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 8 </acctID>
+              <balance> ECPAIRING_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 9 </acctID>
+              <balance> BLAKE2_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+           ...
+          </accounts>
+          <txOrder> _ </txOrder>
+          <txPending> _ </txPending>
+          <messages> _ </messages>
+        </network>
+      </ethereum>
+    requires #rangeAddress(ACCT_ID)
+     andBool ACCT_ID =/=Int 0
+     andBool #notPrecompileAddress(ACCT_ID)
+     andBool #rangeAddress(CALLER_ID)
+     andBool #rangeAddress(ORIGIN_ID)
+     andBool #rangeUInt(256, TIME)
+     andBool #rangeUInt(256, ACCT_ID_balance)
+     andBool #rangeUInt(256, ECREC_BAL)
+     andBool #rangeUInt(256, SHA256_BAL)
+     andBool #rangeUInt(256, RIP160_BAL)
+     andBool #rangeUInt(256, ID_BAL)
+     andBool #rangeUInt(256, MODEXP_BAL)
+     andBool #rangeUInt(256, ECADD_BAL)
+     andBool #rangeUInt(256, ECMUL_BAL)
+     andBool #rangeUInt(256, ECPAIRING_BAL)
+     andBool #rangeUInt(256, BLAKE2_BAL)
+     andBool VCallDepth <=Int 1024
+     andBool #rangeUInt(256, VCallValue)
+     andBool #rangeUInt(256, VChainId)
+
+     andBool (#rangeUInt(256, ABI_x)
+     andBool (#rangeSInt(256, ABI_y)
+     andBool ((#sizeWordStack(WS) <=Int 1000)
+     andBool (#rangeUInt(256, VMemoryUsed)
+     andBool (2300 <Int VGas -Int ((#if ( ABI_y ==K 0 ) #then ( 96 ) #else ( 132 ) #fi))
+     andBool ((#rangeSInt(256, ABI_x))
+     andBool ((#rangeSInt(256, ABI_x *Int ABI_y)))))))))
+
+endmodule

--- a/tests/specs/mcd/verification.k
+++ b/tests/specs/mcd/verification.k
@@ -199,12 +199,12 @@ module VERIFICATION
     //        => (X *Int Y) /Int Y
     //        => X
     //
-    // Via Z3 ?.?.?:
-    // ; 2^6 and 2^5 instead of 2^256 and 2^255 for small model proof
+    // Via Z3 4.7.1:
+    // ; 2^4 and 2^3 instead of 2^256 and 2^255 for small model proof
     // (declare-const pow256 Int)
-    // (assert (= pow256 64))
+    // (assert (= pow256 16))
     // (declare-const pow255 Int)
-    // (assert (= pow255 32))
+    // (assert (= pow255 8))
     //
     // ; sgn
     // (declare-fun sgn (Int) Int)

--- a/tests/specs/mcd/verification.k
+++ b/tests/specs/mcd/verification.k
@@ -69,6 +69,11 @@ module VERIFICATION-SYNTAX
     rule nthbyteof(V, I, N) => nthbyteof(V /Int 256, I, N -Int 1) when N  >Int (I +Int 1) [concrete]
     rule nthbyteof(V, I, N) =>           V modInt 256             when N ==Int (I +Int 1) [concrete]
 
+    syntax Int ::= #unsigned ( Int ) [function]
+ // -------------------------------------------
+    rule #unsigned(DATA) => DATA             requires 0 <=Int DATA andBool DATA <=Int maxSInt256
+    rule #unsigned(DATA) => pow256 +Int DATA requires minSInt256 <=Int DATA andBool DATA <Int 0
+
 endmodule
 
 module VERIFICATION

--- a/tests/specs/mcd/verification.k
+++ b/tests/specs/mcd/verification.k
@@ -147,5 +147,48 @@ module VERIFICATION
     // ### vat-mului-fail-rough
 
     rule #unsigned(Y) ==K 0 => Y ==K 0 requires #rangeSInt(256, Y) [smt-lemma]
+    rule       abs(Y) ==K 0 => Y ==K 0 requires #rangeUInt(256, Y) [smt-lemma]
+
+    // Proof:
+    // case sgn(#unsigned(Y)) ==Int 1                   // #unsigned(Y) ==Int Y andBool 0 <=Int Y
+    //      chop(X *Int #unsigned(Y))
+    //   => chop(X *Int Y)                              // #unsigned(Y) ==Int Y
+    // case sgn(#unsigned(Y)) ==Int -1                  // #unsigned(Y) ==Int Y +Int pow256 andBool Y <Int 0
+    //      chop(X *Int #unsigned(Y))
+    //   => chop(X *Int (Y +Int pow256))                // #unsigned(Y) ==Int Y +Int pow256
+    //   => chop(X *Int Y +Int X *Int pow256)
+    //   => chop((X *Int Y) +Int chop(X *Int pow256))
+    //   => chop(X *Int Y)
+    rule chop(X *Int #unsigned(Y)) => chop(X *Int Y) requires #rangeSInt(256, Y)
+
+    // Proof:
+    // case sgn(#unsigned(Y)) ==Int 1                           // 0 <=Int Y andBool #unsigned(Y) ==Int Y
+    //      sgn(chop(X *Int Y)) *Int sgn(#unsigned(Y))
+    //   => sgn(X *Int Y) *Int sgn(Y)                           // 0 <=Int X andBool 0 <=Int Y andBool #rangeSInt(256, X *Int Y) andBool #unsigned(Y) ==Int Y
+    //   => 1 *Int 1                                            // 0 <=Int X *Int Y andBool #rangeSInt(256, X *Int Y)
+    //   => 1
+    // case sgn(#unsigned(Y)) ==Int -1                          // Y <Int 0 andBool #unsigned(Y) ==Int Y +Int pow256
+    //      sgn(chop(X *Int Y)) *Int sgn(#unsigned(Y))
+    //   => sgn(X *Int Y +Int pow256) *Int sgn(Y +Int pow256)   // 0 <=Int X andBool Y <Int 0 andBool #rangeSInt(256, X *Int Y) andBool #unsigned(Y) ==Int Y +Int pow256
+    //   => -1 *Int -1                                          // X *Int Y <Int 0 andBool #rangeSInt(256, X *Int Y) andBool Y <Int andBool #rangeSInt(256, Y)
+    //   => 1
+    rule sgn(chop(X *Int Y)) *Int sgn(#unsigned(Y)) => 1 requires #rangeUInt(256, X) andBool #rangeSInt(256, Y) andBool #rangeSInt(256, X *Int Y)
+
+    // Proof (assuming Y =/=Int 0):
+    // case sgn(#unsigned(Y)) ==Int 1                                                   // 0 <=Int Y andBool #unsigned(Y) ==Int Y
+    //      abs(chop(X *Int Y)) /Int abs(#unsigned(Y))
+    //      abs(X *Int Y) /Int abs(Y)                                                   // #rangeSInt(256, Y) andBool #unsigned(Y) ==Int Y
+    //      X *Int Y /Int Y                                                             // #rangeSInt(256, X *Int Y) andBool 0 <=Int X *Int Y andBool #rangeSInt(256, Y) andBool 0 <=Int Y
+    //      X
+    // case sgn(#unsigned(Y)) ==Int -1                                                  // Y <Int 0 andBool #unsigned(Y) ==Int Y +Int pow256
+    //      abs(chop(X *Int Y)) /Int abs(#unsigned(Y))
+    //   => abs(X *Int Y +Int pow256) /Int abs(Y +Int pow256)                           // #rangeSInt(256, X *Int Y) andBool #unsigned(Y) ==Int Y +Int pow256
+    //   => (0 -Word (X *Int Y +Int pow256)) /Int (0 -Word (Y +Int pow256))             // #rangeSInt(256, X *Int Y) andBool X *Int Y <Int 0 andBool #rangeSInt(256, Y) andBool Y <Int 0
+    //   => (pow256 -Int (X *Int Y +Int pow256)) /Int (pow256 -Int (Y +Int pow256))     // 0 <Int (X *Int Y +Int pow256) andBool 0 <Int (Y +Int pow256)
+    //   => (X *Int Y) /Int Y
+    //   => X
+    rule abs(chop(X *Int Y)) /Int abs(#unsigned(Y)) => X requires #rangeUInt(256, X) andBool #rangeSInt(256, Y) andBool #rangeSInt(256, X *Int Y) andBool Y =/=Int 0
+
+    rule #unsigned(Y) ==K chop(Y) => true requires #rangeSInt(256, Y) [smt-lemma]
 
 endmodule

--- a/tests/specs/mcd/verification.k
+++ b/tests/specs/mcd/verification.k
@@ -121,60 +121,50 @@ module VERIFICATION
 
     // ### vat-addui-fail-rough
 
-    // Proof (remembering that sgn(0) ==Int 1 and using the rules for _s<Word_ and _<Word_):
+    // Proof:
     // case sgn(X) ==Int  1
     //      X s<Word 0
     //   => X <Word 0           // sgn(X) ==Int 1 andBool sgn(0) ==Int 1
     //   => bool2Word(false)    // #rangeUInt(256, X)
     // case sgn(X) ==Int -1
     //      X s<Word 0
-    //   => bool2Word(true)     // sgn(X) ==Int -1
+    //   => bool2Word(true)     // sgn(X) ==Int -1 andBool sgn(0) ==Int 1
     rule X s<Word 0 => bool2Word(sgn(X) ==Int -1) requires #rangeUInt(256, X)
 
     rule sgn(chop(X)) ==Int -1 => X <Int 0 requires #rangeSInt(256, X)
 
     // ### vat-mului-fail-rough
 
-    // Proof:
-    // case 0 <=Int chop(Y)                             // chop(Y) ==Int Y
-    //      chop(X *Int chop(Y))
-    //   => chop(X *Int Y)                              // chop(Y) ==Int Y
-    // case chop(Y) <Int 0                              // chop(Y) ==Int Y +Int pow256
-    //      chop(X *Int chop(Y))
-    //   => chop(X *Int (Y +Int pow256))                // chop(Y) ==Int Y +Int pow256
-    //   => chop(X *Int Y +Int X *Int pow256)
-    //   => chop(X *Int Y +Int chop(X *Int pow256))
-    //   => chop(X *Int Y +Int 0)
-    //   => chop(X *Int Y)
-    rule chop(X *Int chop(Y)) => chop(X *Int Y) requires #rangeSInt(256, Y)
+    rule chop(X *Int chop(Y)) => chop(X *Int Y)
 
-    // Proof:
-    // case 0 <=Int chop(Y)                                     // chop(Y) ==Int Y
-    //      sgn(chop(X *Int Y)) *Int sgn(chop(Y))
-    //   => sgn(chop(X *Int Y)) *Int sgn(Y)                     // chop(Y) ==Int Y
-    //   => sgn(X *Int Y) *Int sgn(Y)                           // 0 <=Int X andBool 0 <=Int Y andBool #rangeSInt(256, X *Int Y)
-    //   => 1 *Int 1                                            // 0 <=Int X *Int Y andBool 0 <=Int Y
-    //   => 1
-    // case sgn(chop(Y)) ==Int -1                               // Y <Int 0 andBool chop(Y) ==Int Y +Int pow256
-    //      sgn(chop(X *Int Y)) *Int sgn(chop(Y))
-    //   => sgn(X *Int Y +Int pow256) *Int sgn(Y +Int pow256)   // 0 <=Int X andBool Y <Int 0 andBool #rangeSInt(256, X *Int Y) andBool chop(Y) ==Int Y +Int pow256
-    //   => -1 *Int -1                                          // X *Int Y <Int 0 andBool #rangeSInt(256, X *Int Y) andBool Y <Int andBool #rangeSInt(256, Y)
-    //   => 1
-    rule sgn(chop(X *Int Y)) *Int sgn(chop(Y)) => 1 requires #rangeUInt(256, X) andBool #rangeSInt(256, Y) andBool #rangeSInt(256, X *Int Y)
-
-    // Proof (assuming Y =/=Int 0):
-    // case sgn(chop(Y)) ==Int 1                                                        // 0 <=Int Y andBool chop(Y) ==Int Y
-    //      abs(chop(X *Int Y)) /Int abs(chop(Y))
-    //   => abs(X *Int Y) /Int abs(Y)                                                   // #rangeSInt(256, Y) andBool chop(Y) ==Int Y
-    //   => X *Int Y /Int Y                                                             // #rangeSInt(256, X *Int Y) andBool 0 <=Int X *Int Y andBool #rangeSInt(256, Y) andBool 0 <=Int Y
-    //   => X
-    // case sgn(chop(Y)) ==Int -1                                                       // Y <Int 0 andBool chop(Y) ==Int Y +Int pow256
-    //      abs(chop(X *Int Y)) /Int abs(chop(Y))
-    //   => abs(X *Int Y +Int pow256) /Int abs(Y +Int pow256)                           // #rangeSInt(256, X *Int Y) andBool chop(Y) ==Int Y +Int pow256
-    //   => (0 -Word (X *Int Y +Int pow256)) /Int (0 -Word (Y +Int pow256))             // #rangeSInt(256, X *Int Y) andBool X *Int Y <Int 0 andBool #rangeSInt(256, Y) andBool Y <Int 0
-    //   => (pow256 -Int (X *Int Y +Int pow256)) /Int (pow256 -Int (Y +Int pow256))     // 0 <Int (X *Int Y +Int pow256) andBool 0 <Int (Y +Int pow256)
-    //   => (X *Int Y) /Int Y
-    //   => X
-    rule abs(chop(X *Int Y)) /Int abs(chop(Y)) => X requires #rangeUInt(256, X) andBool #rangeSInt(256, Y) andBool #rangeSInt(256, X *Int Y) andBool Y =/=Int 0
+    // Proof #rangUInt(256, X) andBool #rangeSInt(256, Y) andBool #rangeSInt(256, X *Int Y) andBool Y =/=Int 0
+    //      chop(X *Int Y) /sWord chop(Y)
+    //   => #sgnInterp(sgn(chop(X *Int Y)) *Int sgn(chop(Y)), abs(chop(X *Int Y)) /Word abs(chop(Y)))
+    // Focus: sgn(chop(X *Int Y)) *Int sgn(chop(Y))
+    //      case 0 <=Int chop(Y)
+    //           sgn(chop(X *Int Y)) *Int sgn(chop(Y))
+    //        => sgn(chop(X *Int Y)) *Int sgn(Y)                     // chop(Y) ==Int Y
+    //        => sgn(X *Int Y) *Int sgn(Y)                           // 0 <=Int X andBool 0 <=Int Y
+    //        => 1 *Int 1                                            // 0 <=Int X *Int Y andBool 0 <=Int Y
+    //        => 1
+    //      case Y <Int 0
+    //           sgn(chop(X *Int Y)) *Int sgn(chop(Y))
+    //        => sgn(X *Int Y +Int pow256) *Int sgn(Y +Int pow256)   // chop(Y) ==Int Y +Int pow256
+    //        => -1 *Int -1                                          // X *Int Y <Int 0 andBool Y <Int 0
+    //        => 1
+    // Focus: abs(chop(X *Int Y)) /Word abs(chop(Y))
+    //      case 0 <=Int Y
+    //           abs(chop(X *Int Y)) /Int abs(chop(Y))
+    //        => abs(X *Int Y) /Int abs(Y)                                                   // 0 <=Int X andBool 0 <=Int Y andBool #rangeSigne andBool chop(Y) ==Int Y
+    //        => X *Int Y /Int Y                                                             // #rangeSInt(256, X *Int Y) andBool 0 <=Int X *Int Y andBool #rangeSInt(256, Y) andBool 0 <=Int Y
+    //        => X
+    //      case Y <Int 0
+    //           abs(chop(X *Int Y)) /Int abs(chop(Y))
+    //        => abs(X *Int Y +Int pow256) /Int abs(Y +Int pow256)                           // #rangeSInt(256, X *Int Y) andBool chop(Y) ==Int Y +Int pow256
+    //        => (0 -Word (X *Int Y +Int pow256)) /Int (0 -Word (Y +Int pow256))             // #rangeSInt(256, X *Int Y) andBool X *Int Y <Int 0 andBool #rangeSInt(256, Y) andBool Y <Int 0
+    //        => (pow256 -Int (X *Int Y +Int pow256)) /Int (pow256 -Int (Y +Int pow256))     // 0 <Int (X *Int Y +Int pow256) andBool 0 <Int (Y +Int pow256)
+    //        => (X *Int Y) /Int Y
+    //        => X
+    rule chop(X *Int Y) /sWord chop(Y) => X requires #rangeUInt(256, X) andBool #rangeSInt(256, Y) andBool #rangeSInt(256, X *Int Y) andBool Y =/=Int 0
 
 endmodule

--- a/tests/specs/mcd/verification.k
+++ b/tests/specs/mcd/verification.k
@@ -131,27 +131,29 @@ module VERIFICATION
     //   => bool2Word(true)     // sgn(X) ==Int -1
     rule X s<Word 0 => bool2Word(sgn(X) ==Int -1) requires #rangeUInt(256, X)
 
-    rule sgn(chop(X)) ==Int -1 => minSInt256 <=Int X andBool X <Int 0  requires #rangeSInt(256, X)
+    rule sgn(chop(X)) ==Int -1 => X <Int 0 requires #rangeSInt(256, X)
 
     // ### vat-mului-fail-rough
 
     // Proof:
-    // case sgn(chop(Y)) ==Int 1                      // chop(Y) ==Int Y andBool 0 <=Int Y
+    // case 0 <=Int chop(Y)                             // chop(Y) ==Int Y
     //      chop(X *Int chop(Y))
-    //   => chop(X *Int Y)                            // chop(Y) ==Int Y
-    // case sgn(chop(Y)) ==Int -1                     // chop(Y) ==Int Y +Int pow256 andBool Y <Int 0
+    //   => chop(X *Int Y)                              // chop(Y) ==Int Y
+    // case chop(Y) <Int 0                              // chop(Y) ==Int Y +Int pow256
     //      chop(X *Int chop(Y))
-    //   => chop(X *Int (Y +Int pow256))              // chop(Y) ==Int Y +Int pow256
+    //   => chop(X *Int (Y +Int pow256))                // chop(Y) ==Int Y +Int pow256
     //   => chop(X *Int Y +Int X *Int pow256)
-    //   => chop((X *Int Y) +Int chop(X *Int pow256))
+    //   => chop(X *Int Y +Int chop(X *Int pow256))
+    //   => chop(X *Int Y +Int 0)
     //   => chop(X *Int Y)
     rule chop(X *Int chop(Y)) => chop(X *Int Y) requires #rangeSInt(256, Y)
 
     // Proof:
-    // case sgn(chop(Y)) ==Int 1                                // 0 <=Int Y andBool chop(Y) ==Int Y
+    // case 0 <=Int chop(Y)                                     // chop(Y) ==Int Y
     //      sgn(chop(X *Int Y)) *Int sgn(chop(Y))
-    //   => sgn(X *Int Y) *Int sgn(Y)                           // 0 <=Int X andBool 0 <=Int Y andBool #rangeSInt(256, X *Int Y) andBool chop(Y) ==Int Y
-    //   => 1 *Int 1                                            // 0 <=Int X *Int Y andBool #rangeSInt(256, X *Int Y)
+    //   => sgn(chop(X *Int Y)) *Int sgn(Y)                     // chop(Y) ==Int Y
+    //   => sgn(X *Int Y) *Int sgn(Y)                           // 0 <=Int X andBool 0 <=Int Y andBool #rangeSInt(256, X *Int Y)
+    //   => 1 *Int 1                                            // 0 <=Int X *Int Y andBool 0 <=Int Y
     //   => 1
     // case sgn(chop(Y)) ==Int -1                               // Y <Int 0 andBool chop(Y) ==Int Y +Int pow256
     //      sgn(chop(X *Int Y)) *Int sgn(chop(Y))
@@ -163,9 +165,9 @@ module VERIFICATION
     // Proof (assuming Y =/=Int 0):
     // case sgn(chop(Y)) ==Int 1                                                        // 0 <=Int Y andBool chop(Y) ==Int Y
     //      abs(chop(X *Int Y)) /Int abs(chop(Y))
-    //      abs(X *Int Y) /Int abs(Y)                                                   // #rangeSInt(256, Y) andBool chop(Y) ==Int Y
-    //      X *Int Y /Int Y                                                             // #rangeSInt(256, X *Int Y) andBool 0 <=Int X *Int Y andBool #rangeSInt(256, Y) andBool 0 <=Int Y
-    //      X
+    //   => abs(X *Int Y) /Int abs(Y)                                                   // #rangeSInt(256, Y) andBool chop(Y) ==Int Y
+    //   => X *Int Y /Int Y                                                             // #rangeSInt(256, X *Int Y) andBool 0 <=Int X *Int Y andBool #rangeSInt(256, Y) andBool 0 <=Int Y
+    //   => X
     // case sgn(chop(Y)) ==Int -1                                                       // Y <Int 0 andBool chop(Y) ==Int Y +Int pow256
     //      abs(chop(X *Int Y)) /Int abs(chop(Y))
     //   => abs(X *Int Y +Int pow256) /Int abs(Y +Int pow256)                           // #rangeSInt(256, X *Int Y) andBool chop(Y) ==Int Y +Int pow256

--- a/tests/specs/mcd/verification.k
+++ b/tests/specs/mcd/verification.k
@@ -144,4 +144,8 @@ module VERIFICATION
     // property of 2s complement
     rule notBool (0 <=Int X +Int Y) => X <Int chop(X +Int #unsigned(Y)) requires #rangeUInt(256, X) andBool #rangeSInt(256, Y) [smt-lemma]
 
+    // ### vat-mului-fail-rough
+
+    rule #unsigned(Y) ==K 0 => Y ==K 0 requires #rangeSInt(256, Y) [smt-lemma]
+
 endmodule

--- a/tests/specs/mcd/verification.k
+++ b/tests/specs/mcd/verification.k
@@ -69,11 +69,6 @@ module VERIFICATION-SYNTAX
     rule nthbyteof(V, I, N) => nthbyteof(V /Int 256, I, N -Int 1) when N  >Int (I +Int 1) [concrete]
     rule nthbyteof(V, I, N) =>           V modInt 256             when N ==Int (I +Int 1) [concrete]
 
-    syntax Int ::= #unsigned ( Int ) [function, smtlib(unsigned)]
- // -------------------------------------------------------------
-    rule #unsigned(DATA) => DATA             requires 0 <=Int DATA andBool DATA <=Int maxSInt256
-    rule #unsigned(DATA) => pow256 +Int DATA requires minSInt256 <=Int DATA andBool DATA <Int 0
-
 endmodule
 
 module VERIFICATION
@@ -126,7 +121,7 @@ module VERIFICATION
 
     // ### vat-addui-fail-rough
 
-    rule #rangeUInt(256, #unsigned(X)) => true requires #rangeSInt(256, X) [smt-lemma]
+    rule #rangeUInt(256, chop(X)) => true requires #rangeSInt(256, X) [smt-lemma]
 
     // Proof (remembering that sgn(0) ==Int 1 and using the rules for _s<Word_ and _<Word_):
     // X s<Word 0
@@ -138,57 +133,57 @@ module VERIFICATION
     rule X s<Word 0 => bool2Word(sgn(X) ==Int -1)                  requires #rangeUInt(256, X)
     rule 0 s<Word X => bool2Word(sgn(X) ==Int  1 andBool 0 <Int X) requires #rangeUInt(256, X)
 
-    rule sgn(#unsigned(X)) ==Int  1 => 0 <=Int X andBool X <=Int maxSInt256 requires #rangeSInt(256, X)
-    rule sgn(#unsigned(X)) ==Int -1 => minSInt256 <=Int X andBool X <Int 0  requires #rangeSInt(256, X)
+    rule sgn(chop(X)) ==Int  1 => 0 <=Int X andBool X <=Int maxSInt256 requires #rangeSInt(256, X)
+    rule sgn(chop(X)) ==Int -1 => minSInt256 <=Int X andBool X <Int 0  requires #rangeSInt(256, X)
 
     // property of 2s complement
-    rule notBool (0 <=Int X +Int Y) => X <Int chop(X +Int #unsigned(Y)) requires #rangeUInt(256, X) andBool #rangeSInt(256, Y) [smt-lemma]
+    rule notBool (0 <=Int X +Int Y) => X <Int chop(X +Int chop(Y)) requires #rangeUInt(256, X) andBool #rangeSInt(256, Y) [smt-lemma]
 
     // ### vat-mului-fail-rough
 
-    rule #unsigned(Y) ==K 0 => Y ==K 0 requires #rangeSInt(256, Y) [smt-lemma]
-    rule       abs(Y) ==K 0 => Y ==K 0 requires #rangeUInt(256, Y) [smt-lemma]
+    rule chop(Y) ==K 0 => Y ==K 0 requires #rangeSInt(256, Y) [smt-lemma]
+    rule  abs(Y) ==K 0 => Y ==K 0 requires #rangeUInt(256, Y) [smt-lemma]
 
     // Proof:
-    // case sgn(#unsigned(Y)) ==Int 1                   // #unsigned(Y) ==Int Y andBool 0 <=Int Y
-    //      chop(X *Int #unsigned(Y))
-    //   => chop(X *Int Y)                              // #unsigned(Y) ==Int Y
-    // case sgn(#unsigned(Y)) ==Int -1                  // #unsigned(Y) ==Int Y +Int pow256 andBool Y <Int 0
-    //      chop(X *Int #unsigned(Y))
-    //   => chop(X *Int (Y +Int pow256))                // #unsigned(Y) ==Int Y +Int pow256
+    // case sgn(chop(Y)) ==Int 1                      // chop(Y) ==Int Y andBool 0 <=Int Y
+    //      chop(X *Int chop(Y))
+    //   => chop(X *Int Y)                            // chop(Y) ==Int Y
+    // case sgn(chop(Y)) ==Int -1                     // chop(Y) ==Int Y +Int pow256 andBool Y <Int 0
+    //      chop(X *Int chop(Y))
+    //   => chop(X *Int (Y +Int pow256))              // chop(Y) ==Int Y +Int pow256
     //   => chop(X *Int Y +Int X *Int pow256)
     //   => chop((X *Int Y) +Int chop(X *Int pow256))
     //   => chop(X *Int Y)
-    rule chop(X *Int #unsigned(Y)) => chop(X *Int Y) requires #rangeSInt(256, Y)
+    rule chop(X *Int chop(Y)) => chop(X *Int Y) requires #rangeSInt(256, Y)
 
     // Proof:
-    // case sgn(#unsigned(Y)) ==Int 1                           // 0 <=Int Y andBool #unsigned(Y) ==Int Y
-    //      sgn(chop(X *Int Y)) *Int sgn(#unsigned(Y))
-    //   => sgn(X *Int Y) *Int sgn(Y)                           // 0 <=Int X andBool 0 <=Int Y andBool #rangeSInt(256, X *Int Y) andBool #unsigned(Y) ==Int Y
+    // case sgn(chop(Y)) ==Int 1                                // 0 <=Int Y andBool chop(Y) ==Int Y
+    //      sgn(chop(X *Int Y)) *Int sgn(chop(Y))
+    //   => sgn(X *Int Y) *Int sgn(Y)                           // 0 <=Int X andBool 0 <=Int Y andBool #rangeSInt(256, X *Int Y) andBool chop(Y) ==Int Y
     //   => 1 *Int 1                                            // 0 <=Int X *Int Y andBool #rangeSInt(256, X *Int Y)
     //   => 1
-    // case sgn(#unsigned(Y)) ==Int -1                          // Y <Int 0 andBool #unsigned(Y) ==Int Y +Int pow256
-    //      sgn(chop(X *Int Y)) *Int sgn(#unsigned(Y))
-    //   => sgn(X *Int Y +Int pow256) *Int sgn(Y +Int pow256)   // 0 <=Int X andBool Y <Int 0 andBool #rangeSInt(256, X *Int Y) andBool #unsigned(Y) ==Int Y +Int pow256
+    // case sgn(chop(Y)) ==Int -1                               // Y <Int 0 andBool chop(Y) ==Int Y +Int pow256
+    //      sgn(chop(X *Int Y)) *Int sgn(chop(Y))
+    //   => sgn(X *Int Y +Int pow256) *Int sgn(Y +Int pow256)   // 0 <=Int X andBool Y <Int 0 andBool #rangeSInt(256, X *Int Y) andBool chop(Y) ==Int Y +Int pow256
     //   => -1 *Int -1                                          // X *Int Y <Int 0 andBool #rangeSInt(256, X *Int Y) andBool Y <Int andBool #rangeSInt(256, Y)
     //   => 1
-    rule sgn(chop(X *Int Y)) *Int sgn(#unsigned(Y)) => 1 requires #rangeUInt(256, X) andBool #rangeSInt(256, Y) andBool #rangeSInt(256, X *Int Y)
+    rule sgn(chop(X *Int Y)) *Int sgn(chop(Y)) => 1 requires #rangeUInt(256, X) andBool #rangeSInt(256, Y) andBool #rangeSInt(256, X *Int Y)
 
     // Proof (assuming Y =/=Int 0):
-    // case sgn(#unsigned(Y)) ==Int 1                                                   // 0 <=Int Y andBool #unsigned(Y) ==Int Y
-    //      abs(chop(X *Int Y)) /Int abs(#unsigned(Y))
-    //      abs(X *Int Y) /Int abs(Y)                                                   // #rangeSInt(256, Y) andBool #unsigned(Y) ==Int Y
+    // case sgn(chop(Y)) ==Int 1                                                        // 0 <=Int Y andBool chop(Y) ==Int Y
+    //      abs(chop(X *Int Y)) /Int abs(chop(Y))
+    //      abs(X *Int Y) /Int abs(Y)                                                   // #rangeSInt(256, Y) andBool chop(Y) ==Int Y
     //      X *Int Y /Int Y                                                             // #rangeSInt(256, X *Int Y) andBool 0 <=Int X *Int Y andBool #rangeSInt(256, Y) andBool 0 <=Int Y
     //      X
-    // case sgn(#unsigned(Y)) ==Int -1                                                  // Y <Int 0 andBool #unsigned(Y) ==Int Y +Int pow256
-    //      abs(chop(X *Int Y)) /Int abs(#unsigned(Y))
-    //   => abs(X *Int Y +Int pow256) /Int abs(Y +Int pow256)                           // #rangeSInt(256, X *Int Y) andBool #unsigned(Y) ==Int Y +Int pow256
+    // case sgn(chop(Y)) ==Int -1                                                       // Y <Int 0 andBool chop(Y) ==Int Y +Int pow256
+    //      abs(chop(X *Int Y)) /Int abs(chop(Y))
+    //   => abs(X *Int Y +Int pow256) /Int abs(Y +Int pow256)                           // #rangeSInt(256, X *Int Y) andBool chop(Y) ==Int Y +Int pow256
     //   => (0 -Word (X *Int Y +Int pow256)) /Int (0 -Word (Y +Int pow256))             // #rangeSInt(256, X *Int Y) andBool X *Int Y <Int 0 andBool #rangeSInt(256, Y) andBool Y <Int 0
     //   => (pow256 -Int (X *Int Y +Int pow256)) /Int (pow256 -Int (Y +Int pow256))     // 0 <Int (X *Int Y +Int pow256) andBool 0 <Int (Y +Int pow256)
     //   => (X *Int Y) /Int Y
     //   => X
-    rule abs(chop(X *Int Y)) /Int abs(#unsigned(Y)) => X requires #rangeUInt(256, X) andBool #rangeSInt(256, Y) andBool #rangeSInt(256, X *Int Y) andBool Y =/=Int 0
+    rule abs(chop(X *Int Y)) /Int abs(chop(Y)) => X requires #rangeUInt(256, X) andBool #rangeSInt(256, Y) andBool #rangeSInt(256, X *Int Y) andBool Y =/=Int 0
 
-    rule #unsigned(Y) ==K chop(Y) => true requires #rangeSInt(256, Y) [smt-lemma]
+    rule chop(Y) ==K chop(Y) => true requires #rangeSInt(256, Y) [smt-lemma]
 
 endmodule

--- a/tests/specs/mcd/verification.k
+++ b/tests/specs/mcd/verification.k
@@ -23,13 +23,23 @@ module VERIFICATION-SYNTAX
  // -----------------------
     rule pow208 => 411376139330301510538742295639337626245683966408394965837152256 [macro]
 
-    syntax Int ::= #WordPackUInt48UInt48     (       Int , Int ) [function]
-                 | #WordPackAddrUInt8        (       Int , Int ) [function]
-                 | #WordPackAddrUInt48UInt48 ( Int , Int , Int ) [function]
- // -----------------------------------------------------------------------
-    rule #WordPackUInt48UInt48     (     X , Y ) => Y *Int pow48  +Int X                    requires #rangeUInt(48, X) andBool #rangeUInt(48, Y)
-    rule #WordPackAddrUInt8        (     X , Y ) => Y *Int pow160 +Int X                    requires #rangeAddress(X)  andBool #rangeUInt(8, Y)
-    rule #WordPackAddrUInt48UInt48 ( A , X , Y ) => Y *Int pow208 +Int X *Int pow160 +Int A requires #rangeAddress(A)  andBool #rangeUInt(48, X) andBool #rangeUInt(48, Y)
+    syntax Int ::= #WordPackUInt48UInt48     (       Int , Int ) [function, no-evaluators, smtlib(WordPackUInt48UInt48)]
+                 | #WordPackAddrUInt48UInt48 ( Int , Int , Int ) [function, no-evaluators, smtlib(WordPackAddrUInt48UInt48)]
+                 | #WordPackAddrUInt8        (       Int , Int ) [function, no-evaluators, smtlib(WordPackAddrUInt8)]
+ // -----------------------------------------------------------------------------------------------------------------
+    // rule #WordPackUInt48UInt48     (            UINT48_1 , UINT48_2 ) => UINT48_2 *Int pow48 +Int UINT48_1                        requires #rangeUInt(48, UINT48_1) andBool #rangeUInt(48, UINT48_2)
+    // rule #WordPackAddrUInt48UInt48 (     ADDR , UINT48_1 , UINT48_2 ) => UINT48_2 *Int pow208 +Int UINT48_1 *Int pow160 +Int ADDR requires #rangeAddress(ADDR) andBool #rangeUInt(48, UINT48_1) andBool #rangeUInt(48, UINT48_2)
+    // rule #WordPackAddrUInt8        (     ADDR , UINT8               ) => UINT8 *Int pow160 +Int ADDR                              requires #rangeAddress(ADDR) andBool #rangeUInt(8, UINT_8)
+
+    rule maxUInt48 &Int  UINT48_UINT48             => UINT48_1 requires UINT48_UINT48 ==Int #WordPackUInt48UInt48(UINT48_1, UINT48_2) andBool #rangeUInt(48, UINT48_1) andBool #rangeUInt(48, UINT48_2) [smt-lemma]
+    rule maxUInt48 &Int (UINT48_UINT48 /Int pow48) => UINT48_2 requires UINT48_UINT48 ==Int #WordPackUInt48UInt48(UINT48_1, UINT48_2) andBool #rangeUInt(48, UINT48_1) andBool #rangeUInt(48, UINT48_2) [smt-lemma]
+
+    rule maxUInt160 &Int  ADDR_UINT48_UINT48              => ADDR     requires ADDR_UINT48_UINT48 ==Int #WordPackAddrUInt48UInt48(ADDR, UINT48_1, UINT48_2) andBool #rangeAddress(ADDR) andBool #rangeUInt(48, UINT48_1) andBool #rangeUInt(48, UINT48_2) [smt-lemma]
+    rule maxUInt48  &Int (ADDR_UINT48_UINT48 /Int pow160) => UINT48_1 requires ADDR_UINT48_UINT48 ==Int #WordPackAddrUInt48UInt48(ADDR, UINT48_1, UINT48_2) andBool #rangeAddress(ADDR) andBool #rangeUInt(48, UINT48_1) andBool #rangeUInt(48, UINT48_2) [smt-lemma]
+    rule maxUInt48  &Int (ADDR_UINT48_UINT48 /Int pow208) => UINT48_2 requires ADDR_UINT48_UINT48 ==Int #WordPackAddrUInt48UInt48(ADDR, UINT48_1, UINT48_2) andBool #rangeAddress(ADDR) andBool #rangeUInt(48, UINT48_1) andBool #rangeUInt(48, UINT48_2) [smt-lemma]
+
+    rule maxUInt160 &Int  ADDR_UINT8              => ADDR  requires ADDR_UINT8 ==Int #WordPackAddrUInt8(ADDR, UINT8) andBool #rangeAddress(ADDR) andBool #rangeUInt(8, UINT8) [smt-lemma]
+    rule maxUInt8   &Int (ADDR_UINT8 /Int pow160) => UINT8 requires ADDR_UINT8 ==Int #WordPackAddrUInt8(ADDR, UINT8) andBool #rangeAddress(ADDR) andBool #rangeUInt(8, UINT8) [smt-lemma]
 
     syntax Int ::= #string2Word ( String ) [function]
  // -------------------------------------------------

--- a/tests/specs/mcd/verification.k
+++ b/tests/specs/mcd/verification.k
@@ -154,7 +154,8 @@ module VERIFICATION
     //        => 1
     // Focus: abs(chop(X *Int Y)) /Word abs(chop(Y))
     //      case 0 <=Int Y
-    //           abs(chop(X *Int Y)) /Int abs(chop(Y))
+    //           abs(chop(X *Int Y)) /Word abs(chop(Y))
+    //        => abs(chop(X *Int Y)) /Int  abs(chop(Y))
     //        => abs(X *Int Y) /Int abs(Y)                                                   // 0 <=Int X andBool 0 <=Int Y andBool #rangeSigne andBool chop(Y) ==Int Y
     //        => X *Int Y /Int Y                                                             // #rangeSInt(256, X *Int Y) andBool 0 <=Int X *Int Y andBool #rangeSInt(256, Y) andBool 0 <=Int Y
     //        => X

--- a/tests/specs/mcd/verification.k
+++ b/tests/specs/mcd/verification.k
@@ -121,8 +121,6 @@ module VERIFICATION
 
     // ### vat-addui-fail-rough
 
-    rule #rangeUInt(256, chop(X)) => true requires #rangeSInt(256, X) [smt-lemma]
-
     // Proof (remembering that sgn(0) ==Int 1 and using the rules for _s<Word_ and _<Word_):
     // X s<Word 0
     //      case sgn(X) ==Int  1 : X <Word 0 => bool2Word(false) (because #rangeUInt(256, X))
@@ -130,19 +128,11 @@ module VERIFICATION
     // 0 s<Word X
     //      case sgn(X) ==Int  1 : 0 <Word X
     //      case sgn(X) ==Int -1 : bool2Word(false)
-    rule X s<Word 0 => bool2Word(sgn(X) ==Int -1)                  requires #rangeUInt(256, X)
-    rule 0 s<Word X => bool2Word(sgn(X) ==Int  1 andBool 0 <Int X) requires #rangeUInt(256, X)
+    rule X s<Word 0 => bool2Word(sgn(X) ==Int -1) requires #rangeUInt(256, X)
 
-    rule sgn(chop(X)) ==Int  1 => 0 <=Int X andBool X <=Int maxSInt256 requires #rangeSInt(256, X)
     rule sgn(chop(X)) ==Int -1 => minSInt256 <=Int X andBool X <Int 0  requires #rangeSInt(256, X)
 
-    // property of 2s complement
-    rule notBool (0 <=Int X +Int Y) => X <Int chop(X +Int chop(Y)) requires #rangeUInt(256, X) andBool #rangeSInt(256, Y) [smt-lemma]
-
     // ### vat-mului-fail-rough
-
-    rule chop(Y) ==K 0 => Y ==K 0 requires #rangeSInt(256, Y) [smt-lemma]
-    rule  abs(Y) ==K 0 => Y ==K 0 requires #rangeUInt(256, Y) [smt-lemma]
 
     // Proof:
     // case sgn(chop(Y)) ==Int 1                      // chop(Y) ==Int Y andBool 0 <=Int Y
@@ -183,7 +173,5 @@ module VERIFICATION
     //   => (X *Int Y) /Int Y
     //   => X
     rule abs(chop(X *Int Y)) /Int abs(chop(Y)) => X requires #rangeUInt(256, X) andBool #rangeSInt(256, Y) andBool #rangeSInt(256, X *Int Y) andBool Y =/=Int 0
-
-    rule chop(Y) ==K chop(Y) => true requires #rangeSInt(256, Y) [smt-lemma]
 
 endmodule

--- a/tests/specs/mcd/verification.k
+++ b/tests/specs/mcd/verification.k
@@ -122,12 +122,13 @@ module VERIFICATION
     // ### vat-addui-fail-rough
 
     // Proof (remembering that sgn(0) ==Int 1 and using the rules for _s<Word_ and _<Word_):
-    // X s<Word 0
-    //      case sgn(X) ==Int  1 : X <Word 0 => bool2Word(false) (because #rangeUInt(256, X))
-    //      case sgn(X) ==Int -1 : bool2Word(true)
-    // 0 s<Word X
-    //      case sgn(X) ==Int  1 : 0 <Word X
-    //      case sgn(X) ==Int -1 : bool2Word(false)
+    // case sgn(X) ==Int  1
+    //      X s<Word 0
+    //   => X <Word 0           // sgn(X) ==Int 1 andBool sgn(0) ==Int 1
+    //   => bool2Word(false)    // #rangeUInt(256, X)
+    // case sgn(X) ==Int -1
+    //      X s<Word 0
+    //   => bool2Word(true)     // sgn(X) ==Int -1
     rule X s<Word 0 => bool2Word(sgn(X) ==Int -1) requires #rangeUInt(256, X)
 
     rule sgn(chop(X)) ==Int -1 => minSInt256 <=Int X andBool X <Int 0  requires #rangeSInt(256, X)

--- a/tests/specs/mcd/verification.k
+++ b/tests/specs/mcd/verification.k
@@ -129,6 +129,38 @@ module VERIFICATION
     // case sgn(X) ==Int -1
     //      X s<Word 0
     //   => bool2Word(true)     // sgn(X) ==Int -1 andBool sgn(0) ==Int 1
+    //
+    // Via Z3 4.8.7:
+    // ; 2^256
+    // (declare-const pow256 Int)
+    // (assert (= pow256 115792089237316195423570985008687907853269984665640564039457584007913129639936))
+    //
+    // ; 2^255
+    // (declare-const pow255 Int)
+    // (assert (= pow255 57896044618658097711785492504343953926634992332820282019728792003956564819968))
+    //
+    // ; sgn
+    // (declare-fun sgn (Int) Int)
+    // (assert (forall ((x Int)) (=> (and (>= x 0)      (< x pow255)) (= (sgn x)  1))))
+    // (assert (forall ((x Int)) (=> (and (>= x pow255) (< x pow256)) (= (sgn x) -1))))
+    //
+    // ; s<Word
+    // (declare-fun slt (Int Int) Bool)
+    // (assert (forall ((x Int) (y Int)) (=> (and (= (sgn x)  1) (= (sgn y)  1)) (= (slt x y) (< x y)))))
+    // (assert (forall ((x Int) (y Int)) (=> (and (= (sgn x)  1) (= (sgn y) -1)) (= (slt x y) false))))
+    // (assert (forall ((x Int) (y Int)) (=> (and (= (sgn x) -1) (= (sgn y)  1)) (= (slt x y) true))))
+    // (assert (forall ((x Int) (y Int)) (=> (and (= (sgn x) -1) (= (sgn y) -1)) (= (slt x y) (> x y)))))
+    //
+    // ;;;; proof
+    //
+    // ; uint256
+    // (declare-const x Int)
+    // (assert (and (>= x 0) (< x pow256)))
+    //
+    // (assert (not
+    //     (= (slt x 0) (= (sgn x) -1))
+    // ))
+    // (check-sat)
     rule X s<Word 0 => bool2Word(sgn(X) ==Int -1) requires #rangeUInt(256, X)
 
     rule sgn(chop(X)) ==Int -1 => X <Int 0 requires #rangeSInt(256, X)
@@ -166,6 +198,58 @@ module VERIFICATION
     //        => (pow256 -Int (X *Int Y +Int pow256)) /Int (pow256 -Int (Y +Int pow256))     // 0 <Int (X *Int Y +Int pow256) andBool 0 <Int (Y +Int pow256)
     //        => (X *Int Y) /Int Y
     //        => X
+    //
+    // Via Z3 ?.?.?:
+    // ; 2^64 and 2^32 instead of 2^256 for small model proof
+    // (declare-const pow256 Int)
+    // (assert (= pow256 64))
+    // (declare-const pow255 Int)
+    // (assert (= pow255 32))
+    //
+    // ; sgn
+    // (declare-fun sgn (Int) Int)
+    // (assert (forall ((x Int)) (=> (and (>= x 0)      (< x pow255)) (= (sgn x)  1))))
+    // (assert (forall ((x Int)) (=> (and (>= x pow255) (< x pow256)) (= (sgn x) -1))))
+    //
+    // ; s<Word
+    // (declare-fun slt (Int Int) Bool)
+    // (assert (forall ((x Int) (y Int)) (=> (and (= (sgn x)  1) (= (sgn y)  1)) (= (slt x y) (< x y)))))
+    // (assert (forall ((x Int) (y Int)) (=> (and (= (sgn x)  1) (= (sgn y) -1)) (= (slt x y) false))))
+    // (assert (forall ((x Int) (y Int)) (=> (and (= (sgn x) -1) (= (sgn y)  1)) (= (slt x y) true))))
+    // (assert (forall ((x Int) (y Int)) (=> (and (= (sgn x) -1) (= (sgn y) -1)) (= (slt x y) (> x y)))))
+    //
+    // ; chop
+    // (define-fun chop ((x Int)) Int (mod x pow256))
+    //
+    // ; /Word
+    // ;(define-fun zdiv ((x Int) (y Int)) Int (ite (= y 0) 0 (div x y)))
+    // (define-fun zdiv ((x Int) (y Int)) Int (div x y)) ; y is non-zero in the query below
+    //
+    // ; /sWord
+    // (declare-fun sdiv (Int Int) Int)
+    // (assert (forall ((x Int) (y Int)) (=> (> (* (sgn x) (sgn y)) 0) (= (sdiv x y)    (zdiv (abs x) (abs y)) ))))
+    // (assert (forall ((x Int) (y Int)) (=> (< (* (sgn x) (sgn y)) 0) (= (sdiv x y) (- (zdiv (abs x) (abs y)))))))
+    //
+    // ; uint256
+    // (define-fun uint256 ((x Int)) Bool (and (>= x 0) (< x pow256)))
+    //
+    // ; sint256
+    // (define-fun sint256 ((x Int)) Bool (and (>= x (- pow255)) (< x pow255)))
+    //
+    // ;;;; proof
+    //
+    // (declare-const x Int)
+    // (declare-const y Int)
+    //
+    // (assert (uint256 x))
+    // (assert (sint256 y))
+    // (assert (sint256 (* x y)))
+    // (assert (not (= y 0)))
+    //
+    // (assert (not
+    //     (= (sdiv (chop (* x y)) (chop y)) x)
+    // ))
+    // (check-sat)
     rule chop(X *Int Y) /sWord chop(Y) => X requires #rangeUInt(256, X) andBool #rangeSInt(256, Y) andBool #rangeSInt(256, X *Int Y) andBool Y =/=Int 0
 
 endmodule

--- a/tests/specs/mcd/verification.k
+++ b/tests/specs/mcd/verification.k
@@ -133,7 +133,7 @@ module VERIFICATION
 
     rule sgn(chop(X)) ==Int -1 => X <Int 0 requires #rangeSInt(256, X)
 
-    // ### vat-mului-fail-rough
+    // ### vat-mului-pass
 
     rule chop(X *Int chop(Y)) => chop(X *Int Y)
 

--- a/tests/specs/mcd/verification.k
+++ b/tests/specs/mcd/verification.k
@@ -69,8 +69,8 @@ module VERIFICATION-SYNTAX
     rule nthbyteof(V, I, N) => nthbyteof(V /Int 256, I, N -Int 1) when N  >Int (I +Int 1) [concrete]
     rule nthbyteof(V, I, N) =>           V modInt 256             when N ==Int (I +Int 1) [concrete]
 
-    syntax Int ::= #unsigned ( Int ) [function]
- // -------------------------------------------
+    syntax Int ::= #unsigned ( Int ) [function, smtlib(unsigned)]
+ // -------------------------------------------------------------
     rule #unsigned(DATA) => DATA             requires 0 <=Int DATA andBool DATA <=Int maxSInt256
     rule #unsigned(DATA) => pow256 +Int DATA requires minSInt256 <=Int DATA andBool DATA <Int 0
 
@@ -123,5 +123,25 @@ module VERIFICATION
     rule chop(hash2(I1, I2) +Int N) => hash2(I1, I2) +Int N requires 0 <=Int N andBool N <Int 3
 
     rule ( BA1:ByteArray ++ BA2:ByteArray ) ++ BA3:ByteArray => BA1 ++ ( BA2 ++ BA3 )
+
+    // ### vat-addui-fail-rough
+
+    rule #rangeUInt(256, #unsigned(X)) => true requires #rangeSInt(256, X) [smt-lemma]
+
+    // Proof (remembering that sgn(0) ==Int 1 and using the rules for _s<Word_ and _<Word_):
+    // X s<Word 0
+    //      case sgn(X) ==Int  1 : X <Word 0 => bool2Word(false) (because #rangeUInt(256, X))
+    //      case sgn(X) ==Int -1 : bool2Word(true)
+    // 0 s<Word X
+    //      case sgn(X) ==Int  1 : 0 <Word X
+    //      case sgn(X) ==Int -1 : bool2Word(false)
+    rule X s<Word 0 => bool2Word(sgn(X) ==Int -1)                  requires #rangeUInt(256, X)
+    rule 0 s<Word X => bool2Word(sgn(X) ==Int  1 andBool 0 <Int X) requires #rangeUInt(256, X)
+
+    rule sgn(#unsigned(X)) ==Int  1 => 0 <=Int X andBool X <=Int maxSInt256 requires #rangeSInt(256, X)
+    rule sgn(#unsigned(X)) ==Int -1 => minSInt256 <=Int X andBool X <Int 0  requires #rangeSInt(256, X)
+
+    // property of 2s complement
+    rule notBool (0 <=Int X +Int Y) => X <Int chop(X +Int #unsigned(Y)) requires #rangeUInt(256, X) andBool #rangeSInt(256, Y) [smt-lemma]
 
 endmodule

--- a/tests/specs/mcd/verification.k
+++ b/tests/specs/mcd/verification.k
@@ -200,7 +200,7 @@ module VERIFICATION
     //        => X
     //
     // Via Z3 ?.?.?:
-    // ; 2^64 and 2^32 instead of 2^256 for small model proof
+    // ; 2^6 and 2^5 instead of 2^256 and 2^255 for small model proof
     // (declare-const pow256 Int)
     // (assert (= pow256 64))
     // (declare-const pow255 Int)


### PR DESCRIPTION
These proofs demonstrate two new things:

-   More advanced of `#WordPack*` abstractions.
-   Use of signed arithmetic ~(with `#unsigned` abstraction)~. I have replaced use of `#unsigned(X)` with just `chop(X)`, because we have `#rangeSInt(256, X) impliesBool (#unsigned(X) ==Int chop(X))`, and we never use `#unsigned(X)` without `#rangeSInt(256, X)` as an additional constraint.
-   Make `/sWord` concrete so that we can write a lemma directly about it instead of about arguments `sgn` and `abs`.