### PR TITLE
MKR regression tests: vat-slip-pass-rough, vow-flog-fail-rough

### DIFF
--- a/tests/failing-symbolic.haskell
+++ b/tests/failing-symbolic.haskell
@@ -69,4 +69,5 @@ tests/specs/mcd/vat-deny-diff-fail-rough-spec.k
 tests/specs/mcd/vat-move-diff-spec.k
 tests/specs/mcd/vat-mului-pass-spec.k
 tests/specs/mcd/vat-slip-pass-rough-spec.k
+tests/specs/mcd/vow-flog-fail-rough-spec.k
 tests/specs/opcodes/create-spec.k

--- a/tests/failing-symbolic.haskell
+++ b/tests/failing-symbolic.haskell
@@ -68,4 +68,5 @@ tests/specs/mcd/vat-addui-fail-rough-spec.k
 tests/specs/mcd/vat-deny-diff-fail-rough-spec.k
 tests/specs/mcd/vat-move-diff-spec.k
 tests/specs/mcd/vat-mului-pass-spec.k
+tests/specs/mcd/vat-slip-pass-rough-spec.k
 tests/specs/opcodes/create-spec.k

--- a/tests/specs/mcd/vat-slip-pass-rough-spec.k
+++ b/tests/specs/mcd/vat-slip-pass-rough-spec.k
@@ -1,0 +1,387 @@
+requires "verification.k"
+
+module VAT-SLIP-PASS-ROUGH-SPEC
+    imports VERIFICATION
+
+    // Vat_slip
+    rule [Vat.slip.pass.rough]:
+      <k> #execute ~> CONTINUATION => #halt ~> CONTINUATION </k>
+      <exit-code> 1 </exit-code>
+      <mode> NORMAL </mode>
+      <schedule> ISTANBUL </schedule>
+      <ethereum>
+        <evm>
+          <output> .ByteArray </output>
+          <statusCode> _ => EVMC_SUCCESS </statusCode>
+          <endPC> _ => ?_ </endPC>
+          <callStack> _VCallStack </callStack>
+          <interimStates> _ </interimStates>
+          <touchedAccounts> _ => ?_ </touchedAccounts>
+          <callState>
+            <program> Vat_bin_runtime </program>
+            <jumpDests> #computeValidJumpDests(Vat_bin_runtime) </jumpDests>
+            <id> ACCT_ID </id>
+            <caller> CALLER_ID </caller>
+            <callData> #abiCallData("slip", #bytes32(ABI_ilk), #address(ABI_usr), #int256(ABI_wad)) ++ CD => ?_ </callData>
+            <callValue> VCallValue </callValue>
+            <wordStack> .WordStack => ?_ </wordStack>
+            <localMem> .Memory => ?_ </localMem>
+            <pc> 0 => ?_ </pc>
+            <gas> VGas => ?_ </gas>
+            <memoryUsed> 0 => ?_ </memoryUsed>
+            <callGas> _ => ?_ </callGas>
+            <static> false </static>
+            <callDepth> VCallDepth </callDepth>
+          </callState>
+          <substate>
+            <selfDestruct> _VSelfDestruct </selfDestruct>
+            <log> _ => ?_ </log>
+            <refund> _Vrefund => ?_ </refund>
+          </substate>
+          <gasPrice> _ </gasPrice>
+          <origin> ORIGIN_ID </origin>
+          <blockhashes> _ </blockhashes>
+          <block>
+            <previousHash> _ </previousHash>
+            <ommersHash> _ </ommersHash>
+            <coinbase> _ </coinbase>
+            <stateRoot> _ </stateRoot>
+            <transactionsRoot> _ </transactionsRoot>
+            <receiptsRoot> _ </receiptsRoot>
+            <logsBloom> _ </logsBloom>
+            <difficulty> _ </difficulty>
+            <number> _BLOCK_NUMBER </number>
+            <gasLimit> _ </gasLimit>
+            <gasUsed> _ </gasUsed>
+            <timestamp> TIME </timestamp>
+            <extraData> _ </extraData>
+            <mixHash> _ </mixHash>
+            <blockNonce> _ </blockNonce>
+            <ommerBlockHeaders> _ </ommerBlockHeaders>
+          </block>
+        </evm>
+        <network>
+          <chainID> VChainId </chainID>
+          <activeAccounts> SetItem(ACCT_ID)
+          SetItem(1)
+          SetItem(2)
+          SetItem(3)
+          SetItem(4)
+          SetItem(5)
+          SetItem(6)
+          SetItem(7)
+          SetItem(8)
+          SetItem(9) _ </activeAccounts>
+          <accounts>
+            <account>
+              <acctID> ACCT_ID </acctID>
+              <balance> ACCT_ID_balance </balance>
+              <code> Vat_bin_runtime </code>
+              <storage> ACCT_ID_STORAGE => ACCT_ID_STORAGE [ #Vat.gem[ABI_ilk][ABI_usr] <- Gem +Int ABI_wad ] </storage>
+              <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
+              <nonce> _Nonce_Vat => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> 1 </acctID>
+              <balance> ECREC_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 2 </acctID>
+              <balance> SHA256_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 3 </acctID>
+              <balance> RIP160_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 4 </acctID>
+              <balance> ID_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 5 </acctID>
+              <balance> MODEXP_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 6 </acctID>
+              <balance> ECADD_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 7 </acctID>
+              <balance> ECMUL_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 8 </acctID>
+              <balance> ECPAIRING_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 9 </acctID>
+              <balance> BLAKE2_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+           ...
+          </accounts>
+          <txOrder> _ </txOrder>
+          <txPending> _ </txPending>
+          <messages> _ </messages>
+        </network>
+      </ethereum>
+    requires #rangeAddress(ACCT_ID)
+     andBool ACCT_ID =/=Int 0
+     andBool #notPrecompileAddress(ACCT_ID)
+     andBool #rangeAddress(CALLER_ID)
+     andBool #rangeAddress(ORIGIN_ID)
+     andBool #rangeUInt(256, TIME)
+     andBool #rangeUInt(256, ACCT_ID_balance)
+     andBool #rangeUInt(256, ECREC_BAL)
+     andBool #rangeUInt(256, SHA256_BAL)
+     andBool #rangeUInt(256, RIP160_BAL)
+     andBool #rangeUInt(256, ID_BAL)
+     andBool #rangeUInt(256, MODEXP_BAL)
+     andBool #rangeUInt(256, ECADD_BAL)
+     andBool #rangeUInt(256, ECMUL_BAL)
+     andBool #rangeUInt(256, ECPAIRING_BAL)
+     andBool #rangeUInt(256, BLAKE2_BAL)
+     andBool VCallDepth <=Int 1024
+     andBool #rangeUInt(256, VCallValue)
+     andBool #rangeUInt(256, VChainId)
+
+     andBool (#rangeBytes(32, ABI_ilk)
+     andBool (#rangeAddress(ABI_usr)
+     andBool (#rangeSInt(256, ABI_wad)
+     andBool (#rangeUInt(256, May)
+     andBool (#rangeUInt(256, Gem)
+     andBool (#sizeByteArray(CD) <=Int 1250000000
+     andBool (VGas >=Int 3000000
+     andBool (#rangeUInt(256, Junk_0)
+     andBool (#rangeUInt(256, Junk_1)
+     andBool (((May ==Int 1))
+     andBool (((VCallValue ==Int 0))
+     andBool ((#rangeUInt(256, Gem +Int ABI_wad))))))))))))))
+
+     andBool #lookup(ACCT_ID_STORAGE, #Vat.wards[CALLER_ID]) ==Int May
+     andBool #lookup(ACCT_ID_STORAGE, #Vat.gem[ABI_ilk][ABI_usr]) ==Int Gem
+     andBool #lookup(ACCT_ID_ORIG_STORAGE, #Vat.wards[CALLER_ID]) ==Int Junk_0
+     andBool #lookup(ACCT_ID_ORIG_STORAGE, #Vat.gem[ABI_ilk][ABI_usr]) ==Int Junk_1
+     andBool #Vat.wards[CALLER_ID] =/=Int #Vat.gem[ABI_ilk][ABI_usr]
+
+    // Vat_addui
+    rule [Vat.addui.pass]:
+      <k> #execute ~> CONTINUATION => #execute ~> CONTINUATION </k>
+      <exit-code> 1 </exit-code>
+      <mode> NORMAL </mode>
+      <schedule> ISTANBUL </schedule>
+      <ethereum>
+        <evm>
+          <output> VOutput => VOutput </output>
+          <statusCode> _ => ?_ </statusCode>
+          <endPC> _ => ?_ </endPC>
+          <callStack> _VCallStack </callStack>
+          <interimStates> _ </interimStates>
+          <touchedAccounts> _ => ?_ </touchedAccounts>
+          <callState>
+            <program> Vat_bin_runtime </program>
+            <jumpDests> #computeValidJumpDests(Vat_bin_runtime) </jumpDests>
+            <id> ACCT_ID </id>
+            <caller> CALLER_ID </caller>
+            <callData> _ => ?_ </callData>
+            <callValue> VCallValue </callValue>
+            <wordStack> chop(ABI_y) : ABI_x : JMPTO : WS  =>  JMPTO : ABI_x +Int ABI_y : WS </wordStack>
+            <localMem> _ </localMem>
+            <pc> 13112 => 13174 </pc>
+            <gas> VGas => (#if ( ( 0 <=Int ABI_y ) andBool ( ABI_y <=Int 0 ) ) #then ( VGas +Int -114 ) #else ( VGas +Int -128 ) #fi) </gas>
+            <memoryUsed> VMemoryUsed </memoryUsed>
+            <callGas> _ => ?_ </callGas>
+            <static> _ </static>
+            <callDepth> VCallDepth </callDepth>
+          </callState>
+          <substate>
+            <selfDestruct> _VSelfDestruct </selfDestruct>
+            <log> _ => ?_ </log>
+            <refund> _Vrefund => ?_ </refund>
+          </substate>
+          <gasPrice> _ </gasPrice>
+          <origin> ORIGIN_ID </origin>
+          <blockhashes> _ </blockhashes>
+          <block>
+            <previousHash> _ </previousHash>
+            <ommersHash> _ </ommersHash>
+            <coinbase> _ </coinbase>
+            <stateRoot> _ </stateRoot>
+            <transactionsRoot> _ </transactionsRoot>
+            <receiptsRoot> _ </receiptsRoot>
+            <logsBloom> _ </logsBloom>
+            <difficulty> _ </difficulty>
+            <number> _BLOCK_NUMBER </number>
+            <gasLimit> _ </gasLimit>
+            <gasUsed> _ </gasUsed>
+            <timestamp> TIME </timestamp>
+            <extraData> _ </extraData>
+            <mixHash> _ </mixHash>
+            <blockNonce> _ </blockNonce>
+            <ommerBlockHeaders> _ </ommerBlockHeaders>
+          </block>
+        </evm>
+        <network>
+          <chainID> VChainId </chainID>
+          <activeAccounts> SetItem(ACCT_ID)
+          SetItem(1)
+          SetItem(2)
+          SetItem(3)
+          SetItem(4)
+          SetItem(5)
+          SetItem(6)
+          SetItem(7)
+          SetItem(8)
+          SetItem(9) _ </activeAccounts>
+          <accounts>
+            <account>
+              <acctID> ACCT_ID </acctID>
+              <balance> ACCT_ID_balance </balance>
+              <code> Vat_bin_runtime </code>
+              <storage> ACCT_ID_STORAGE => ACCT_ID_STORAGE  </storage>
+              <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
+              <nonce> _Nonce_Vat => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> 1 </acctID>
+              <balance> ECREC_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 2 </acctID>
+              <balance> SHA256_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 3 </acctID>
+              <balance> RIP160_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 4 </acctID>
+              <balance> ID_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 5 </acctID>
+              <balance> MODEXP_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 6 </acctID>
+              <balance> ECADD_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 7 </acctID>
+              <balance> ECMUL_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 8 </acctID>
+              <balance> ECPAIRING_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 9 </acctID>
+              <balance> BLAKE2_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+           ...
+          </accounts>
+          <txOrder> _ </txOrder>
+          <txPending> _ </txPending>
+          <messages> _ </messages>
+        </network>
+      </ethereum>
+    requires #rangeAddress(ACCT_ID)
+     andBool ACCT_ID =/=Int 0
+     andBool #notPrecompileAddress(ACCT_ID)
+     andBool #rangeAddress(CALLER_ID)
+     andBool #rangeAddress(ORIGIN_ID)
+     andBool #rangeUInt(256, TIME)
+     andBool #rangeUInt(256, ACCT_ID_balance)
+     andBool #rangeUInt(256, ECREC_BAL)
+     andBool #rangeUInt(256, SHA256_BAL)
+     andBool #rangeUInt(256, RIP160_BAL)
+     andBool #rangeUInt(256, ID_BAL)
+     andBool #rangeUInt(256, MODEXP_BAL)
+     andBool #rangeUInt(256, ECADD_BAL)
+     andBool #rangeUInt(256, ECMUL_BAL)
+     andBool #rangeUInt(256, ECPAIRING_BAL)
+     andBool #rangeUInt(256, BLAKE2_BAL)
+     andBool VCallDepth <=Int 1024
+     andBool #rangeUInt(256, VCallValue)
+     andBool #rangeUInt(256, VChainId)
+
+     andBool (#rangeUInt(256, ABI_x)
+     andBool (#rangeSInt(256, ABI_y)
+     andBool ((#sizeWordStack(WS) <=Int 1015)
+     andBool (#rangeUInt(256, VMemoryUsed)
+     andBool (2300 <Int (#if ( ( 0 <=Int ABI_y ) andBool ( ABI_y <=Int 0 ) ) #then ( VGas +Int -114 ) #else ( VGas +Int -128 ) #fi)
+     andBool ((#rangeUInt(256, ABI_x +Int ABI_y))))))))
+    [trusted]
+
+endmodule

--- a/tests/specs/mcd/verification.k
+++ b/tests/specs/mcd/verification.k
@@ -300,4 +300,8 @@ module VERIFICATION
 
     rule I -Int I => 0
 
+    // ### vat-slip-pass-rough
+
+    rule chop(X +Int chop(Y)) => chop(X +Int Y)
+
 endmodule

--- a/tests/specs/mcd/verification.k
+++ b/tests/specs/mcd/verification.k
@@ -304,4 +304,9 @@ module VERIFICATION
 
     rule chop(X +Int chop(Y)) => chop(X +Int Y)
 
+    // ### vow-flog-fail-rough
+
+    rule X -Word Y <=Int X => #rangeUInt(256, X -Int Y) requires #rangeUInt(256, X) andBool #rangeUInt(256, Y)
+    rule 0 <=Int X +Int Y => true requires 0 <=Int X andBool 0 <=Int Y
+
 endmodule

--- a/tests/specs/mcd/verification.k
+++ b/tests/specs/mcd/verification.k
@@ -296,4 +296,8 @@ module VERIFICATION
 
     rule chop(X *Int Y) => X *Int Y requires 0 <=Int X andBool 0 <=Int Y andBool X *Int Y <Int pow256
 
+    // ### Gas Simplification
+
+    rule I -Int I => 0
+
 endmodule

--- a/tests/specs/mcd/vow-flog-fail-rough-spec.k
+++ b/tests/specs/mcd/vow-flog-fail-rough-spec.k
@@ -1,0 +1,582 @@
+requires "verification.k"
+
+module VOW-FLOG-FAIL-ROUGH-SPEC
+    imports VERIFICATION
+
+    // Vow_flog
+    rule [Vow.flog.fail.rough]:
+      <k> #execute ~> CONTINUATION => #halt ~> CONTINUATION </k>
+      <exit-code> 1 </exit-code>
+      <mode> NORMAL </mode>
+      <schedule> ISTANBUL </schedule>
+      <ethereum>
+        <evm>
+          <output> _ => ?_ </output>
+          <statusCode> _ => ?FAILURE:EndStatusCode </statusCode>
+          <endPC> _ => ?_ </endPC>
+          <callStack> _VCallStack </callStack>
+          <interimStates> _ </interimStates>
+          <touchedAccounts> _ => ?_ </touchedAccounts>
+          <callState>
+            <program> Vow_bin_runtime </program>
+            <jumpDests> #computeValidJumpDests(Vow_bin_runtime) </jumpDests>
+            <id> ACCT_ID </id>
+            <caller> CALLER_ID </caller>
+            <callData> #abiCallData("flog", #uint256(ABI_t)) ++ CD => ?_ </callData>
+            <callValue> VCallValue </callValue>
+            <wordStack> .WordStack => ?_ </wordStack>
+            <localMem> .Memory => ?_ </localMem>
+            <pc> 0 => ?_ </pc>
+            <gas> VGas => ?_ </gas>
+            <memoryUsed> 0 => ?_ </memoryUsed>
+            <callGas> _ => ?_ </callGas>
+            <static> false </static>
+            <callDepth> VCallDepth => ?_ </callDepth>
+          </callState>
+          <substate>
+            <selfDestruct> _VSelfDestruct </selfDestruct>
+            <log> _ => ?_ </log>
+            <refund> _Vrefund => ?_ </refund>
+          </substate>
+          <gasPrice> _ </gasPrice>
+          <origin> ORIGIN_ID </origin>
+          <blockhashes> _ </blockhashes>
+          <block>
+            <previousHash> _ </previousHash>
+            <ommersHash> _ </ommersHash>
+            <coinbase> _ </coinbase>
+            <stateRoot> _ </stateRoot>
+            <transactionsRoot> _ </transactionsRoot>
+            <receiptsRoot> _ </receiptsRoot>
+            <logsBloom> _ </logsBloom>
+            <difficulty> _ </difficulty>
+            <number> _BLOCK_NUMBER </number>
+            <gasLimit> _ </gasLimit>
+            <gasUsed> _ </gasUsed>
+            <timestamp> TIME </timestamp>
+            <extraData> _ </extraData>
+            <mixHash> _ </mixHash>
+            <blockNonce> _ </blockNonce>
+            <ommerBlockHeaders> _ </ommerBlockHeaders>
+          </block>
+        </evm>
+        <network>
+          <chainID> VChainId </chainID>
+          <activeAccounts> SetItem(ACCT_ID)
+          SetItem(1)
+          SetItem(2)
+          SetItem(3)
+          SetItem(4)
+          SetItem(5)
+          SetItem(6)
+          SetItem(7)
+          SetItem(8)
+          SetItem(9) _ </activeAccounts>
+          <accounts>
+            <account>
+              <acctID> ACCT_ID </acctID>
+              <balance> ACCT_ID_balance </balance>
+              <code> Vow_bin_runtime </code>
+              <storage> ACCT_ID_STORAGE => ?_ACCT_ID_STORAGE </storage>
+              <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
+              <nonce> _Nonce_Vow => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> 1 </acctID>
+              <balance> ECREC_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 2 </acctID>
+              <balance> SHA256_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 3 </acctID>
+              <balance> RIP160_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 4 </acctID>
+              <balance> ID_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 5 </acctID>
+              <balance> MODEXP_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 6 </acctID>
+              <balance> ECADD_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 7 </acctID>
+              <balance> ECMUL_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 8 </acctID>
+              <balance> ECPAIRING_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 9 </acctID>
+              <balance> BLAKE2_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+           ...
+          </accounts>
+          <txOrder> _ </txOrder>
+          <txPending> _ </txPending>
+          <messages> _ </messages>
+        </network>
+      </ethereum>
+    requires #rangeAddress(ACCT_ID)
+     andBool ACCT_ID =/=Int 0
+     andBool #notPrecompileAddress(ACCT_ID)
+     andBool #rangeAddress(CALLER_ID)
+     andBool #rangeAddress(ORIGIN_ID)
+     andBool #rangeUInt(256, TIME)
+     andBool #rangeUInt(256, ACCT_ID_balance)
+     andBool #rangeUInt(256, ECREC_BAL)
+     andBool #rangeUInt(256, SHA256_BAL)
+     andBool #rangeUInt(256, RIP160_BAL)
+     andBool #rangeUInt(256, ID_BAL)
+     andBool #rangeUInt(256, MODEXP_BAL)
+     andBool #rangeUInt(256, ECADD_BAL)
+     andBool #rangeUInt(256, ECMUL_BAL)
+     andBool #rangeUInt(256, ECPAIRING_BAL)
+     andBool #rangeUInt(256, BLAKE2_BAL)
+     andBool VCallDepth <=Int 1024
+     andBool #rangeUInt(256, VCallValue)
+     andBool #rangeUInt(256, VChainId)
+
+     andBool (#rangeUInt(256, ABI_t)
+     andBool (#rangeUInt(256, Wait)
+     andBool (#rangeUInt(256, Sin_t)
+     andBool (#rangeUInt(256, Sin)
+     andBool (#sizeByteArray(CD) <=Int 1250000000
+     andBool (VGas >=Int 3000000
+     andBool (#rangeUInt(256, Junk_0)
+     andBool (#rangeUInt(256, Junk_1)
+     andBool (#rangeUInt(256, Junk_2))))))))))
+
+     andBool #lookup(ACCT_ID_STORAGE, #Vow.wait) ==Int Wait
+     andBool #lookup(ACCT_ID_STORAGE, #Vow.Sin) ==Int Sin
+     andBool #lookup(ACCT_ID_STORAGE, #Vow.sin[ABI_t]) ==Int Sin_t
+     andBool #lookup(ACCT_ID_ORIG_STORAGE, #Vow.wait) ==Int Junk_0
+     andBool #lookup(ACCT_ID_ORIG_STORAGE, #Vow.Sin) ==Int Junk_1
+     andBool #lookup(ACCT_ID_ORIG_STORAGE, #Vow.sin[ABI_t]) ==Int Junk_2
+     andBool #Vow.wait =/=Int #Vow.Sin
+     andBool #Vow.wait =/=Int #Vow.sin[ABI_t]
+     andBool #Vow.Sin =/=Int #Vow.sin[ABI_t]
+     andBool notBool ( (((ABI_t:Int +Int Wait:Int <=Int TIME:Int))
+               andBool (((VCallValue:Int ==Int 0))
+               andBool ((#rangeUInt(256, ABI_t:Int   +Int Wait:Int))
+               andBool ((#rangeUInt(256, Sin:Int -Int Sin_t:Int))))))
+                     )
+
+    ensures ?FAILURE =/=K EVMC_SUCCESS
+
+    // Vow_adduu
+    rule [Vow.adduu.pass]:
+      <k> #execute ~> CONTINUATION => #execute ~> CONTINUATION </k>
+      <exit-code> 1 </exit-code>
+      <mode> NORMAL </mode>
+      <schedule> ISTANBUL </schedule>
+      <ethereum>
+        <evm>
+          <output> VOutput => VOutput </output>
+          <statusCode> _ => ?_ </statusCode>
+          <endPC> _ => ?_ </endPC>
+          <callStack> _VCallStack </callStack>
+          <interimStates> _ </interimStates>
+          <touchedAccounts> _ => ?_ </touchedAccounts>
+          <callState>
+            <program> Vow_bin_runtime </program>
+            <jumpDests> #computeValidJumpDests(Vow_bin_runtime) </jumpDests>
+            <id> ACCT_ID </id>
+            <caller> CALLER_ID </caller>
+            <callData> _ => ?_ </callData>
+            <callValue> VCallValue </callValue>
+            <wordStack> ABI_y : ABI_x : JMPTO : WS  =>  JMPTO : ABI_x +Int ABI_y : WS </wordStack>
+            <localMem> _ </localMem>
+            <pc> 9777 => 9802 </pc>
+            <gas> VGas => ( VGas +Int -54 ) </gas>
+            <memoryUsed> VMemoryUsed </memoryUsed>
+            <callGas> _ => ?_ </callGas>
+            <static> _ </static>
+            <callDepth> VCallDepth </callDepth>
+          </callState>
+          <substate>
+            <selfDestruct> _VSelfDestruct </selfDestruct>
+            <log> _ => ?_ </log>
+            <refund> _Vrefund => ?_ </refund>
+          </substate>
+          <gasPrice> _ </gasPrice>
+          <origin> ORIGIN_ID </origin>
+          <blockhashes> _ </blockhashes>
+          <block>
+            <previousHash> _ </previousHash>
+            <ommersHash> _ </ommersHash>
+            <coinbase> _ </coinbase>
+            <stateRoot> _ </stateRoot>
+            <transactionsRoot> _ </transactionsRoot>
+            <receiptsRoot> _ </receiptsRoot>
+            <logsBloom> _ </logsBloom>
+            <difficulty> _ </difficulty>
+            <number> _BLOCK_NUMBER </number>
+            <gasLimit> _ </gasLimit>
+            <gasUsed> _ </gasUsed>
+            <timestamp> TIME </timestamp>
+            <extraData> _ </extraData>
+            <mixHash> _ </mixHash>
+            <blockNonce> _ </blockNonce>
+            <ommerBlockHeaders> _ </ommerBlockHeaders>
+          </block>
+        </evm>
+        <network>
+          <chainID> VChainId </chainID>
+          <activeAccounts> SetItem(ACCT_ID)
+          SetItem(1)
+          SetItem(2)
+          SetItem(3)
+          SetItem(4)
+          SetItem(5)
+          SetItem(6)
+          SetItem(7)
+          SetItem(8)
+          SetItem(9) _ </activeAccounts>
+          <accounts>
+            <account>
+              <acctID> ACCT_ID </acctID>
+              <balance> ACCT_ID_balance </balance>
+              <code> Vow_bin_runtime </code>
+              <storage> ACCT_ID_STORAGE => ACCT_ID_STORAGE  </storage>
+              <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
+              <nonce> _Nonce_Vow => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> 1 </acctID>
+              <balance> ECREC_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 2 </acctID>
+              <balance> SHA256_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 3 </acctID>
+              <balance> RIP160_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 4 </acctID>
+              <balance> ID_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 5 </acctID>
+              <balance> MODEXP_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 6 </acctID>
+              <balance> ECADD_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 7 </acctID>
+              <balance> ECMUL_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 8 </acctID>
+              <balance> ECPAIRING_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 9 </acctID>
+              <balance> BLAKE2_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+           ...
+          </accounts>
+          <txOrder> _ </txOrder>
+          <txPending> _ </txPending>
+          <messages> _ </messages>
+        </network>
+      </ethereum>
+    requires #rangeAddress(ACCT_ID)
+     andBool ACCT_ID =/=Int 0
+     andBool #notPrecompileAddress(ACCT_ID)
+     andBool #rangeAddress(CALLER_ID)
+     andBool #rangeAddress(ORIGIN_ID)
+     andBool #rangeUInt(256, TIME)
+     andBool #rangeUInt(256, ACCT_ID_balance)
+     andBool #rangeUInt(256, ECREC_BAL)
+     andBool #rangeUInt(256, SHA256_BAL)
+     andBool #rangeUInt(256, RIP160_BAL)
+     andBool #rangeUInt(256, ID_BAL)
+     andBool #rangeUInt(256, MODEXP_BAL)
+     andBool #rangeUInt(256, ECADD_BAL)
+     andBool #rangeUInt(256, ECMUL_BAL)
+     andBool #rangeUInt(256, ECPAIRING_BAL)
+     andBool #rangeUInt(256, BLAKE2_BAL)
+     andBool VCallDepth <=Int 1024
+     andBool #rangeUInt(256, VCallValue)
+     andBool #rangeUInt(256, VChainId)
+
+     andBool (#rangeUInt(256, ABI_x)
+     andBool (#rangeUInt(256, ABI_y)
+     andBool ((#sizeWordStack(WS) <=Int 100)
+     andBool (#rangeUInt(256, VMemoryUsed)
+     andBool (2300 <Int ( VGas +Int -54 )
+     andBool ((#rangeUInt(256, ABI_x +Int ABI_y))))))))
+    [trusted]
+
+
+    // Vow_subuu
+    rule [Vow.subuu.pass]:
+      <k> #execute ~> CONTINUATION => #execute ~> CONTINUATION </k>
+      <exit-code> 1 </exit-code>
+      <mode> NORMAL </mode>
+      <schedule> ISTANBUL </schedule>
+      <ethereum>
+        <evm>
+          <output> VOutput => VOutput </output>
+          <statusCode> _ => ?_ </statusCode>
+          <endPC> _ => ?_ </endPC>
+          <callStack> _VCallStack </callStack>
+          <interimStates> _ </interimStates>
+          <touchedAccounts> _ => ?_ </touchedAccounts>
+          <callState>
+            <program> Vow_bin_runtime </program>
+            <jumpDests> #computeValidJumpDests(Vow_bin_runtime) </jumpDests>
+            <id> ACCT_ID </id>
+            <caller> CALLER_ID </caller>
+            <callData> _ => ?_ </callData>
+            <callValue> VCallValue </callValue>
+            <wordStack> ABI_y : ABI_x : JMPTO : WS  =>  JMPTO : ABI_x -Int ABI_y : WS </wordStack>
+            <localMem> _ </localMem>
+            <pc> 9803 => 9828 </pc>
+            <gas> VGas => ( VGas +Int -54 ) </gas>
+            <memoryUsed> VMemoryUsed </memoryUsed>
+            <callGas> _ => ?_ </callGas>
+            <static> _ </static>
+            <callDepth> VCallDepth </callDepth>
+          </callState>
+          <substate>
+            <selfDestruct> _VSelfDestruct </selfDestruct>
+            <log> _ => ?_ </log>
+            <refund> _Vrefund => ?_ </refund>
+          </substate>
+          <gasPrice> _ </gasPrice>
+          <origin> ORIGIN_ID </origin>
+          <blockhashes> _ </blockhashes>
+          <block>
+            <previousHash> _ </previousHash>
+            <ommersHash> _ </ommersHash>
+            <coinbase> _ </coinbase>
+            <stateRoot> _ </stateRoot>
+            <transactionsRoot> _ </transactionsRoot>
+            <receiptsRoot> _ </receiptsRoot>
+            <logsBloom> _ </logsBloom>
+            <difficulty> _ </difficulty>
+            <number> _BLOCK_NUMBER </number>
+            <gasLimit> _ </gasLimit>
+            <gasUsed> _ </gasUsed>
+            <timestamp> TIME </timestamp>
+            <extraData> _ </extraData>
+            <mixHash> _ </mixHash>
+            <blockNonce> _ </blockNonce>
+            <ommerBlockHeaders> _ </ommerBlockHeaders>
+          </block>
+        </evm>
+        <network>
+          <chainID> VChainId </chainID>
+          <activeAccounts> SetItem(ACCT_ID)
+          SetItem(1)
+          SetItem(2)
+          SetItem(3)
+          SetItem(4)
+          SetItem(5)
+          SetItem(6)
+          SetItem(7)
+          SetItem(8)
+          SetItem(9) _ </activeAccounts>
+          <accounts>
+            <account>
+              <acctID> ACCT_ID </acctID>
+              <balance> ACCT_ID_balance </balance>
+              <code> Vow_bin_runtime </code>
+              <storage> ACCT_ID_STORAGE => ACCT_ID_STORAGE  </storage>
+              <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
+              <nonce> _Nonce_Vow => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> 1 </acctID>
+              <balance> ECREC_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 2 </acctID>
+              <balance> SHA256_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 3 </acctID>
+              <balance> RIP160_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 4 </acctID>
+              <balance> ID_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 5 </acctID>
+              <balance> MODEXP_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 6 </acctID>
+              <balance> ECADD_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 7 </acctID>
+              <balance> ECMUL_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 8 </acctID>
+              <balance> ECPAIRING_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 9 </acctID>
+              <balance> BLAKE2_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+           ...
+          </accounts>
+          <txOrder> _ </txOrder>
+          <txPending> _ </txPending>
+          <messages> _ </messages>
+        </network>
+      </ethereum>
+    requires #rangeAddress(ACCT_ID)
+     andBool ACCT_ID =/=Int 0
+     andBool #notPrecompileAddress(ACCT_ID)
+     andBool #rangeAddress(CALLER_ID)
+     andBool #rangeAddress(ORIGIN_ID)
+     andBool #rangeUInt(256, TIME)
+     andBool #rangeUInt(256, ACCT_ID_balance)
+     andBool #rangeUInt(256, ECREC_BAL)
+     andBool #rangeUInt(256, SHA256_BAL)
+     andBool #rangeUInt(256, RIP160_BAL)
+     andBool #rangeUInt(256, ID_BAL)
+     andBool #rangeUInt(256, MODEXP_BAL)
+     andBool #rangeUInt(256, ECADD_BAL)
+     andBool #rangeUInt(256, ECMUL_BAL)
+     andBool #rangeUInt(256, ECPAIRING_BAL)
+     andBool #rangeUInt(256, BLAKE2_BAL)
+     andBool VCallDepth <=Int 1024
+     andBool #rangeUInt(256, VCallValue)
+     andBool #rangeUInt(256, VChainId)
+
+     andBool (#rangeUInt(256, ABI_x)
+     andBool (#rangeUInt(256, ABI_y)
+     andBool ((#sizeWordStack(WS) <=Int 100)
+     andBool (#rangeUInt(256, VMemoryUsed)
+     andBool (2300 <Int ( VGas +Int -54 )
+     andBool ((#rangeUInt(256, ABI_x -Int ABI_y))))))))
+    [trusted]
+
+
+endmodule


### PR DESCRIPTION
These proofs demonstrate some more arithmetic lemmas that are needed:

-   vat-slip-pass-rough demonstrates a missing `chop(...)` lemma.
-   vow-flog-fail-rough demonstrates some inference on boundaries of additions/subtractions of bounded integers.
-   A lemma `I -Int I => 0` is added for simplifying the gas expressions which show up when calculating `Cmem(X, Y) -Int Cmem(X, Y)`.