### PR TITLE
Remove [symbolic] from EDSL module

### DIFF
--- a/edsl.md
+++ b/edsl.md
@@ -9,7 +9,7 @@ The notations are inspired by the production compilers of the smart contract lan
 ```k
 requires "evm.md"
 
-module EDSL         [symbolic]
+module EDSL
     imports EVM
 ```
 


### PR DESCRIPTION
for https://github.com/runtimeverification/firefly/issues/1075

This removes the `[symbolic]` attribute from `edsl.md` so we can use it for Firefly's llvm backend.