### PR TITLE
Updates to infinite gas abstraction

### DIFF
--- a/tests/failing-symbolic.haskell
+++ b/tests/failing-symbolic.haskell
@@ -74,6 +74,7 @@ tests/specs/mcd/flipper-ttl-pass-spec.k
 tests/specs/mcd/flopper-cage-pass-spec.k
 tests/specs/mcd/flopper-file-pass-rough-spec.k
 tests/specs/mcd/flopper-tick-pass-rough-spec.k
+tests/specs/mcd/pot-join-pass-rough-spec.k
 tests/specs/mcd/vat-addui-fail-rough-spec.k
 tests/specs/mcd/vat-deny-diff-fail-rough-spec.k
 tests/specs/mcd/vat-move-diff-rough-spec.k

--- a/tests/failing-symbolic.haskell
+++ b/tests/failing-symbolic.haskell
@@ -65,6 +65,7 @@ tests/specs/mcd/dstoken-burn-self-fail-rough-spec.k
 tests/specs/mcd/dstoken-transferfrom-fail-rough-spec.k
 tests/specs/mcd/dsvalue-peek-pass-rough-spec.k
 tests/specs/mcd/dsvalue-read-pass-spec.k
+tests/specs/mcd/end-pack-pass-rough-spec.k
 tests/specs/mcd/end-subuu-pass-spec.k
 tests/specs/mcd/flipper-addu48u48-fail-rough-spec.k
 tests/specs/mcd/flipper-bids-pass-rough-spec.k

--- a/tests/specs/functional/infinite-gas-spec.k
+++ b/tests/specs/functional/infinite-gas-spec.k
@@ -50,10 +50,7 @@ module INFINITE-GAS-SPEC
 
     claim <k> runLemma((VGas +Int -3844) -Int ((VGas -Int ((VGas +Int -4544) /Int 64)) +Int -3844)) => doneLemma((VGas +Int -4544) /Int 64) ... </k>
 
-    claim <k> runLemma(#gas((((((VGas +Int -1148) -Int G1) +Int -866) -Int G2) +Int -4337)))
-           => doneLemma(#gas(((VGas -Int G1) -Int G2) +Int -6351))
-          ...
-          </k>
+    claim <k> runLemma(#gas((((((VGas +Int -1148) -Int G1) +Int -866) -Int G2) +Int -4337))) => doneLemma(#gas(((VGas -Int G1) -Int G2) +Int -6351)) ... </k>
 
     claim <k> runLemma(#if _:Int ==Int 0 #then #gas(VGas -Int Csstore(_, _, _,_)) #else #gas(VGas +Int -344) #fi <Int 8)  => doneLemma(false) ... </k>
     claim <k> runLemma(8 <=Int #if _:Int ==Int 0 #then #gas(VGas -Int Csstore(_, _, _,_)) #else #gas(VGas +Int -344) #fi) => doneLemma(true)  ... </k>

--- a/tests/specs/functional/infinite-gas-spec.k
+++ b/tests/specs/functional/infinite-gas-spec.k
@@ -55,4 +55,10 @@ module INFINITE-GAS-SPEC
           ...
           </k>
 
+    claim <k> runLemma(#if _:Int ==Int 0 #then #gas(VGas -Int Csstore(_, _, _,_)) #else #gas(VGas +Int -344) #fi <Int 8)  => doneLemma(false) ... </k>
+    claim <k> runLemma(8 <=Int #if _:Int ==Int 0 #then #gas(VGas -Int Csstore(_, _, _,_)) #else #gas(VGas +Int -344) #fi) => doneLemma(true)  ... </k>
+
+    claim <k> runLemma(#if _:Int ==Int 0 #then #gas(VGas -Int Csstore(_, _, _,_)) #else #gas(VGas +Int -344) #fi <Int minInt(#if _ #then #gas(_) #else #gas(_) #fi, #gas(_)))  => doneLemma(false) ... </k>
+    claim <k> runLemma(minInt(#if _ #then #gas(_) #else #gas(_) #fi, #gas(_)) <=Int #if _:Int ==Int 0 #then #gas(VGas -Int Csstore(_, _, _,_)) #else #gas(VGas +Int -344) #fi) => doneLemma(true)  ... </k>
+
 endmodule

--- a/tests/specs/functional/infinite-gas-spec.k
+++ b/tests/specs/functional/infinite-gas-spec.k
@@ -46,4 +46,6 @@ module INFINITE-GAS-SPEC
     claim <k> runLemma(#gas(G) <Int #gas(G' +Int 700))  => doneLemma(false) ... </k>
     claim <k> runLemma(#gas(G' +Int 700) <=Int #gas(G)) => doneLemma(true)  ... </k>
 
+    claim <k> runLemma(#gas((((VGas +Int -1259) -Int Csstore(ISTANBUL, 1, 1, Junk_0)) +Int -4339))) => doneLemma(#gas((VGas -Int Csstore(ISTANBUL, 1, 1, Junk_0)) +Int -5598)) ... </k>
+
 endmodule

--- a/tests/specs/functional/infinite-gas-spec.k
+++ b/tests/specs/functional/infinite-gas-spec.k
@@ -48,4 +48,6 @@ module INFINITE-GAS-SPEC
 
     claim <k> runLemma(#gas((((VGas +Int -1259) -Int Csstore(ISTANBUL, 1, 1, Junk_0)) +Int -4339))) => doneLemma(#gas((VGas -Int Csstore(ISTANBUL, 1, 1, Junk_0)) +Int -5598)) ... </k>
 
+    claim <k> runLemma((VGas +Int -3844) -Int ((VGas -Int ((VGas +Int -4544) /Int 64)) +Int -3844)) => doneLemma((VGas +Int -4544) /Int 64) ... </k>
+
 endmodule

--- a/tests/specs/functional/infinite-gas-spec.k
+++ b/tests/specs/functional/infinite-gas-spec.k
@@ -50,4 +50,9 @@ module INFINITE-GAS-SPEC
 
     claim <k> runLemma((VGas +Int -3844) -Int ((VGas -Int ((VGas +Int -4544) /Int 64)) +Int -3844)) => doneLemma((VGas +Int -4544) /Int 64) ... </k>
 
+    claim <k> runLemma(#gas((((((VGas +Int -1148) -Int G1) +Int -866) -Int G2) +Int -4337)))
+           => doneLemma(#gas(((VGas -Int G1) -Int G2) +Int -6351))
+          ...
+          </k>
+
 endmodule

--- a/tests/specs/functional/infinite-gas-spec.k
+++ b/tests/specs/functional/infinite-gas-spec.k
@@ -18,7 +18,7 @@ module INFINITE-GAS-SPEC
  // Gas arithmetic
  // --------------
 
-    claim <k> runLemma(#gas(8) -Int 3) => doneLemma(#gas(11)) ... </k>
+    claim <k> runLemma(#gas(8) -Int 3) => doneLemma(#gas(5)) ... </k>
 
  // Gas comparisons
  // ---------------
@@ -32,5 +32,18 @@ module INFINITE-GAS-SPEC
 
     // Awaiting Haskell backend updates
     // claim <k> runLemma(#gas(_) <Int (I1 +Int (I2 /Int I3) *Int I4)) => doneLemma(false) ... </k> requires I1 <=Int pow256 andBool I2 <=Int pow256 andBool I3 =/=Int 0 andBool I3 <=Int pow256 andBool I4 <=Int pow256
+
+    claim <k> runLemma(4822 <Int minInt(#gas(VGas +Int 4544) +Int (#gas(VGas +Int 4544) /Int 64), #gas(VGas +Int 3844))) => doneLemma(true) ... </k>
+
+    claim <k> runLemma(3 <Int minInt(#gas(VGas), 2)) => doneLemma(false) ... </k>
+    claim <k> runLemma(2 <Int minInt(#gas(VGas), 3)) => doneLemma(true ) ... </k>
+
+    claim <k> runLemma(#gas(G) -Int #gas(G')) => doneLemma(#gas(G -Int G')) ... </k>
+
+    claim <k> runLemma(#gas(G) -Int Csstore(_, _, _, _) <Int 2) => doneLemma(false) ... </k>
+    claim <k> runLemma(minInt(#gas(G), #gas(G'')) +Int -2522 <Int Csstore(_, _, _, _)) => doneLemma(false) ... </k>
+
+    claim <k> runLemma(#gas(G) <Int #gas(G' +Int 700))  => doneLemma(false) ... </k>
+    claim <k> runLemma(#gas(G' +Int 700) <=Int #gas(G)) => doneLemma(true)  ... </k>
 
 endmodule

--- a/tests/specs/infinite-gas.k
+++ b/tests/specs/infinite-gas.k
@@ -20,6 +20,7 @@ module INFINITE-GAS
     rule #gas(_, _, _) => #gas(0)
 
     rule #gas(G) -Int G' => #gas(G +Int G') [simplification]
+    rule #gas(G) +Int G' => #gas(G -Int G') [simplification]
 
     rule #gas(_)  <Int I => false requires I <=Int pow256 [simplification]
     rule #gas(_) <=Int I => false requires I <=Int pow256 [simplification]

--- a/tests/specs/infinite-gas.k
+++ b/tests/specs/infinite-gas.k
@@ -18,6 +18,7 @@ module INFINITE-GAS-HASKELL [kore]
     rule I1         <=Int I2 +Int I3 => I1 -Int I3 <=Int I2         [concrete(I1, I3), simplification]
 
     rule ((I1 +Int I2) -Int I3) +Int I4 => (I1 -Int I3) +Int (I2 +Int I4) [concrete(I2, I4), symbolic(I1, I3), simplification]
+    rule ((I1 +Int I2) -Int I3) +Int I4 => (I1 -Int I3) +Int (I2 -Int I4) [concrete(I2, I4), symbolic(I1, I3), simplification]
     rule (I1 +Int I2) -Int (I3 +Int I4) => (I1 -Int I3) +Int (I2 -Int I4) [concrete(I2, I4), symbolic(I1, I3), simplification]
 endmodule
 
@@ -35,6 +36,7 @@ module INFINITE-GAS-JAVA [kast]
     rule I1         <=Int I2 +Int I3 => I1 -Int I3 <=Int I2         requires #isConcrete(I1) andBool #isConcrete(I3) [simplification]
 
     rule ((I1 +Int I2) +Int I3) +Int I4 => (I1 +Int I3) +Int (I2 +Int I4) requires #isConcrete(I2) andBool #isConcrete(I4) andBool notBool (#isConcrete(I1) orBool #isConcrete(I3)) [simplification]
+    rule ((I1 +Int I2) -Int I3) +Int I4 => (I1 -Int I3) +Int (I2 +Int I4) requires #isConcrete(I2) andBool #isConcrete(I4) andBool notBool (#isConcrete(I1) orBool #isConcrete(I3)) [simplification]
     rule (I1 +Int I2) -Int (I3 +Int I4) => (I1 -Int I3) +Int (I2 -Int I4) requires #isConcrete(I2) andBool #isConcrete(I4) andBool notBool (#isConcrete(I1) orBool #isConcrete(I3)) [simplification]
 endmodule
 

--- a/tests/specs/infinite-gas.k
+++ b/tests/specs/infinite-gas.k
@@ -79,7 +79,8 @@ module INFINITE-GAS-COMMON
 
     rule #gas(G) -Int #gas(G') => #gas(G -Int G') [simplification]
 
-    rule minInt(#gas(G), #gas(G')) => #gas(minInt(G, G')) [simplification]
+    rule minInt(#gas(G), #gas(G'))              => #gas(minInt(G, G'))              [simplification]
+    rule #if B #then #gas(G) #else #gas(G') #fi => #gas(#if B #then G #else G' #fi) [simplification]
 
     rule #gas(_)  <Int #gas(_) => false [simplification]
     rule #gas(_) <=Int #gas(_) => true  [simplification]

--- a/tests/specs/infinite-gas.k
+++ b/tests/specs/infinite-gas.k
@@ -1,8 +1,31 @@
 requires "evm.md"
 
 module INFINITE-GAS
-    imports EVM
+    imports INFINITE-GAS-JAVA
+    imports INFINITE-GAS-HASKELL
+endmodule
 
+module INFINITE-GAS-HASKELL [kore]
+    imports INFINITE-GAS-COMMON
+
+    rule #gas(_)  <Int _I => false [concrete(_I), simplification]
+    rule #gas(_) <=Int _I => false [concrete(_I), simplification]
+    rule #gas(_) >=Int _I => true  [concrete(_I), simplification]
+    rule _I <=Int #gas(_) => true  [concrete(_I), simplification]
+endmodule
+
+module INFINITE-GAS-JAVA [kast]
+    imports INFINITE-GAS-COMMON
+    imports K-REFLECTION
+
+    rule #gas(_)  <Int I => false requires #isConcrete(I) [simplification]
+    rule #gas(_) <=Int I => false requires #isConcrete(I) [simplification]
+    rule #gas(_) >=Int I => true  requires #isConcrete(I) [simplification]
+    rule I <=Int #gas(_) => true  requires #isConcrete(I) [simplification]
+endmodule
+
+module INFINITE-GAS-COMMON
+    imports EVM
 
  // Symbolic Gas
 
@@ -26,11 +49,6 @@ module INFINITE-GAS
     rule #gas(_) <=Int I => false requires I <=Int pow256 [simplification]
     rule #gas(_) >=Int I => true  requires I <=Int pow256 [simplification]
     rule I <=Int #gas(_) => true  requires I <=Int pow256 [simplification]
-
-    rule #gas(_)  <Int _I => false [concrete(_I), simplification]
-    rule #gas(_) <=Int _I => false [concrete(_I), simplification]
-    rule #gas(_) >=Int _I => true  [concrete(_I), simplification]
-    rule _I <=Int #gas(_) => true  [concrete(_I), simplification]
 
     rule I +Int I' <=Int #gas(G) => true requires                     I <=Int #gas(G) andBool I' <=Int #gas(G) [simplification]
     rule I -Int I' <=Int #gas(G) => true requires                     I <=Int #gas(G) andBool I' <=Int #gas(G) [simplification]

--- a/tests/specs/infinite-gas.k
+++ b/tests/specs/infinite-gas.k
@@ -65,6 +65,9 @@ module INFINITE-GAS-COMMON
     rule #gas(G) <=Int I *Int I' => false requires                     notBool (#gas(G) <=Int I orBool #gas(G) <=Int I') [simplification]
     rule #gas(G) <=Int I /Int I' => false requires I' =/=Int 0 andBool notBool (#gas(G) <=Int I orBool #gas(G) <=Int I') [simplification]
 
+    rule minInt(G, G') <Int G'' => false requires (notBool G <Int G'') andBool (notBool G' <Int G'') [simplification]
+    rule G <Int minInt(G', G'') => true  requires          G <Int G'   andBool          G  <Int G''  [simplification]
+
     rule #gas(_) <Int Csstore(_, _, _, _) => false [simplification]
     rule #gas(_) <Int Cmem(_, _)          => false [simplification]
 

--- a/tests/specs/infinite-gas.k
+++ b/tests/specs/infinite-gas.k
@@ -18,6 +18,7 @@ module INFINITE-GAS-HASKELL [kore]
     rule I1         <=Int I2 +Int I3 => I1 -Int I3 <=Int I2         [concrete(I1, I3), simplification]
 
     rule ((I1 +Int I2) -Int I3) +Int I4 => (I1 -Int I3) +Int (I2 +Int I4) [concrete(I2, I4), symbolic(I1, I3), simplification]
+    rule (I1 +Int I2) -Int (I3 +Int I4) => (I1 -Int I3) +Int (I2 -Int I4) [concrete(I2, I4), symbolic(I1, I3), simplification]
 endmodule
 
 module INFINITE-GAS-JAVA [kast]
@@ -34,10 +35,17 @@ module INFINITE-GAS-JAVA [kast]
     rule I1         <=Int I2 +Int I3 => I1 -Int I3 <=Int I2         requires #isConcrete(I1) andBool #isConcrete(I3) [simplification]
 
     rule ((I1 +Int I2) +Int I3) +Int I4 => (I1 +Int I3) +Int (I2 +Int I4) requires #isConcrete(I2) andBool #isConcrete(I4) andBool notBool (#isConcrete(I1) orBool #isConcrete(I3)) [simplification]
+    rule (I1 +Int I2) -Int (I3 +Int I4) => (I1 -Int I3) +Int (I2 -Int I4) requires #isConcrete(I2) andBool #isConcrete(I4) andBool notBool (#isConcrete(I1) orBool #isConcrete(I3)) [simplification]
 endmodule
 
 module INFINITE-GAS-COMMON
     imports EVM
+
+ // Generic rules
+
+    rule I -Int I => 0                                              [simplification]
+    rule I1 -Int (I1 -Int I2) => I2                                 [simplification]
+    rule (notBool (A andBool B)) andBool A => (notBool B) andBool A [simplification]
 
  // Symbolic Gas
 

--- a/tests/specs/infinite-gas.k
+++ b/tests/specs/infinite-gas.k
@@ -23,8 +23,8 @@ module INFINITE-GAS-HASKELL [kore]
     rule I1          <Int I2 +Int I3 => I1 -Int I3  <Int I2         [concrete(I1, I3), simplification]
     rule I1         <=Int I2 +Int I3 => I1 -Int I3 <=Int I2         [concrete(I1, I3), simplification]
 
+    rule ((I1 +Int I2) +Int I3) +Int I4 => (I1 +Int I3) +Int (I2 +Int I4) [concrete(I2, I4), symbolic(I1, I3), simplification]
     rule ((I1 +Int I2) -Int I3) +Int I4 => (I1 -Int I3) +Int (I2 +Int I4) [concrete(I2, I4), symbolic(I1, I3), simplification]
-    rule ((I1 +Int I2) -Int I3) +Int I4 => (I1 -Int I3) +Int (I2 -Int I4) [concrete(I2, I4), symbolic(I1, I3), simplification]
     rule (I1 +Int I2) -Int (I3 +Int I4) => (I1 -Int I3) +Int (I2 -Int I4) [concrete(I2, I4), symbolic(I1, I3), simplification]
 endmodule
 

--- a/tests/specs/infinite-gas.k
+++ b/tests/specs/infinite-gas.k
@@ -50,13 +50,32 @@ module INFINITE-GAS-COMMON
  // ---------------------------------------------------------------------------------------------------------
     rule #gas(_, _, _) => #gas(0)
 
-    rule #gas(G) -Int G' => #gas(G +Int G') [simplification]
-    rule #gas(G) +Int G' => #gas(G -Int G') [simplification]
+    rule #gas(G) +Int G' => #gas(G +Int G') requires 0 <Int G' orBool 0 -Int G' <Int #gas(G)  [simplification]
+    rule G +Int #gas(G') => #gas(G +Int G') requires 0 <Int G  orBool 0 -Int G  <Int #gas(G') [simplification]
+
+    rule #gas(G) -Int G' => #gas(G -Int G') requires 0 <Int G' andBool G' <Int #gas(G) [simplification]
+
+    rule #gas(G) *Int G' => #gas(G *Int G') requires 0 <Int G' [simplification]
+    rule G *Int #gas(G') => #gas(G *Int G') requires 0 <Int G  [simplification]
+
+    rule #gas(G) /Int G' => #gas(G /Int G') requires 0 <Int G' andBool G' <Int #gas(G)  [simplification]
+    rule G /Int #gas(G') => 0               requires 0 <Int G  andBool G  <Int #gas(G') [simplification]
+
+    rule #gas(#gas(G)) => #gas(G) [simplification]
+
+    rule #gas(G) -Int #gas(G') => #gas(G -Int G') [simplification]
+
+    rule minInt(#gas(G), #gas(G')) => #gas(minInt(G, G')) [simplification]
+
+    rule #gas(_)  <Int #gas(_) => false [simplification]
+    rule #gas(_) <=Int #gas(_) => true  [simplification]
 
     rule #gas(_)  <Int I => false requires I <=Int pow256 [simplification]
     rule #gas(_) <=Int I => false requires I <=Int pow256 [simplification]
     rule #gas(_) >=Int I => true  requires I <=Int pow256 [simplification]
-    rule I <=Int #gas(_) => true  requires I <=Int pow256 [simplification]
+
+    rule I  <Int #gas(_) => true requires I <=Int pow256 [simplification]
+    rule I <=Int #gas(_) => true requires I <=Int pow256 [simplification]
 
     rule I +Int I' <=Int #gas(G) => true requires                     I <=Int #gas(G) andBool I' <=Int #gas(G) [simplification]
     rule I -Int I' <=Int #gas(G) => true requires                     I <=Int #gas(G) andBool I' <=Int #gas(G) [simplification]
@@ -73,14 +92,15 @@ module INFINITE-GAS-COMMON
     rule #gas(G) <=Int I *Int I' => false requires                     notBool (#gas(G) <=Int I orBool #gas(G) <=Int I') [simplification]
     rule #gas(G) <=Int I /Int I' => false requires I' =/=Int 0 andBool notBool (#gas(G) <=Int I orBool #gas(G) <=Int I') [simplification]
 
-    rule minInt(G, G') <Int G''  => false requires (notBool G  <Int G'') andBool (notBool G' <Int G'') [simplification]
-    rule G  <Int minInt(G', G'') => true  requires          G  <Int G'   andBool          G <=Int G''  [simplification]
-    rule G <=Int minInt(G', G'') => true  requires          G <=Int G'   andBool          G <=Int G''  [simplification]
+    rule minInt(G, G') <Int G''  => G <Int G'' orBool G' <Int G''  [simplification]
+    rule G  <Int minInt(G', G'') => G  <Int G' andBool G  <Int G'' [simplification]
+    rule G <=Int minInt(G', G'') => G <=Int G' andBool G <=Int G'' [simplification]
 
-    rule #gas(_) <Int Csstore(_, _, _, _) => false [simplification]
-    rule #gas(_) <Int Cmem(_, _)          => false [simplification]
+    rule 0 <Int Csstore(_, _, _, _)        => true  [simplification]
+    rule Csstore(_, _, _, _) <Int #gas(_)  => true  [simplification]
+    rule #gas(_)  <Int Csstore(_, _, _, _) => false [simplification]
+    rule #gas(_) >=Int Csstore(_, _, _, _) => true  [simplification]
 
-    rule #gas(_) >=Int Csstore(_, _, _, _) => true [simplification]
-
-    rule Cmem(_, _) <=Int #gas(_) => true [simplification]
+    rule #gas(_) <Int Cmem(_, _)  => false [simplification]
+    rule Cmem(_, _) <=Int #gas(_) => true  [simplification]
 endmodule

--- a/tests/specs/infinite-gas.k
+++ b/tests/specs/infinite-gas.k
@@ -1,5 +1,11 @@
 requires "evm.md"
 
+ //
+ // Infinite Gas
+ // Here we use the construct `#gas` to represent positive infinity, while tracking the gas formula through execution.
+ // This allows (i) computing final gas used, and (ii) never stopping because of out-of-gas.
+ //
+
 module INFINITE-GAS
     imports INFINITE-GAS-JAVA
     imports INFINITE-GAS-HASKELL
@@ -53,12 +59,6 @@ module INFINITE-GAS-COMMON
 
     syntax Int ::= #gas ( Int , Int , Int )  [function]  // startGas, nonMemory, memory
  //-----------------------------------------------------------------------------------
-
- //
- // Infinite Gas
- // Here we use the construct `#gas` to count _up_ gas used instead of counting down.
- // This allows (i) computing final gas used, and (ii) never stopping because of out-of-gas.
- //
 
     syntax Int ::= #gas ( Int ) [function, functional, no-evaluators, klabel(infGas), symbol, smtlib(infGas)]
  // ---------------------------------------------------------------------------------------------------------

--- a/tests/specs/infinite-gas.k
+++ b/tests/specs/infinite-gas.k
@@ -16,6 +16,8 @@ module INFINITE-GAS-HASKELL [kore]
     rule I1 +Int I2  <Int I3         => I1          <Int I3 -Int I2 [concrete(I2, I3), simplification]
     rule I1          <Int I2 +Int I3 => I1 -Int I3  <Int I2         [concrete(I1, I3), simplification]
     rule I1         <=Int I2 +Int I3 => I1 -Int I3 <=Int I2         [concrete(I1, I3), simplification]
+
+    rule ((I1 +Int I2) -Int I3) +Int I4 => (I1 -Int I3) +Int (I2 +Int I4) [concrete(I2, I4), simplification]
 endmodule
 
 module INFINITE-GAS-JAVA [kast]
@@ -30,6 +32,8 @@ module INFINITE-GAS-JAVA [kast]
     rule I1 +Int I2  <Int I3         => I1          <Int I3 -Int I2 requires #isConcrete(I2) andBool #isConcrete(I3) [simplification]
     rule I1          <Int I2 +Int I3 => I1 -Int I3  <Int I2         requires #isConcrete(I1) andBool #isConcrete(I3) [simplification]
     rule I1         <=Int I2 +Int I3 => I1 -Int I3 <=Int I2         requires #isConcrete(I1) andBool #isConcrete(I3) [simplification]
+
+    rule ((I1 +Int I2) -Int I3) +Int I4 => (I1 -Int I3) +Int (I2 +Int I4) requires #isConcrete(I2) andBool #isConcrete(I4) [simplification]
 endmodule
 
 module INFINITE-GAS-COMMON

--- a/tests/specs/infinite-gas.k
+++ b/tests/specs/infinite-gas.k
@@ -17,7 +17,7 @@ module INFINITE-GAS-HASKELL [kore]
     rule I1          <Int I2 +Int I3 => I1 -Int I3  <Int I2         [concrete(I1, I3), simplification]
     rule I1         <=Int I2 +Int I3 => I1 -Int I3 <=Int I2         [concrete(I1, I3), simplification]
 
-    rule ((I1 +Int I2) -Int I3) +Int I4 => (I1 -Int I3) +Int (I2 +Int I4) [concrete(I2, I4), simplification]
+    rule ((I1 +Int I2) -Int I3) +Int I4 => (I1 -Int I3) +Int (I2 +Int I4) [concrete(I2, I4), symbolic(I1, I3), simplification]
 endmodule
 
 module INFINITE-GAS-JAVA [kast]
@@ -33,7 +33,7 @@ module INFINITE-GAS-JAVA [kast]
     rule I1          <Int I2 +Int I3 => I1 -Int I3  <Int I2         requires #isConcrete(I1) andBool #isConcrete(I3) [simplification]
     rule I1         <=Int I2 +Int I3 => I1 -Int I3 <=Int I2         requires #isConcrete(I1) andBool #isConcrete(I3) [simplification]
 
-    rule ((I1 +Int I2) -Int I3) +Int I4 => (I1 -Int I3) +Int (I2 +Int I4) requires #isConcrete(I2) andBool #isConcrete(I4) [simplification]
+    rule ((I1 +Int I2) +Int I3) +Int I4 => (I1 +Int I3) +Int (I2 +Int I4) requires #isConcrete(I2) andBool #isConcrete(I4) andBool notBool (#isConcrete(I1) orBool #isConcrete(I3)) [simplification]
 endmodule
 
 module INFINITE-GAS-COMMON

--- a/tests/specs/infinite-gas.k
+++ b/tests/specs/infinite-gas.k
@@ -12,6 +12,10 @@ module INFINITE-GAS-HASKELL [kore]
     rule #gas(_) <=Int _I => false [concrete(_I), simplification]
     rule #gas(_) >=Int _I => true  [concrete(_I), simplification]
     rule _I <=Int #gas(_) => true  [concrete(_I), simplification]
+
+    rule I1 +Int I2  <Int I3         => I1          <Int I3 -Int I2 [concrete(I2, I3), simplification]
+    rule I1          <Int I2 +Int I3 => I1 -Int I3  <Int I2         [concrete(I1, I3), simplification]
+    rule I1         <=Int I2 +Int I3 => I1 -Int I3 <=Int I3         [concrete(I1, I3), simplification]
 endmodule
 
 module INFINITE-GAS-JAVA [kast]
@@ -22,6 +26,10 @@ module INFINITE-GAS-JAVA [kast]
     rule #gas(_) <=Int I => false requires #isConcrete(I) [simplification]
     rule #gas(_) >=Int I => true  requires #isConcrete(I) [simplification]
     rule I <=Int #gas(_) => true  requires #isConcrete(I) [simplification]
+
+    rule I1 +Int I2  <Int I3         => I1          <Int I3 -Int I2 requires #isConcrete(I2) andBool #isConcrete(I3) [simplification]
+    rule I1          <Int I2 +Int I3 => I1 -Int I3  <Int I2         requires #isConcrete(I1) andBool #isConcrete(I3) [simplification]
+    rule I1         <=Int I2 +Int I3 => I1 -Int I3 <=Int I3         requires #isConcrete(I1) andBool #isConcrete(I3) [simplification]
 endmodule
 
 module INFINITE-GAS-COMMON
@@ -65,8 +73,9 @@ module INFINITE-GAS-COMMON
     rule #gas(G) <=Int I *Int I' => false requires                     notBool (#gas(G) <=Int I orBool #gas(G) <=Int I') [simplification]
     rule #gas(G) <=Int I /Int I' => false requires I' =/=Int 0 andBool notBool (#gas(G) <=Int I orBool #gas(G) <=Int I') [simplification]
 
-    rule minInt(G, G') <Int G'' => false requires (notBool G <Int G'') andBool (notBool G' <Int G'') [simplification]
-    rule G <Int minInt(G', G'') => true  requires          G <Int G'   andBool          G  <Int G''  [simplification]
+    rule minInt(G, G') <Int G''  => false requires (notBool G  <Int G'') andBool (notBool G' <Int G'') [simplification]
+    rule G  <Int minInt(G', G'') => true  requires          G  <Int G'   andBool          G <=Int G''  [simplification]
+    rule G <=Int minInt(G', G'') => true  requires          G <=Int G'   andBool          G <=Int G''  [simplification]
 
     rule #gas(_) <Int Csstore(_, _, _, _) => false [simplification]
     rule #gas(_) <Int Cmem(_, _)          => false [simplification]

--- a/tests/specs/infinite-gas.k
+++ b/tests/specs/infinite-gas.k
@@ -15,7 +15,7 @@ module INFINITE-GAS-HASKELL [kore]
 
     rule I1 +Int I2  <Int I3         => I1          <Int I3 -Int I2 [concrete(I2, I3), simplification]
     rule I1          <Int I2 +Int I3 => I1 -Int I3  <Int I2         [concrete(I1, I3), simplification]
-    rule I1         <=Int I2 +Int I3 => I1 -Int I3 <=Int I3         [concrete(I1, I3), simplification]
+    rule I1         <=Int I2 +Int I3 => I1 -Int I3 <=Int I2         [concrete(I1, I3), simplification]
 endmodule
 
 module INFINITE-GAS-JAVA [kast]
@@ -29,7 +29,7 @@ module INFINITE-GAS-JAVA [kast]
 
     rule I1 +Int I2  <Int I3         => I1          <Int I3 -Int I2 requires #isConcrete(I2) andBool #isConcrete(I3) [simplification]
     rule I1          <Int I2 +Int I3 => I1 -Int I3  <Int I2         requires #isConcrete(I1) andBool #isConcrete(I3) [simplification]
-    rule I1         <=Int I2 +Int I3 => I1 -Int I3 <=Int I3         requires #isConcrete(I1) andBool #isConcrete(I3) [simplification]
+    rule I1         <=Int I2 +Int I3 => I1 -Int I3 <=Int I2         requires #isConcrete(I1) andBool #isConcrete(I3) [simplification]
 endmodule
 
 module INFINITE-GAS-COMMON

--- a/tests/specs/infinite-gas.k
+++ b/tests/specs/infinite-gas.k
@@ -4,6 +4,9 @@ requires "evm.md"
  // Infinite Gas
  // Here we use the construct `#gas` to represent positive infinity, while tracking the gas formula through execution.
  // This allows (i) computing final gas used, and (ii) never stopping because of out-of-gas.
+ // Note that the argument to `#gas(_)` is just metadata tracking the current gas usage, and is not meant to be compared to other values.
+ // As such, any `#gas(G)` and `#gas(G')` are the _same_ positive infinite, regardless of the values `G` and `G'`.
+ // In particular, this means that `#gas(_) <Int #gas(_) => false`, and `#gas(_) <=Int #gas(_) => true`, regardless of the values contained in the `#gas(_)`.
  //
 
 module INFINITE-GAS

--- a/tests/specs/mcd/cat-exhaustiveness-spec.k
+++ b/tests/specs/mcd/cat-exhaustiveness-spec.k
@@ -4,7 +4,7 @@ module CAT-EXHAUSTIVENESS-SPEC
   imports VERIFICATION
 
      // Cat__exhaustiveness
-     rule [Cat..exhaustiveness]:
+     claim [Cat..exhaustiveness]:
        <k> #execute ~> CONTINUATION => #halt ~> CONTINUATION </k>
        <exit-code> 1 </exit-code>
        <mode> NORMAL </mode>

--- a/tests/specs/mcd/cat-exhaustiveness-spec.k
+++ b/tests/specs/mcd/cat-exhaustiveness-spec.k
@@ -27,7 +27,7 @@ module CAT-EXHAUSTIVENESS-SPEC
              <wordStack> .WordStack => ?_ </wordStack>
              <localMem> .Memory => ?_ </localMem>
              <pc> 0 => ?_ </pc>
-             <gas> VGas => ?_ </gas>
+             <gas> #gas(VGas) => ?_ </gas>
              <memoryUsed> 0 => ?_ </memoryUsed>
              <callGas> _ => ?_ </callGas>
              <static> _VStatic </static>

--- a/tests/specs/mcd/cat-file-addr-pass-rough-spec.k
+++ b/tests/specs/mcd/cat-file-addr-pass-rough-spec.k
@@ -4,7 +4,7 @@ module CAT-FILE-ADDR-PASS-ROUGH-SPEC
     imports VERIFICATION
 
     // Cat_file-addr
-    rule [Cat.file-addr.pass.rough]:
+    claim [Cat.file-addr.pass.rough]:
       <k> #execute ~> CONTINUATION => #halt ~> CONTINUATION </k>
       <exit-code> 1 </exit-code>
       <mode> NORMAL </mode>

--- a/tests/specs/mcd/concrete-rules.txt
+++ b/tests/specs/mcd/concrete-rules.txt
@@ -1,7 +1,6 @@
 EDSL.#ceil32
 EDSL.keccakIntList
 EVM.Cextra
-EVM.Cgascap
 EVM.Cmem
 EVM.Cnew
 EVM.Csstore.new

--- a/tests/specs/mcd/dai-adduu-fail-rough-spec.k
+++ b/tests/specs/mcd/dai-adduu-fail-rough-spec.k
@@ -4,7 +4,7 @@ module DAI-ADDUU-FAIL-ROUGH-SPEC
     imports VERIFICATION
 
     // Dai_adduu
-    rule [Dai.adduu.fail.rough]:
+    claim [Dai.adduu.fail.rough]:
       <k> #execute ~> CONTINUATION => #halt ~> CONTINUATION </k>
       <exit-code> 1 </exit-code>
       <mode> NORMAL </mode>

--- a/tests/specs/mcd/dai-adduu-fail-rough-spec.k
+++ b/tests/specs/mcd/dai-adduu-fail-rough-spec.k
@@ -27,7 +27,7 @@ module DAI-ADDUU-FAIL-ROUGH-SPEC
             <wordStack> ABI_y : ABI_x : _JMPTO : WS  => ?_ </wordStack>
             <localMem> _ </localMem>
             <pc> 7825 => ?_ </pc>
-            <gas> VGas => ?_ </gas>
+            <gas> #gas(VGas) => ?_ </gas>
             <memoryUsed> VMemoryUsed </memoryUsed>
             <callGas> _ => ?_ </callGas>
             <static> _ </static>

--- a/tests/specs/mcd/dai-symbol-pass-spec.k
+++ b/tests/specs/mcd/dai-symbol-pass-spec.k
@@ -27,7 +27,7 @@ module DAI-SYMBOL-PASS-SPEC
             <wordStack> .WordStack => ?_ </wordStack>
             <localMem> .Memory => ?_ </localMem>
             <pc> 0 => ?_ </pc>
-            <gas> VGas => VGas -Int (672) </gas>
+            <gas> #gas(VGas) => #gas(VGas +Int 672) </gas>
             <memoryUsed> 0 => ?_ </memoryUsed>
             <callGas> _ => ?_ </callGas>
             <static> _ </static>

--- a/tests/specs/mcd/dai-symbol-pass-spec.k
+++ b/tests/specs/mcd/dai-symbol-pass-spec.k
@@ -27,7 +27,7 @@ module DAI-SYMBOL-PASS-SPEC
             <wordStack> .WordStack => ?_ </wordStack>
             <localMem> .Memory => ?_ </localMem>
             <pc> 0 => ?_ </pc>
-            <gas> #gas(VGas) => #gas(VGas +Int 672) </gas>
+            <gas> #gas(VGas) => #gas(VGas +Int -672) </gas>
             <memoryUsed> 0 => ?_ </memoryUsed>
             <callGas> _ => ?_ </callGas>
             <static> _ </static>

--- a/tests/specs/mcd/dai-symbol-pass-spec.k
+++ b/tests/specs/mcd/dai-symbol-pass-spec.k
@@ -4,7 +4,7 @@ module DAI-SYMBOL-PASS-SPEC
   imports VERIFICATION
 
     // Dai_symbol
-    rule [Dai.symbol.pass]:
+    claim [Dai.symbol.pass]:
       <k> #execute ~> CONTINUATION => #halt ~> CONTINUATION </k>
       <exit-code> 1 </exit-code>
       <mode> NORMAL </mode>

--- a/tests/specs/mcd/dstoken-approve-fail-rough-spec.k
+++ b/tests/specs/mcd/dstoken-approve-fail-rough-spec.k
@@ -27,7 +27,7 @@ module DSTOKEN-APPROVE-FAIL-ROUGH-SPEC
             <wordStack> .WordStack => ?_ </wordStack>
             <localMem> .Memory => ?_ </localMem>
             <pc> 0 => ?_ </pc>
-            <gas> VGas => ?_ </gas>
+            <gas> #gas(VGas) => ?_ </gas>
             <memoryUsed> 0 => ?_ </memoryUsed>
             <callGas> _ => ?_ </callGas>
             <static> false </static>

--- a/tests/specs/mcd/dstoken-approve-fail-rough-spec.k
+++ b/tests/specs/mcd/dstoken-approve-fail-rough-spec.k
@@ -4,7 +4,7 @@ module DSTOKEN-APPROVE-FAIL-ROUGH-SPEC
     imports VERIFICATION
 
     // DSToken_approve
-    rule [DSToken.approve.fail.rough]:
+    claim [DSToken.approve.fail.rough]:
       <k> #execute ~> CONTINUATION => #halt ~> CONTINUATION </k>
       <exit-code> 1 </exit-code>
       <mode> NORMAL </mode>

--- a/tests/specs/mcd/dstoken-burn-self-fail-rough-spec.k
+++ b/tests/specs/mcd/dstoken-burn-self-fail-rough-spec.k
@@ -27,7 +27,7 @@ module DSTOKEN-BURN-SELF-FAIL-ROUGH-SPEC
             <wordStack> .WordStack => ?_ </wordStack>
             <localMem> .Memory => ?_ </localMem>
             <pc> 0 => ?_ </pc>
-            <gas> VGas => ?_ </gas>
+            <gas> #gas(VGas) => ?_ </gas>
             <memoryUsed> 0 => ?_ </memoryUsed>
             <callGas> _ => ?_ </callGas>
             <static> false </static>

--- a/tests/specs/mcd/dstoken-burn-self-fail-rough-spec.k
+++ b/tests/specs/mcd/dstoken-burn-self-fail-rough-spec.k
@@ -4,7 +4,7 @@ module DSTOKEN-BURN-SELF-FAIL-ROUGH-SPEC
     imports VERIFICATION
 
     // DSToken_burn-self
-    rule [DSToken.burn-self.fail.rough]:
+    claim [DSToken.burn-self.fail.rough]:
       <k> #execute ~> CONTINUATION => #halt ~> CONTINUATION </k>
       <exit-code> 1 </exit-code>
       <mode> NORMAL </mode>

--- a/tests/specs/mcd/dstoken-transferfrom-fail-rough-spec.k
+++ b/tests/specs/mcd/dstoken-transferfrom-fail-rough-spec.k
@@ -27,7 +27,7 @@ module DSTOKEN-TRANSFERFROM-FAIL-ROUGH-SPEC
             <wordStack> .WordStack => ?_ </wordStack>
             <localMem> .Memory => ?_ </localMem>
             <pc> 0 => ?_ </pc>
-            <gas> VGas => ?_ </gas>
+            <gas> #gas(VGas) => ?_ </gas>
             <memoryUsed> 0 => ?_ </memoryUsed>
             <callGas> _ => ?_ </callGas>
             <static> false </static>

--- a/tests/specs/mcd/dstoken-transferfrom-fail-rough-spec.k
+++ b/tests/specs/mcd/dstoken-transferfrom-fail-rough-spec.k
@@ -4,7 +4,7 @@ module DSTOKEN-TRANSFERFROM-FAIL-ROUGH-SPEC
     imports VERIFICATION
 
     // DSToken_transferFrom
-    rule [DSToken.transferFrom.fail.rough]:
+    claim [DSToken.transferFrom.fail.rough]:
       <k> #execute ~> CONTINUATION => #halt ~> CONTINUATION </k>
       <exit-code> 1 </exit-code>
       <mode> NORMAL </mode>

--- a/tests/specs/mcd/dsvalue-peek-pass-rough-spec.k
+++ b/tests/specs/mcd/dsvalue-peek-pass-rough-spec.k
@@ -27,7 +27,7 @@ module DSVALUE-PEEK-PASS-ROUGH-SPEC
             <wordStack> .WordStack => ?_ </wordStack>
             <localMem> .Memory => ?_ </localMem>
             <pc> 0 => ?_ </pc>
-            <gas> VGas => ?_ </gas>
+            <gas> #gas(VGas) => ?_ </gas>
             <memoryUsed> 0 => ?_ </memoryUsed>
             <callGas> _ => ?_ </callGas>
             <static> _ </static>

--- a/tests/specs/mcd/dsvalue-peek-pass-rough-spec.k
+++ b/tests/specs/mcd/dsvalue-peek-pass-rough-spec.k
@@ -4,7 +4,7 @@ module DSVALUE-PEEK-PASS-ROUGH-SPEC
     imports VERIFICATION
 
     // DSValue_peek
-    rule [DSValue.peek.pass.rough]:
+    claim [DSValue.peek.pass.rough]:
       <k> #execute ~> CONTINUATION => #halt ~> CONTINUATION </k>
       <exit-code> 1 </exit-code>
       <mode> NORMAL </mode>

--- a/tests/specs/mcd/dsvalue-read-pass-spec.k
+++ b/tests/specs/mcd/dsvalue-read-pass-spec.k
@@ -27,7 +27,7 @@ module DSVALUE-READ-PASS-SPEC
             <wordStack> .WordStack => ?_ </wordStack>
             <localMem> .Memory => ?_ </localMem>
             <pc> 0 => ?_ </pc>
-            <gas> VGas => VGas -Int (2043) </gas>
+            <gas> #gas(VGas) => #gas(VGas +Int 2043) </gas>
             <memoryUsed> 0 => ?_ </memoryUsed>
             <callGas> _ => ?_ </callGas>
             <static> _ </static>

--- a/tests/specs/mcd/dsvalue-read-pass-spec.k
+++ b/tests/specs/mcd/dsvalue-read-pass-spec.k
@@ -27,7 +27,7 @@ module DSVALUE-READ-PASS-SPEC
             <wordStack> .WordStack => ?_ </wordStack>
             <localMem> .Memory => ?_ </localMem>
             <pc> 0 => ?_ </pc>
-            <gas> #gas(VGas) => #gas(VGas +Int 2043) </gas>
+            <gas> #gas(VGas) => #gas(VGas +Int -2043) </gas>
             <memoryUsed> 0 => ?_ </memoryUsed>
             <callGas> _ => ?_ </callGas>
             <static> _ </static>

--- a/tests/specs/mcd/dsvalue-read-pass-spec.k
+++ b/tests/specs/mcd/dsvalue-read-pass-spec.k
@@ -4,7 +4,7 @@ module DSVALUE-READ-PASS-SPEC
     imports VERIFICATION
 
     // DSValue_read
-    rule [DSValue.read.pass]:
+    claim [DSValue.read.pass]:
       <k> #execute ~> CONTINUATION => #halt ~> CONTINUATION </k>
       <exit-code> 1 </exit-code>
       <mode> NORMAL </mode>

--- a/tests/specs/mcd/end-pack-pass-rough-spec.k
+++ b/tests/specs/mcd/end-pack-pass-rough-spec.k
@@ -1,0 +1,830 @@
+requires "verification.k"
+
+module END-PACK-PASS-ROUGH-SPEC
+    imports VERIFICATION
+
+    // End_pack
+    claim [End.pack.pass.rough]:
+      <k> #execute ~> CONTINUATION => #halt ~> CONTINUATION </k>
+      <exit-code> 1 </exit-code>
+      <mode> NORMAL </mode>
+      <schedule> ISTANBUL </schedule>
+      <ethereum>
+        <evm>
+          <output> .ByteArray </output>
+          <statusCode> _ => EVMC_SUCCESS </statusCode>
+          <endPC> _ => ?_ </endPC>
+          <callStack> _VCallStack </callStack>
+          <interimStates> _ </interimStates>
+          <touchedAccounts> _ => ?_ </touchedAccounts>
+          <callState>
+            <program> End_bin_runtime </program>
+            <jumpDests> #computeValidJumpDests(End_bin_runtime) </jumpDests>
+            <id> ACCT_ID </id>
+            <caller> CALLER_ID </caller>
+            <callData> #abiCallData("pack", #uint256(ABI_wad)) ++ CD => ?_ </callData>
+            <callValue> VCallValue </callValue>
+            <wordStack> .WordStack => ?_ </wordStack>
+            <localMem> .Memory => ?_ </localMem>
+            <pc> 0 => ?_ </pc>
+            <gas> #gas(VGas) => ?_ </gas>
+            <memoryUsed> 0 => ?_ </memoryUsed>
+            <callGas> _ => ?_ </callGas>
+            <static> false </static>
+            <callDepth> VCallDepth </callDepth>
+          </callState>
+          <substate>
+            <selfDestruct> _VSelfDestruct </selfDestruct>
+            <log> _ => ?_ </log>
+            <refund> _Vrefund => ?_ </refund>
+          </substate>
+          <gasPrice> _ </gasPrice>
+          <origin> ORIGIN_ID </origin>
+          <blockhashes> _ </blockhashes>
+          <block>
+            <previousHash> _ </previousHash>
+            <ommersHash> _ </ommersHash>
+            <coinbase> _ </coinbase>
+            <stateRoot> _ </stateRoot>
+            <transactionsRoot> _ </transactionsRoot>
+            <receiptsRoot> _ </receiptsRoot>
+            <logsBloom> _ </logsBloom>
+            <difficulty> _ </difficulty>
+            <number> _BLOCK_NUMBER </number>
+            <gasLimit> _ </gasLimit>
+            <gasUsed> _ </gasUsed>
+            <timestamp> TIME </timestamp>
+            <extraData> _ </extraData>
+            <mixHash> _ </mixHash>
+            <blockNonce> _ </blockNonce>
+            <ommerBlockHeaders> _ </ommerBlockHeaders>
+          </block>
+        </evm>
+        <network>
+          <chainID> VChainId </chainID>
+          <activeAccounts> SetItem(ACCT_ID)
+          SetItem(Vat)
+          SetItem(1)
+          SetItem(2)
+          SetItem(3)
+          SetItem(4)
+          SetItem(5)
+          SetItem(6)
+          SetItem(7)
+          SetItem(8)
+          SetItem(9) _ </activeAccounts>
+          <accounts>
+            <account>
+              <acctID> ACCT_ID </acctID>
+              <balance> ACCT_ID_balance </balance>
+              <code> End_bin_runtime </code>
+              <storage> ACCT_ID_STORAGE => ACCT_ID_STORAGE [ #End.bag[CALLER_ID] <- Bag +Int ABI_wad ] </storage>
+              <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
+              <nonce> _Nonce_End => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> Vat </acctID>
+              <balance> Vat_balance </balance>
+              <code> Vat_bin_runtime </code>
+              <storage> Vat_STORAGE => Vat_STORAGE [ #Vat.dai[CALLER_ID] <- Dai -Int ABI_wad *Int #Ray ] [ #Vat.dai[Vow] <- Joy +Int ABI_wad *Int #Ray ] </storage>
+              <origStorage> Vat_ORIG_STORAGE </origStorage>
+              <nonce> _Nonce_Vat => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> 1 </acctID>
+              <balance> ECREC_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 2 </acctID>
+              <balance> SHA256_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 3 </acctID>
+              <balance> RIP160_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 4 </acctID>
+              <balance> ID_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 5 </acctID>
+              <balance> MODEXP_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 6 </acctID>
+              <balance> ECADD_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 7 </acctID>
+              <balance> ECMUL_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 8 </acctID>
+              <balance> ECPAIRING_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 9 </acctID>
+              <balance> BLAKE2_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+           ...
+          </accounts>
+          <txOrder> _ </txOrder>
+          <txPending> _ </txPending>
+          <messages> _ </messages>
+        </network>
+      </ethereum>
+      requires #rangeAddress(ACCT_ID)
+       andBool ACCT_ID =/=Int 0
+       andBool #notPrecompileAddress(ACCT_ID)
+       andBool #rangeAddress(CALLER_ID)
+       andBool #rangeAddress(ORIGIN_ID)
+       andBool #rangeUInt(256, TIME)
+       andBool #rangeUInt(256, ACCT_ID_balance)
+       andBool #rangeUInt(256, ECREC_BAL)
+       andBool #rangeUInt(256, SHA256_BAL)
+       andBool #rangeUInt(256, RIP160_BAL)
+       andBool #rangeUInt(256, ID_BAL)
+       andBool #rangeUInt(256, MODEXP_BAL)
+       andBool #rangeUInt(256, ECADD_BAL)
+       andBool #rangeUInt(256, ECMUL_BAL)
+       andBool #rangeUInt(256, ECPAIRING_BAL)
+       andBool #rangeUInt(256, BLAKE2_BAL)
+       andBool VCallDepth <=Int 1024
+       andBool #rangeUInt(256, VCallValue)
+       andBool #rangeUInt(256, VChainId)
+
+       andBool (#rangeUInt(256, ABI_wad)
+       andBool (#rangeAddress(Vat)
+       andBool (#rangeAddress(Vow)
+       andBool (#rangeUInt(256, Debt)
+       andBool (#rangeUInt(256, Bag)
+       andBool (#rangeUInt(256, Joy)
+       andBool (#rangeUInt(256, Dai)
+       andBool (#rangeUInt(256, Can)
+       andBool (#rangeUInt(256, Vat_balance)
+       andBool ((#sizeByteArray(CD) <=Int 1250000000)
+       andBool ((#notPrecompileAddress(Vat))
+       andBool ((#notPrecompileAddress(Vow))
+       andBool ((ACCT_ID =/=Int Vat)
+       andBool ((CALLER_ID =/=Int Vow)
+       andBool ((CALLER_ID =/=Int ACCT_ID)
+       andBool ((Vat =/=Int 0)
+       andBool (#rangeUInt(256, Junk_0)
+       andBool (#rangeUInt(256, Junk_1)
+       andBool (#rangeUInt(256, Junk_2)
+       andBool (#rangeUInt(256, Junk_3)
+       andBool (#rangeUInt(256, Junk_4)
+       andBool (#rangeUInt(256, Junk_5)
+       andBool (#rangeUInt(256, Junk_6)
+       andBool (((Debt =/=Int 0))
+       andBool (((Can  ==Int 1))
+       andBool (((VCallValue ==Int 0))
+       andBool (((VCallDepth <Int 1024))
+       andBool ((#rangeUInt(256, Bag +Int ABI_wad))
+       andBool ((#rangeUInt(256, ABI_wad *Int #Ray))
+       andBool ((#rangeUInt(256, Dai -Int (ABI_wad *Int #Ray)))
+       andBool ((#rangeUInt(256, Joy +Int (ABI_wad *Int #Ray))))))))))))))))))))))))))))))))))
+
+       andBool #lookup(ACCT_ID_STORAGE, #End.vat) ==Int Vat
+       andBool #lookup(ACCT_ID_STORAGE, #End.vow) ==Int Vow
+       andBool #lookup(ACCT_ID_STORAGE, #End.debt) ==Int Debt
+       andBool #lookup(ACCT_ID_STORAGE, #End.bag[CALLER_ID]) ==Int Bag
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #End.vat) ==Int Junk_0
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #End.vow) ==Int Junk_1
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #End.debt) ==Int Junk_2
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #End.bag[CALLER_ID]) ==Int Junk_3
+       andBool #End.vat =/=Int #End.vow
+       andBool #End.vat =/=Int #End.debt
+       andBool #End.vat =/=Int #End.bag[CALLER_ID]
+       andBool #End.vow =/=Int #End.debt
+       andBool #End.vow =/=Int #End.bag[CALLER_ID]
+       andBool #End.debt =/=Int #End.bag[CALLER_ID]
+       andBool #lookup(Vat_STORAGE, #Vat.can[CALLER_ID][ACCT_ID]) ==Int Can
+       andBool #lookup(Vat_STORAGE, #Vat.dai[CALLER_ID]) ==Int Dai
+       andBool #lookup(Vat_STORAGE, #Vat.dai[Vow]) ==Int Joy
+       andBool #lookup(Vat_ORIG_STORAGE, #Vat.can[CALLER_ID][ACCT_ID]) ==Int Junk_4
+       andBool #lookup(Vat_ORIG_STORAGE, #Vat.dai[CALLER_ID]) ==Int Junk_5
+       andBool #lookup(Vat_ORIG_STORAGE, #Vat.dai[Vow]) ==Int Junk_6
+       andBool #Vat.can[CALLER_ID][ACCT_ID] =/=Int #Vat.dai[CALLER_ID]
+       andBool #Vat.can[CALLER_ID][ACCT_ID] =/=Int #Vat.dai[Vow]
+       andBool #Vat.dai[CALLER_ID] =/=Int #Vat.dai[Vow]
+
+    // End_muluu
+    claim [End.muluu.pass]:
+      <k> #execute ~> CONTINUATION => #execute ~> CONTINUATION </k>
+      <exit-code> 1 </exit-code>
+      <mode> NORMAL </mode>
+      <schedule> ISTANBUL </schedule>
+      <ethereum>
+        <evm>
+          <output> VOutput => VOutput </output>
+          <statusCode> _ => ?_ </statusCode>
+          <endPC> _ => ?_ </endPC>
+          <callStack> _VCallStack </callStack>
+          <interimStates> _ </interimStates>
+          <touchedAccounts> _ => ?_ </touchedAccounts>
+          <callState>
+            <program> End_bin_runtime </program>
+            <jumpDests> #computeValidJumpDests(End_bin_runtime) </jumpDests>
+            <id> ACCT_ID </id>
+            <caller> CALLER_ID </caller>
+            <callData> _ => ?_ </callData>
+            <callValue> VCallValue </callValue>
+            <wordStack> ABI_y : ABI_x : JMPTO : WS  =>  JMPTO : ABI_x *Int ABI_y : WS </wordStack>
+            <localMem> _ </localMem>
+            <pc> 14690 => 14733 </pc>
+            <gas> #gas(VGas) => #if ABI_y ==Int 0
+              #then   #gas ( ( VGas +Int 54 ) )
+              #else   #gas ( ( VGas +Int 106 ) )
+            #fi </gas>
+            <memoryUsed> VMemoryUsed </memoryUsed>
+            <callGas> _ => ?_ </callGas>
+            <static> _ </static>
+            <callDepth> VCallDepth </callDepth>
+          </callState>
+          <substate>
+            <selfDestruct> _VSelfDestruct </selfDestruct>
+            <log> _ => ?_ </log>
+            <refund> _Vrefund => ?_ </refund>
+          </substate>
+          <gasPrice> _ </gasPrice>
+          <origin> ORIGIN_ID </origin>
+          <blockhashes> _ </blockhashes>
+          <block>
+            <previousHash> _ </previousHash>
+            <ommersHash> _ </ommersHash>
+            <coinbase> _ </coinbase>
+            <stateRoot> _ </stateRoot>
+            <transactionsRoot> _ </transactionsRoot>
+            <receiptsRoot> _ </receiptsRoot>
+            <logsBloom> _ </logsBloom>
+            <difficulty> _ </difficulty>
+            <number> _BLOCK_NUMBER </number>
+            <gasLimit> _ </gasLimit>
+            <gasUsed> _ </gasUsed>
+            <timestamp> TIME </timestamp>
+            <extraData> _ </extraData>
+            <mixHash> _ </mixHash>
+            <blockNonce> _ </blockNonce>
+            <ommerBlockHeaders> _ </ommerBlockHeaders>
+          </block>
+        </evm>
+        <network>
+          <chainID> VChainId </chainID>
+          <activeAccounts> SetItem(ACCT_ID)
+          SetItem(1)
+          SetItem(2)
+          SetItem(3)
+          SetItem(4)
+          SetItem(5)
+          SetItem(6)
+          SetItem(7)
+          SetItem(8)
+          SetItem(9) _ </activeAccounts>
+          <accounts>
+            <account>
+              <acctID> ACCT_ID </acctID>
+              <balance> ACCT_ID_balance </balance>
+              <code> End_bin_runtime </code>
+              <storage> ACCT_ID_STORAGE => ACCT_ID_STORAGE  </storage>
+              <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
+              <nonce> _Nonce_End => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> 1 </acctID>
+              <balance> ECREC_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 2 </acctID>
+              <balance> SHA256_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 3 </acctID>
+              <balance> RIP160_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 4 </acctID>
+              <balance> ID_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 5 </acctID>
+              <balance> MODEXP_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 6 </acctID>
+              <balance> ECADD_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 7 </acctID>
+              <balance> ECMUL_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 8 </acctID>
+              <balance> ECPAIRING_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 9 </acctID>
+              <balance> BLAKE2_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+           ...
+          </accounts>
+          <txOrder> _ </txOrder>
+          <txPending> _ </txPending>
+          <messages> _ </messages>
+        </network>
+      </ethereum>
+      requires #rangeAddress(ACCT_ID)
+       andBool ACCT_ID =/=Int 0
+       andBool #notPrecompileAddress(ACCT_ID)
+       andBool #rangeAddress(CALLER_ID)
+       andBool #rangeAddress(ORIGIN_ID)
+       andBool #rangeUInt(256, TIME)
+       andBool #rangeUInt(256, ACCT_ID_balance)
+       andBool #rangeUInt(256, ECREC_BAL)
+       andBool #rangeUInt(256, SHA256_BAL)
+       andBool #rangeUInt(256, RIP160_BAL)
+       andBool #rangeUInt(256, ID_BAL)
+       andBool #rangeUInt(256, MODEXP_BAL)
+       andBool #rangeUInt(256, ECADD_BAL)
+       andBool #rangeUInt(256, ECMUL_BAL)
+       andBool #rangeUInt(256, ECPAIRING_BAL)
+       andBool #rangeUInt(256, BLAKE2_BAL)
+       andBool VCallDepth <=Int 1024
+       andBool #rangeUInt(256, VCallValue)
+       andBool #rangeUInt(256, VChainId)
+
+       andBool (#rangeUInt(256, ABI_x)
+       andBool (#rangeUInt(256, ABI_y)
+       andBool ((#sizeWordStack(WS) <=Int 1000)
+       andBool (#rangeUInt(256, VMemoryUsed)
+       andBool ((#rangeUInt(256, ABI_x *Int ABI_y)))))))
+
+
+    [trusted, matching(infGas)]
+
+
+    // End_adduu
+    claim [End.adduu.pass]:
+      <k> #execute ~> CONTINUATION => #execute ~> CONTINUATION </k>
+      <exit-code> 1 </exit-code>
+      <mode> NORMAL </mode>
+      <schedule> ISTANBUL </schedule>
+      <ethereum>
+        <evm>
+          <output> VOutput => VOutput </output>
+          <statusCode> _ => ?_ </statusCode>
+          <endPC> _ => ?_ </endPC>
+          <callStack> _VCallStack </callStack>
+          <interimStates> _ </interimStates>
+          <touchedAccounts> _ => ?_ </touchedAccounts>
+          <callState>
+            <program> End_bin_runtime </program>
+            <jumpDests> #computeValidJumpDests(End_bin_runtime) </jumpDests>
+            <id> ACCT_ID </id>
+            <caller> CALLER_ID </caller>
+            <callData> _ => ?_ </callData>
+            <callValue> VCallValue </callValue>
+            <wordStack> ABI_y : ABI_x : JMPTO : WS  =>  JMPTO : ABI_x +Int ABI_y : WS </wordStack>
+            <localMem> _ </localMem>
+            <pc> 14775 => 14800 </pc>
+            <gas> #gas(VGas) => #gas ( ( VGas +Int 54 ) ) </gas>
+            <memoryUsed> VMemoryUsed </memoryUsed>
+            <callGas> _ => ?_ </callGas>
+            <static> _ </static>
+            <callDepth> VCallDepth </callDepth>
+          </callState>
+          <substate>
+            <selfDestruct> _VSelfDestruct </selfDestruct>
+            <log> _ => ?_ </log>
+            <refund> _Vrefund => ?_ </refund>
+          </substate>
+          <gasPrice> _ </gasPrice>
+          <origin> ORIGIN_ID </origin>
+          <blockhashes> _ </blockhashes>
+          <block>
+            <previousHash> _ </previousHash>
+            <ommersHash> _ </ommersHash>
+            <coinbase> _ </coinbase>
+            <stateRoot> _ </stateRoot>
+            <transactionsRoot> _ </transactionsRoot>
+            <receiptsRoot> _ </receiptsRoot>
+            <logsBloom> _ </logsBloom>
+            <difficulty> _ </difficulty>
+            <number> _BLOCK_NUMBER </number>
+            <gasLimit> _ </gasLimit>
+            <gasUsed> _ </gasUsed>
+            <timestamp> TIME </timestamp>
+            <extraData> _ </extraData>
+            <mixHash> _ </mixHash>
+            <blockNonce> _ </blockNonce>
+            <ommerBlockHeaders> _ </ommerBlockHeaders>
+          </block>
+        </evm>
+        <network>
+          <chainID> VChainId </chainID>
+          <activeAccounts> SetItem(ACCT_ID)
+          SetItem(1)
+          SetItem(2)
+          SetItem(3)
+          SetItem(4)
+          SetItem(5)
+          SetItem(6)
+          SetItem(7)
+          SetItem(8)
+          SetItem(9) _ </activeAccounts>
+          <accounts>
+            <account>
+              <acctID> ACCT_ID </acctID>
+              <balance> ACCT_ID_balance </balance>
+              <code> End_bin_runtime </code>
+              <storage> ACCT_ID_STORAGE => ACCT_ID_STORAGE  </storage>
+              <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
+              <nonce> _Nonce_End => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> 1 </acctID>
+              <balance> ECREC_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 2 </acctID>
+              <balance> SHA256_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 3 </acctID>
+              <balance> RIP160_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 4 </acctID>
+              <balance> ID_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 5 </acctID>
+              <balance> MODEXP_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 6 </acctID>
+              <balance> ECADD_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 7 </acctID>
+              <balance> ECMUL_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 8 </acctID>
+              <balance> ECPAIRING_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 9 </acctID>
+              <balance> BLAKE2_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+           ...
+          </accounts>
+          <txOrder> _ </txOrder>
+          <txPending> _ </txPending>
+          <messages> _ </messages>
+        </network>
+      </ethereum>
+      requires #rangeAddress(ACCT_ID)
+       andBool ACCT_ID =/=Int 0
+       andBool #notPrecompileAddress(ACCT_ID)
+       andBool #rangeAddress(CALLER_ID)
+       andBool #rangeAddress(ORIGIN_ID)
+       andBool #rangeUInt(256, TIME)
+       andBool #rangeUInt(256, ACCT_ID_balance)
+       andBool #rangeUInt(256, ECREC_BAL)
+       andBool #rangeUInt(256, SHA256_BAL)
+       andBool #rangeUInt(256, RIP160_BAL)
+       andBool #rangeUInt(256, ID_BAL)
+       andBool #rangeUInt(256, MODEXP_BAL)
+       andBool #rangeUInt(256, ECADD_BAL)
+       andBool #rangeUInt(256, ECMUL_BAL)
+       andBool #rangeUInt(256, ECPAIRING_BAL)
+       andBool #rangeUInt(256, BLAKE2_BAL)
+       andBool VCallDepth <=Int 1024
+       andBool #rangeUInt(256, VCallValue)
+       andBool #rangeUInt(256, VChainId)
+
+       andBool (#rangeUInt(256, ABI_x)
+       andBool (#rangeUInt(256, ABI_y)
+       andBool ((#sizeWordStack(WS) <=Int 100)
+       andBool (#rangeUInt(256, VMemoryUsed)
+       andBool ((#rangeUInt(256, ABI_x +Int ABI_y)))))))
+
+
+    [trusted, matching(infGas)]
+
+
+    // Vat_move-diff
+    claim [Vat.move-diff.pass]:
+      <k> #execute ~> CONTINUATION => #halt ~> CONTINUATION </k>
+      <exit-code> 1 </exit-code>
+      <mode> NORMAL </mode>
+      <schedule> ISTANBUL </schedule>
+      <ethereum>
+        <evm>
+          <output> .ByteArray </output>
+          <statusCode> _ => EVMC_SUCCESS </statusCode>
+          <endPC> _ => ?_ </endPC>
+          <callStack> _VCallStack </callStack>
+          <interimStates> _ </interimStates>
+          <touchedAccounts> _ => ?_ </touchedAccounts>
+          <callState>
+            <program> Vat_bin_runtime </program>
+            <jumpDests> #computeValidJumpDests(Vat_bin_runtime) </jumpDests>
+            <id> ACCT_ID </id>
+            <caller> CALLER_ID </caller>
+            <callData> #abiCallData("move", #address(ABI_src), #address(ABI_dst), #uint256(ABI_rad)) ++ CD => ?_ </callData>
+            <callValue> VCallValue </callValue>
+            <wordStack> .WordStack => ?_ </wordStack>
+            <localMem> .Memory => ?_ </localMem>
+            <pc> 0 => ?_ </pc>
+            <gas> #gas(VGas) => #gas ( ( VGas +Int ( Csstore( ISTANBUL , ( Dai_src -Int ABI_rad ) , Dai_src , Junk_1 ) +Int ( Csstore( ISTANBUL , ( Dai_dst +Int ABI_rad ) , Dai_dst , Junk_2 ) +Int 7943 ) ) ) ) </gas>
+            <memoryUsed> 0 => ?_ </memoryUsed>
+            <callGas> _ => ?_ </callGas>
+            <static> false </static>
+            <callDepth> VCallDepth </callDepth>
+          </callState>
+          <substate>
+            <selfDestruct> _VSelfDestruct </selfDestruct>
+            <log> _ => ?_ </log>
+            <refund> _Vrefund => ?_ </refund>
+          </substate>
+          <gasPrice> _ </gasPrice>
+          <origin> ORIGIN_ID </origin>
+          <blockhashes> _ </blockhashes>
+          <block>
+            <previousHash> _ </previousHash>
+            <ommersHash> _ </ommersHash>
+            <coinbase> _ </coinbase>
+            <stateRoot> _ </stateRoot>
+            <transactionsRoot> _ </transactionsRoot>
+            <receiptsRoot> _ </receiptsRoot>
+            <logsBloom> _ </logsBloom>
+            <difficulty> _ </difficulty>
+            <number> _BLOCK_NUMBER </number>
+            <gasLimit> _ </gasLimit>
+            <gasUsed> _ </gasUsed>
+            <timestamp> TIME </timestamp>
+            <extraData> _ </extraData>
+            <mixHash> _ </mixHash>
+            <blockNonce> _ </blockNonce>
+            <ommerBlockHeaders> _ </ommerBlockHeaders>
+          </block>
+        </evm>
+        <network>
+          <chainID> VChainId </chainID>
+          <activeAccounts> SetItem(ACCT_ID)
+          SetItem(1)
+          SetItem(2)
+          SetItem(3)
+          SetItem(4)
+          SetItem(5)
+          SetItem(6)
+          SetItem(7)
+          SetItem(8)
+          SetItem(9) _ </activeAccounts>
+          <accounts>
+            <account>
+              <acctID> ACCT_ID </acctID>
+              <balance> ACCT_ID_balance </balance>
+              <code> Vat_bin_runtime </code>
+              <storage> ACCT_ID_STORAGE => ACCT_ID_STORAGE [ #Vat.dai[ABI_src] <- Dai_src -Int ABI_rad ] [ #Vat.dai[ABI_dst] <- Dai_dst +Int ABI_rad ] </storage>
+              <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
+              <nonce> _Nonce_Vat => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> 1 </acctID>
+              <balance> ECREC_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 2 </acctID>
+              <balance> SHA256_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 3 </acctID>
+              <balance> RIP160_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 4 </acctID>
+              <balance> ID_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 5 </acctID>
+              <balance> MODEXP_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 6 </acctID>
+              <balance> ECADD_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 7 </acctID>
+              <balance> ECMUL_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 8 </acctID>
+              <balance> ECPAIRING_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 9 </acctID>
+              <balance> BLAKE2_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+           ...
+          </accounts>
+          <txOrder> _ </txOrder>
+          <txPending> _ </txPending>
+          <messages> _ </messages>
+        </network>
+      </ethereum>
+      requires #rangeAddress(ACCT_ID)
+       andBool ACCT_ID =/=Int 0
+       andBool #notPrecompileAddress(ACCT_ID)
+       andBool #rangeAddress(CALLER_ID)
+       andBool #rangeAddress(ORIGIN_ID)
+       andBool #rangeUInt(256, TIME)
+       andBool #rangeUInt(256, ACCT_ID_balance)
+       andBool #rangeUInt(256, ECREC_BAL)
+       andBool #rangeUInt(256, SHA256_BAL)
+       andBool #rangeUInt(256, RIP160_BAL)
+       andBool #rangeUInt(256, ID_BAL)
+       andBool #rangeUInt(256, MODEXP_BAL)
+       andBool #rangeUInt(256, ECADD_BAL)
+       andBool #rangeUInt(256, ECMUL_BAL)
+       andBool #rangeUInt(256, ECPAIRING_BAL)
+       andBool #rangeUInt(256, BLAKE2_BAL)
+       andBool VCallDepth <=Int 1024
+       andBool #rangeUInt(256, VCallValue)
+       andBool #rangeUInt(256, VChainId)
+
+       andBool (#rangeAddress(ABI_src)
+       andBool (#rangeAddress(ABI_dst)
+       andBool (#rangeUInt(256, ABI_rad)
+       andBool (#rangeUInt(256, Dai_dst)
+       andBool (#rangeUInt(256, Dai_src)
+       andBool (#rangeUInt(256, May)
+       andBool ((#sizeByteArray(CD) <=Int 1250000000)
+       andBool ((ABI_src =/=Int ABI_dst)
+       andBool (#rangeUInt(256, Junk_0)
+       andBool (#rangeUInt(256, Junk_1)
+       andBool (#rangeUInt(256, Junk_2)
+       andBool ((((May ==Int 1 orBool ABI_src ==Int CALLER_ID)))
+       andBool (((VCallValue ==Int 0))
+       andBool ((#rangeUInt(256, Dai_src -Int ABI_rad))
+       andBool ((#rangeUInt(256, Dai_dst +Int ABI_rad)))))))))))))))))
+
+       andBool #lookup(ACCT_ID_STORAGE, #Vat.can[ABI_src][CALLER_ID]) ==Int May
+       andBool #lookup(ACCT_ID_STORAGE, #Vat.dai[ABI_src]) ==Int Dai_src
+       andBool #lookup(ACCT_ID_STORAGE, #Vat.dai[ABI_dst]) ==Int Dai_dst
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Vat.can[ABI_src][CALLER_ID]) ==Int Junk_0
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Vat.dai[ABI_src]) ==Int Junk_1
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Vat.dai[ABI_dst]) ==Int Junk_2
+       andBool #Vat.can[ABI_src][CALLER_ID] =/=Int #Vat.dai[ABI_src]
+       andBool #Vat.can[ABI_src][CALLER_ID] =/=Int #Vat.dai[ABI_dst]
+       andBool #Vat.dai[ABI_src] =/=Int #Vat.dai[ABI_dst]
+    [trusted, matching(infGas)]
+
+
+endmodule

--- a/tests/specs/mcd/end-subuu-pass-spec.k
+++ b/tests/specs/mcd/end-subuu-pass-spec.k
@@ -27,7 +27,7 @@ module END-SUBUU-PASS-SPEC
             <wordStack> ABI_y : ABI_x : JMPTO : WS  =>  JMPTO : ABI_x -Int ABI_y : WS </wordStack>
             <localMem> _ </localMem>
             <pc> 14664 => 14689 </pc>
-            <gas> #gas(VGas) => #gas(VGas +Int 54) </gas>
+            <gas> #gas(VGas) => #gas(VGas +Int -54) </gas>
             <memoryUsed> VMemoryUsed </memoryUsed>
             <callGas> _ => ?_ </callGas>
             <static> _ </static>

--- a/tests/specs/mcd/end-subuu-pass-spec.k
+++ b/tests/specs/mcd/end-subuu-pass-spec.k
@@ -4,7 +4,7 @@ module END-SUBUU-PASS-SPEC
   imports VERIFICATION
 
     // End_subuu
-    rule [End.subuu.pass]:
+    claim [End.subuu.pass]:
       <k> #execute ~> CONTINUATION => #execute ~> CONTINUATION </k>
       <exit-code> 1 </exit-code>
       <mode> NORMAL </mode>

--- a/tests/specs/mcd/end-subuu-pass-spec.k
+++ b/tests/specs/mcd/end-subuu-pass-spec.k
@@ -27,7 +27,7 @@ module END-SUBUU-PASS-SPEC
             <wordStack> ABI_y : ABI_x : JMPTO : WS  =>  JMPTO : ABI_x -Int ABI_y : WS </wordStack>
             <localMem> _ </localMem>
             <pc> 14664 => 14689 </pc>
-            <gas> VGas => VGas -Int (54) </gas>
+            <gas> #gas(VGas) => #gas(VGas +Int 54) </gas>
             <memoryUsed> VMemoryUsed </memoryUsed>
             <callGas> _ => ?_ </callGas>
             <static> _ </static>

--- a/tests/specs/mcd/flipper-addu48u48-fail-rough-spec.k
+++ b/tests/specs/mcd/flipper-addu48u48-fail-rough-spec.k
@@ -4,7 +4,7 @@ module FLIPPER-ADDU48U48-FAIL-ROUGH-SPEC
     imports VERIFICATION
 
     // Flipper_addu48u48
-    rule [Flipper.addu48u48.fail.rough]:
+    claim [Flipper.addu48u48.fail.rough]:
       <k> #execute ~> CONTINUATION => #halt ~> CONTINUATION </k>
       <exit-code> 1 </exit-code>
       <mode> NORMAL </mode>

--- a/tests/specs/mcd/flipper-addu48u48-fail-rough-spec.k
+++ b/tests/specs/mcd/flipper-addu48u48-fail-rough-spec.k
@@ -27,7 +27,7 @@ module FLIPPER-ADDU48U48-FAIL-ROUGH-SPEC
             <wordStack> ABI_y : ABI_x : JMPTO : WS  => ?_ </wordStack>
             <localMem> _ </localMem>
             <pc> 11354 => ?_ </pc>
-            <gas> VGas => ?_ </gas>
+            <gas> #gas(VGas) => ?_ </gas>
             <memoryUsed> VMemoryUsed </memoryUsed>
             <callGas> _ => ?_ </callGas>
             <static> _ </static>

--- a/tests/specs/mcd/flipper-bids-pass-rough-spec.k
+++ b/tests/specs/mcd/flipper-bids-pass-rough-spec.k
@@ -4,7 +4,7 @@ module FLIPPER-BIDS-PASS-ROUGH-SPEC
     imports VERIFICATION
 
     // Flipper_bids
-    rule [Flipper.bids.pass.rough]:
+    claim [Flipper.bids.pass.rough]:
       <k> #execute ~> CONTINUATION => #halt ~> CONTINUATION </k>
       <exit-code> 1 </exit-code>
       <mode> NORMAL </mode>

--- a/tests/specs/mcd/flipper-bids-pass-rough-spec.k
+++ b/tests/specs/mcd/flipper-bids-pass-rough-spec.k
@@ -27,7 +27,7 @@ module FLIPPER-BIDS-PASS-ROUGH-SPEC
             <wordStack> .WordStack => ?_ </wordStack>
             <localMem> .Memory => ?_ </localMem>
             <pc> 0 => ?_ </pc>
-            <gas> VGas => ?_ </gas>
+            <gas> #gas(VGas) => ?_ </gas>
             <memoryUsed> 0 => ?_ </memoryUsed>
             <callGas> _ => ?_ </callGas>
             <static> _ </static>

--- a/tests/specs/mcd/flipper-tau-pass-spec.k
+++ b/tests/specs/mcd/flipper-tau-pass-spec.k
@@ -27,7 +27,7 @@ module FLIPPER-TAU-PASS-SPEC
             <wordStack> .WordStack => ?_ </wordStack>
             <localMem> .Memory => ?_ </localMem>
             <pc> 0 => ?_ </pc>
-            <gas> #gas(VGas) => #gas(VGas +Int 1169) </gas>
+            <gas> #gas(VGas) => #gas(VGas +Int -1169) </gas>
             <memoryUsed> 0 => ?_ </memoryUsed>
             <callGas> _ => ?_ </callGas>
             <static> _ </static>

--- a/tests/specs/mcd/flipper-tau-pass-spec.k
+++ b/tests/specs/mcd/flipper-tau-pass-spec.k
@@ -27,7 +27,7 @@ module FLIPPER-TAU-PASS-SPEC
             <wordStack> .WordStack => ?_ </wordStack>
             <localMem> .Memory => ?_ </localMem>
             <pc> 0 => ?_ </pc>
-            <gas> VGas => VGas -Int (1169) </gas>
+            <gas> #gas(VGas) => #gas(VGas +Int 1169) </gas>
             <memoryUsed> 0 => ?_ </memoryUsed>
             <callGas> _ => ?_ </callGas>
             <static> _ </static>

--- a/tests/specs/mcd/flipper-tau-pass-spec.k
+++ b/tests/specs/mcd/flipper-tau-pass-spec.k
@@ -4,7 +4,7 @@ module FLIPPER-TAU-PASS-SPEC
     imports VERIFICATION
 
     // Flipper_tau
-    rule [Flipper.tau.pass]:
+    claim [Flipper.tau.pass]:
       <k> #execute ~> CONTINUATION => #halt ~> CONTINUATION </k>
       <exit-code> 1 </exit-code>
       <mode> NORMAL </mode>

--- a/tests/specs/mcd/flipper-ttl-pass-spec.k
+++ b/tests/specs/mcd/flipper-ttl-pass-spec.k
@@ -27,7 +27,7 @@ module FLIPPER-TTL-PASS-SPEC
             <wordStack> .WordStack => ?_ </wordStack>
             <localMem> .Memory => ?_ </localMem>
             <pc> 0 => ?_ </pc>
-            <gas> #gas(VGas) => #gas(VGas +Int 1120) </gas>
+            <gas> #gas(VGas) => #gas(VGas +Int -1120) </gas>
             <memoryUsed> 0 => ?_ </memoryUsed>
             <callGas> _ => ?_ </callGas>
             <static> _ </static>

--- a/tests/specs/mcd/flipper-ttl-pass-spec.k
+++ b/tests/specs/mcd/flipper-ttl-pass-spec.k
@@ -27,7 +27,7 @@ module FLIPPER-TTL-PASS-SPEC
             <wordStack> .WordStack => ?_ </wordStack>
             <localMem> .Memory => ?_ </localMem>
             <pc> 0 => ?_ </pc>
-            <gas> VGas => VGas -Int (1120) </gas>
+            <gas> #gas(VGas) => #gas(VGas +Int 1120) </gas>
             <memoryUsed> 0 => ?_ </memoryUsed>
             <callGas> _ => ?_ </callGas>
             <static> _ </static>

--- a/tests/specs/mcd/flipper-ttl-pass-spec.k
+++ b/tests/specs/mcd/flipper-ttl-pass-spec.k
@@ -4,7 +4,7 @@ module FLIPPER-TTL-PASS-SPEC
     imports VERIFICATION
 
     // Flipper_ttl
-    rule [Flipper.ttl.pass]:
+    claim [Flipper.ttl.pass]:
       <k> #execute ~> CONTINUATION => #halt ~> CONTINUATION </k>
       <exit-code> 1 </exit-code>
       <mode> NORMAL </mode>

--- a/tests/specs/mcd/flopper-cage-pass-spec.k
+++ b/tests/specs/mcd/flopper-cage-pass-spec.k
@@ -27,7 +27,7 @@ module FLOPPER-CAGE-PASS-SPEC
             <wordStack> .WordStack => ?_ </wordStack>
             <localMem> .Memory => ?_ </localMem>
             <pc> 0 => ?_ </pc>
-            <gas> #gas(VGas) => #gas ( ( VGas -Int ( Csstore( ISTANBUL , 0 , Live , Junk_1 ) -Int ( Csstore( ISTANBUL , CALLER_ID , Vow , Junk_2 ) +Int -6351 ) ) ) ) </gas>
+            <gas> #gas(VGas) => #gas ( ( ( VGas -Int Csstore( ISTANBUL , 0 , Live , Junk_1 ) ) -Int Csstore( ISTANBUL , CALLER_ID , Vow , Junk_2 ) ) +Int -6351 ) </gas>
             <memoryUsed> 0 => ?_ </memoryUsed>
             <callGas> _ => ?_ </callGas>
             <static> false </static>

--- a/tests/specs/mcd/flopper-cage-pass-spec.k
+++ b/tests/specs/mcd/flopper-cage-pass-spec.k
@@ -27,7 +27,7 @@ module FLOPPER-CAGE-PASS-SPEC
             <wordStack> .WordStack => ?_ </wordStack>
             <localMem> .Memory => ?_ </localMem>
             <pc> 0 => ?_ </pc>
-            <gas> #gas(VGas) => #gas ( ( VGas +Int ( Csstore( ISTANBUL , 0 , Live , Junk_1 ) +Int ( Csstore( ISTANBUL , CALLER_ID , Vow , Junk_2 ) +Int 6351 ) ) ) ) </gas>
+            <gas> #gas(VGas) => #gas ( ( VGas -Int ( Csstore( ISTANBUL , 0 , Live , Junk_1 ) -Int ( Csstore( ISTANBUL , CALLER_ID , Vow , Junk_2 ) +Int -6351 ) ) ) ) </gas>
             <memoryUsed> 0 => ?_ </memoryUsed>
             <callGas> _ => ?_ </callGas>
             <static> false </static>

--- a/tests/specs/mcd/flopper-cage-pass-spec.k
+++ b/tests/specs/mcd/flopper-cage-pass-spec.k
@@ -4,7 +4,7 @@ module FLOPPER-CAGE-PASS-SPEC
     imports VERIFICATION
 
     // Flopper_cage
-    rule [Flopper.cage.pass]:
+    claim [Flopper.cage.pass]:
       <k> #execute ~> CONTINUATION => #halt ~> CONTINUATION </k>
       <exit-code> 1 </exit-code>
       <mode> NORMAL </mode>

--- a/tests/specs/mcd/flopper-file-pass-rough-spec.k
+++ b/tests/specs/mcd/flopper-file-pass-rough-spec.k
@@ -4,7 +4,7 @@ module FLOPPER-FILE-PASS-ROUGH-SPEC
     imports VERIFICATION
 
     // Flopper_file
-    rule [Flopper.file.pass.rough]:
+    claim [Flopper.file.pass.rough]:
       <k> #execute ~> CONTINUATION => #halt ~> CONTINUATION </k>
       <exit-code> 1 </exit-code>
       <mode> NORMAL </mode>

--- a/tests/specs/mcd/flopper-tick-pass-rough-spec.k
+++ b/tests/specs/mcd/flopper-tick-pass-rough-spec.k
@@ -4,7 +4,7 @@ module FLOPPER-TICK-PASS-ROUGH-SPEC
     imports VERIFICATION
 
     // Flopper_tick
-    rule [Flopper.tick.pass.rough]:
+    claim [Flopper.tick.pass.rough]:
       <k> #execute ~> CONTINUATION => #halt ~> CONTINUATION </k>
       <exit-code> 1 </exit-code>
       <mode> NORMAL </mode>
@@ -217,7 +217,7 @@ module FLOPPER-TICK-PASS-ROUGH-SPEC
      andBool #Flopper.bids[ABI_id].lot =/=Int #Flopper.bids[ABI_id].guy_tic_end
 
     // Flopper_addu48u48
-    rule [Flopper.addu48u48.pass]:
+    claim [Flopper.addu48u48.pass]:
       <k> #execute ~> CONTINUATION => #execute ~> CONTINUATION </k>
       <exit-code> 1 </exit-code>
       <mode> NORMAL </mode>

--- a/tests/specs/mcd/flopper-tick-pass-rough-spec.k
+++ b/tests/specs/mcd/flopper-tick-pass-rough-spec.k
@@ -398,7 +398,7 @@ module FLOPPER-TICK-PASS-ROUGH-SPEC
      andBool ((#sizeWordStack(WS) <=Int 100)
      andBool (#rangeUInt(256, VMemoryUsed)
      andBool ((#rangeUInt(48, ABI_x +Int ABI_y)))))))
-    [trusted]
+    [trusted, matching(infGas)]
 
 
 endmodule

--- a/tests/specs/mcd/pot-join-pass-rough-spec.k
+++ b/tests/specs/mcd/pot-join-pass-rough-spec.k
@@ -1,0 +1,837 @@
+requires "verification.k"
+
+module POT-JOIN-PASS-ROUGH-SPEC
+    imports VERIFICATION
+
+    // Pot_join
+    claim [Pot.join.pass.rough]:
+      <k> #execute ~> CONTINUATION => #halt ~> CONTINUATION </k>
+      <exit-code> 1 </exit-code>
+      <mode> NORMAL </mode>
+      <schedule> ISTANBUL </schedule>
+      <ethereum>
+        <evm>
+          <output> .ByteArray </output>
+          <statusCode> _ => EVMC_SUCCESS </statusCode>
+          <endPC> _ => ?_ </endPC>
+          <callStack> _VCallStack </callStack>
+          <interimStates> _ </interimStates>
+          <touchedAccounts> _ => ?_ </touchedAccounts>
+          <callState>
+            <program> Pot_bin_runtime </program>
+            <jumpDests> #computeValidJumpDests(Pot_bin_runtime) </jumpDests>
+            <id> ACCT_ID </id>
+            <caller> CALLER_ID </caller>
+            <callData> #abiCallData("join", #uint256(ABI_wad)) ++ CD => ?_ </callData>
+            <callValue> VCallValue </callValue>
+            <wordStack> .WordStack => ?_ </wordStack>
+            <localMem> .Memory => ?_ </localMem>
+            <pc> 0 => ?_ </pc>
+            <gas> #gas(VGas) => ?_ </gas>
+            <memoryUsed> 0 => ?_ </memoryUsed>
+            <callGas> _ => ?_ </callGas>
+            <static> false </static>
+            <callDepth> VCallDepth </callDepth>
+          </callState>
+          <substate>
+            <selfDestruct> _VSelfDestruct </selfDestruct>
+            <log> _ => ?_ </log>
+            <refund> _Vrefund => ?_ </refund>
+          </substate>
+          <gasPrice> _ </gasPrice>
+          <origin> ORIGIN_ID </origin>
+          <blockhashes> _ </blockhashes>
+          <block>
+            <previousHash> _ </previousHash>
+            <ommersHash> _ </ommersHash>
+            <coinbase> _ </coinbase>
+            <stateRoot> _ </stateRoot>
+            <transactionsRoot> _ </transactionsRoot>
+            <receiptsRoot> _ </receiptsRoot>
+            <logsBloom> _ </logsBloom>
+            <difficulty> _ </difficulty>
+            <number> _BLOCK_NUMBER </number>
+            <gasLimit> _ </gasLimit>
+            <gasUsed> _ </gasUsed>
+            <timestamp> TIME </timestamp>
+            <extraData> _ </extraData>
+            <mixHash> _ </mixHash>
+            <blockNonce> _ </blockNonce>
+            <ommerBlockHeaders> _ </ommerBlockHeaders>
+          </block>
+        </evm>
+        <network>
+          <chainID> VChainId </chainID>
+          <activeAccounts> SetItem(ACCT_ID)
+          SetItem(Vat)
+          SetItem(1)
+          SetItem(2)
+          SetItem(3)
+          SetItem(4)
+          SetItem(5)
+          SetItem(6)
+          SetItem(7)
+          SetItem(8)
+          SetItem(9) _ </activeAccounts>
+          <accounts>
+            <account>
+              <acctID> ACCT_ID </acctID>
+              <balance> ACCT_ID_balance </balance>
+              <code> Pot_bin_runtime </code>
+              <storage> ACCT_ID_STORAGE => ACCT_ID_STORAGE [ #Pot.pie[CALLER_ID] <- Pie_u +Int ABI_wad ] [ #Pot.Pie <- Pie_tot +Int ABI_wad ] </storage>
+              <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
+              <nonce> _Nonce_Pot => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> Vat </acctID>
+              <balance> Vat_balance </balance>
+              <code> Vat_bin_runtime </code>
+              <storage> Vat_STORAGE => Vat_STORAGE [ #Vat.dai[CALLER_ID] <- Dai_u -Int Chi *Int ABI_wad ] [ #Vat.dai[ACCT_ID] <- Dai_p +Int Chi *Int ABI_wad ] </storage>
+              <origStorage> Vat_ORIG_STORAGE </origStorage>
+              <nonce> _Nonce_Vat => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> 1 </acctID>
+              <balance> ECREC_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 2 </acctID>
+              <balance> SHA256_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 3 </acctID>
+              <balance> RIP160_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 4 </acctID>
+              <balance> ID_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 5 </acctID>
+              <balance> MODEXP_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 6 </acctID>
+              <balance> ECADD_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 7 </acctID>
+              <balance> ECMUL_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 8 </acctID>
+              <balance> ECPAIRING_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 9 </acctID>
+              <balance> BLAKE2_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+           ...
+          </accounts>
+          <txOrder> _ </txOrder>
+          <txPending> _ </txPending>
+          <messages> _ </messages>
+        </network>
+      </ethereum>
+      requires #rangeAddress(ACCT_ID)
+       andBool ACCT_ID =/=Int 0
+       andBool #notPrecompileAddress(ACCT_ID)
+       andBool #rangeAddress(CALLER_ID)
+       andBool #rangeAddress(ORIGIN_ID)
+       andBool #rangeUInt(256, TIME)
+       andBool #rangeUInt(256, ACCT_ID_balance)
+       andBool #rangeUInt(256, ECREC_BAL)
+       andBool #rangeUInt(256, SHA256_BAL)
+       andBool #rangeUInt(256, RIP160_BAL)
+       andBool #rangeUInt(256, ID_BAL)
+       andBool #rangeUInt(256, MODEXP_BAL)
+       andBool #rangeUInt(256, ECADD_BAL)
+       andBool #rangeUInt(256, ECMUL_BAL)
+       andBool #rangeUInt(256, ECPAIRING_BAL)
+       andBool #rangeUInt(256, BLAKE2_BAL)
+       andBool VCallDepth <=Int 1024
+       andBool #rangeUInt(256, VCallValue)
+       andBool #rangeUInt(256, VChainId)
+
+       andBool (#rangeUInt(256, ABI_wad)
+       andBool (#rangeUInt(256, Pie_u)
+       andBool (#rangeUInt(256, Pie_tot)
+       andBool (#rangeUInt(256, Chi)
+       andBool (#rangeUInt(256, Rho)
+       andBool (#rangeAddress(Vat)
+       andBool (#rangeUInt(256, Can)
+       andBool (#rangeUInt(256, Dai_u)
+       andBool (#rangeUInt(256, Dai_p)
+       andBool (#rangeUInt(256, Vat_balance)
+       andBool ((#sizeByteArray(CD) <=Int 1250000000)
+       andBool ((#notPrecompileAddress(Vat))
+       andBool ((ACCT_ID =/=Int Vat)
+       andBool ((ACCT_ID =/=Int CALLER_ID)
+       andBool ((Vat =/=Int 0)
+       andBool (#rangeUInt(256, Junk_0)
+       andBool (#rangeUInt(256, Junk_1)
+       andBool (#rangeUInt(256, Junk_2)
+       andBool (#rangeUInt(256, Junk_3)
+       andBool (#rangeUInt(256, Junk_4)
+       andBool (#rangeUInt(256, Junk_5)
+       andBool (#rangeUInt(256, Junk_6)
+       andBool (#rangeUInt(256, Junk_7)
+       andBool (((VCallValue ==Int 0))
+       andBool (((VCallDepth <Int 1024))
+       andBool (((Can ==Int 1))
+       andBool (((Rho ==Int TIME))
+       andBool ((#rangeUInt(256, Pie_u +Int ABI_wad))
+       andBool ((#rangeUInt(256, Pie_tot +Int ABI_wad))
+       andBool ((#rangeUInt(256, Chi *Int ABI_wad))
+       andBool ((#rangeUInt(256, Dai_u -Int Chi *Int ABI_wad))
+       andBool ((#rangeUInt(256, Dai_p +Int Chi *Int ABI_wad))))))))))))))))))))))))))))))))))
+
+       andBool #lookup(ACCT_ID_STORAGE, #Pot.pie[CALLER_ID]) ==Int Pie_u
+       andBool #lookup(ACCT_ID_STORAGE, #Pot.Pie) ==Int Pie_tot
+       andBool #lookup(ACCT_ID_STORAGE, #Pot.chi) ==Int Chi
+       andBool #lookup(ACCT_ID_STORAGE, #Pot.rho) ==Int Rho
+       andBool #lookup(ACCT_ID_STORAGE, #Pot.vat) ==Int Vat
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Pot.pie[CALLER_ID]) ==Int Junk_0
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Pot.Pie) ==Int Junk_1
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Pot.chi) ==Int Junk_2
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Pot.rho) ==Int Junk_3
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Pot.vat) ==Int Junk_4
+       andBool #Pot.pie[CALLER_ID] =/=Int #Pot.Pie
+       andBool #Pot.pie[CALLER_ID] =/=Int #Pot.chi
+       andBool #Pot.pie[CALLER_ID] =/=Int #Pot.rho
+       andBool #Pot.pie[CALLER_ID] =/=Int #Pot.vat
+       andBool #Pot.Pie =/=Int #Pot.chi
+       andBool #Pot.Pie =/=Int #Pot.rho
+       andBool #Pot.Pie =/=Int #Pot.vat
+       andBool #Pot.chi =/=Int #Pot.rho
+       andBool #Pot.chi =/=Int #Pot.vat
+       andBool #Pot.rho =/=Int #Pot.vat
+       andBool #lookup(Vat_STORAGE, #Vat.can[CALLER_ID][ACCT_ID]) ==Int Can
+       andBool #lookup(Vat_STORAGE, #Vat.dai[CALLER_ID]) ==Int Dai_u
+       andBool #lookup(Vat_STORAGE, #Vat.dai[ACCT_ID]) ==Int Dai_p
+       andBool #lookup(Vat_ORIG_STORAGE, #Vat.can[CALLER_ID][ACCT_ID]) ==Int Junk_5
+       andBool #lookup(Vat_ORIG_STORAGE, #Vat.dai[CALLER_ID]) ==Int Junk_6
+       andBool #lookup(Vat_ORIG_STORAGE, #Vat.dai[ACCT_ID]) ==Int Junk_7
+       andBool #Vat.can[CALLER_ID][ACCT_ID] =/=Int #Vat.dai[CALLER_ID]
+       andBool #Vat.can[CALLER_ID][ACCT_ID] =/=Int #Vat.dai[ACCT_ID]
+       andBool #Vat.dai[CALLER_ID] =/=Int #Vat.dai[ACCT_ID]
+
+    // Pot_adduu
+    claim [Pot.adduu.pass]:
+      <k> #execute ~> CONTINUATION => #execute ~> CONTINUATION </k>
+      <exit-code> 1 </exit-code>
+      <mode> NORMAL </mode>
+      <schedule> ISTANBUL </schedule>
+      <ethereum>
+        <evm>
+          <output> VOutput => VOutput </output>
+          <statusCode> _ => ?_ </statusCode>
+          <endPC> _ => ?_ </endPC>
+          <callStack> _VCallStack </callStack>
+          <interimStates> _ </interimStates>
+          <touchedAccounts> _ => ?_ </touchedAccounts>
+          <callState>
+            <program> Pot_bin_runtime </program>
+            <jumpDests> #computeValidJumpDests(Pot_bin_runtime) </jumpDests>
+            <id> ACCT_ID </id>
+            <caller> CALLER_ID </caller>
+            <callData> _ => ?_ </callData>
+            <callValue> VCallValue </callValue>
+            <wordStack> ABI_y : ABI_x : JMPTO : WS  =>  JMPTO : ABI_x +Int ABI_y : WS </wordStack>
+            <localMem> _ </localMem>
+            <pc> 4851 => 4876 </pc>
+            <gas> #gas(VGas) => #gas ( ( VGas +Int -54 ) ) </gas>
+            <memoryUsed> VMemoryUsed </memoryUsed>
+            <callGas> _ => ?_ </callGas>
+            <static> _ </static>
+            <callDepth> VCallDepth </callDepth>
+          </callState>
+          <substate>
+            <selfDestruct> _VSelfDestruct </selfDestruct>
+            <log> _ => ?_ </log>
+            <refund> _Vrefund => ?_ </refund>
+          </substate>
+          <gasPrice> _ </gasPrice>
+          <origin> ORIGIN_ID </origin>
+          <blockhashes> _ </blockhashes>
+          <block>
+            <previousHash> _ </previousHash>
+            <ommersHash> _ </ommersHash>
+            <coinbase> _ </coinbase>
+            <stateRoot> _ </stateRoot>
+            <transactionsRoot> _ </transactionsRoot>
+            <receiptsRoot> _ </receiptsRoot>
+            <logsBloom> _ </logsBloom>
+            <difficulty> _ </difficulty>
+            <number> _BLOCK_NUMBER </number>
+            <gasLimit> _ </gasLimit>
+            <gasUsed> _ </gasUsed>
+            <timestamp> TIME </timestamp>
+            <extraData> _ </extraData>
+            <mixHash> _ </mixHash>
+            <blockNonce> _ </blockNonce>
+            <ommerBlockHeaders> _ </ommerBlockHeaders>
+          </block>
+        </evm>
+        <network>
+          <chainID> VChainId </chainID>
+          <activeAccounts> SetItem(ACCT_ID)
+          SetItem(1)
+          SetItem(2)
+          SetItem(3)
+          SetItem(4)
+          SetItem(5)
+          SetItem(6)
+          SetItem(7)
+          SetItem(8)
+          SetItem(9) _ </activeAccounts>
+          <accounts>
+            <account>
+              <acctID> ACCT_ID </acctID>
+              <balance> ACCT_ID_balance </balance>
+              <code> Pot_bin_runtime </code>
+              <storage> ACCT_ID_STORAGE => ACCT_ID_STORAGE  </storage>
+              <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
+              <nonce> _Nonce_Pot => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> 1 </acctID>
+              <balance> ECREC_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 2 </acctID>
+              <balance> SHA256_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 3 </acctID>
+              <balance> RIP160_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 4 </acctID>
+              <balance> ID_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 5 </acctID>
+              <balance> MODEXP_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 6 </acctID>
+              <balance> ECADD_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 7 </acctID>
+              <balance> ECMUL_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 8 </acctID>
+              <balance> ECPAIRING_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 9 </acctID>
+              <balance> BLAKE2_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+           ...
+          </accounts>
+          <txOrder> _ </txOrder>
+          <txPending> _ </txPending>
+          <messages> _ </messages>
+        </network>
+      </ethereum>
+      requires #rangeAddress(ACCT_ID)
+       andBool ACCT_ID =/=Int 0
+       andBool #notPrecompileAddress(ACCT_ID)
+       andBool #rangeAddress(CALLER_ID)
+       andBool #rangeAddress(ORIGIN_ID)
+       andBool #rangeUInt(256, TIME)
+       andBool #rangeUInt(256, ACCT_ID_balance)
+       andBool #rangeUInt(256, ECREC_BAL)
+       andBool #rangeUInt(256, SHA256_BAL)
+       andBool #rangeUInt(256, RIP160_BAL)
+       andBool #rangeUInt(256, ID_BAL)
+       andBool #rangeUInt(256, MODEXP_BAL)
+       andBool #rangeUInt(256, ECADD_BAL)
+       andBool #rangeUInt(256, ECMUL_BAL)
+       andBool #rangeUInt(256, ECPAIRING_BAL)
+       andBool #rangeUInt(256, BLAKE2_BAL)
+       andBool VCallDepth <=Int 1024
+       andBool #rangeUInt(256, VCallValue)
+       andBool #rangeUInt(256, VChainId)
+
+       andBool (#rangeUInt(256, ABI_x)
+       andBool (#rangeUInt(256, ABI_y)
+       andBool ((#sizeWordStack(WS) <=Int 100)
+       andBool (#rangeUInt(256, VMemoryUsed)
+       andBool ((#rangeUInt(256, ABI_x +Int ABI_y)))))))
+
+
+    [trusted, matching(infGas)]
+
+
+    // Pot_muluu
+    claim [Pot.muluu.pass]:
+      <k> #execute ~> CONTINUATION => #execute ~> CONTINUATION </k>
+      <exit-code> 1 </exit-code>
+      <mode> NORMAL </mode>
+      <schedule> ISTANBUL </schedule>
+      <ethereum>
+        <evm>
+          <output> VOutput => VOutput </output>
+          <statusCode> _ => ?_ </statusCode>
+          <endPC> _ => ?_ </endPC>
+          <callStack> _VCallStack </callStack>
+          <interimStates> _ </interimStates>
+          <touchedAccounts> _ => ?_ </touchedAccounts>
+          <callState>
+            <program> Pot_bin_runtime </program>
+            <jumpDests> #computeValidJumpDests(Pot_bin_runtime) </jumpDests>
+            <id> ACCT_ID </id>
+            <caller> CALLER_ID </caller>
+            <callData> _ => ?_ </callData>
+            <callValue> VCallValue </callValue>
+            <wordStack> ABI_y : ABI_x : JMPTO : WS  =>  JMPTO : ABI_x *Int ABI_y : WS </wordStack>
+            <localMem> _ </localMem>
+            <pc> 4877 => 4920 </pc>
+            <gas> #gas(VGas) => #if ABI_y ==Int 0
+              #then   #gas ( ( VGas +Int -54 ) )
+              #else   #gas ( ( VGas +Int -106 ) )
+            #fi </gas>
+            <memoryUsed> VMemoryUsed </memoryUsed>
+            <callGas> _ => ?_ </callGas>
+            <static> _ </static>
+            <callDepth> VCallDepth </callDepth>
+          </callState>
+          <substate>
+            <selfDestruct> _VSelfDestruct </selfDestruct>
+            <log> _ => ?_ </log>
+            <refund> _Vrefund => ?_ </refund>
+          </substate>
+          <gasPrice> _ </gasPrice>
+          <origin> ORIGIN_ID </origin>
+          <blockhashes> _ </blockhashes>
+          <block>
+            <previousHash> _ </previousHash>
+            <ommersHash> _ </ommersHash>
+            <coinbase> _ </coinbase>
+            <stateRoot> _ </stateRoot>
+            <transactionsRoot> _ </transactionsRoot>
+            <receiptsRoot> _ </receiptsRoot>
+            <logsBloom> _ </logsBloom>
+            <difficulty> _ </difficulty>
+            <number> _BLOCK_NUMBER </number>
+            <gasLimit> _ </gasLimit>
+            <gasUsed> _ </gasUsed>
+            <timestamp> TIME </timestamp>
+            <extraData> _ </extraData>
+            <mixHash> _ </mixHash>
+            <blockNonce> _ </blockNonce>
+            <ommerBlockHeaders> _ </ommerBlockHeaders>
+          </block>
+        </evm>
+        <network>
+          <chainID> VChainId </chainID>
+          <activeAccounts> SetItem(ACCT_ID)
+          SetItem(1)
+          SetItem(2)
+          SetItem(3)
+          SetItem(4)
+          SetItem(5)
+          SetItem(6)
+          SetItem(7)
+          SetItem(8)
+          SetItem(9) _ </activeAccounts>
+          <accounts>
+            <account>
+              <acctID> ACCT_ID </acctID>
+              <balance> ACCT_ID_balance </balance>
+              <code> Pot_bin_runtime </code>
+              <storage> ACCT_ID_STORAGE => ACCT_ID_STORAGE  </storage>
+              <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
+              <nonce> _Nonce_Pot => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> 1 </acctID>
+              <balance> ECREC_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 2 </acctID>
+              <balance> SHA256_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 3 </acctID>
+              <balance> RIP160_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 4 </acctID>
+              <balance> ID_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 5 </acctID>
+              <balance> MODEXP_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 6 </acctID>
+              <balance> ECADD_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 7 </acctID>
+              <balance> ECMUL_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 8 </acctID>
+              <balance> ECPAIRING_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 9 </acctID>
+              <balance> BLAKE2_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+           ...
+          </accounts>
+          <txOrder> _ </txOrder>
+          <txPending> _ </txPending>
+          <messages> _ </messages>
+        </network>
+      </ethereum>
+      requires #rangeAddress(ACCT_ID)
+       andBool ACCT_ID =/=Int 0
+       andBool #notPrecompileAddress(ACCT_ID)
+       andBool #rangeAddress(CALLER_ID)
+       andBool #rangeAddress(ORIGIN_ID)
+       andBool #rangeUInt(256, TIME)
+       andBool #rangeUInt(256, ACCT_ID_balance)
+       andBool #rangeUInt(256, ECREC_BAL)
+       andBool #rangeUInt(256, SHA256_BAL)
+       andBool #rangeUInt(256, RIP160_BAL)
+       andBool #rangeUInt(256, ID_BAL)
+       andBool #rangeUInt(256, MODEXP_BAL)
+       andBool #rangeUInt(256, ECADD_BAL)
+       andBool #rangeUInt(256, ECMUL_BAL)
+       andBool #rangeUInt(256, ECPAIRING_BAL)
+       andBool #rangeUInt(256, BLAKE2_BAL)
+       andBool VCallDepth <=Int 1024
+       andBool #rangeUInt(256, VCallValue)
+       andBool #rangeUInt(256, VChainId)
+
+       andBool (#rangeUInt(256, ABI_x)
+       andBool (#rangeUInt(256, ABI_y)
+       andBool ((#sizeWordStack(WS) <=Int 1000)
+       andBool (#rangeUInt(256, VMemoryUsed)
+       andBool ((#rangeUInt(256, ABI_x *Int ABI_y)))))))
+
+
+    [trusted, matching(infGas)]
+
+
+    // Vat_move-diff
+    claim [Vat.move-diff.pass]:
+      <k> #execute ~> CONTINUATION => #halt ~> CONTINUATION </k>
+      <exit-code> 1 </exit-code>
+      <mode> NORMAL </mode>
+      <schedule> ISTANBUL </schedule>
+      <ethereum>
+        <evm>
+          <output> .ByteArray </output>
+          <statusCode> _ => EVMC_SUCCESS </statusCode>
+          <endPC> _ => ?_ </endPC>
+          <callStack> _VCallStack </callStack>
+          <interimStates> _ </interimStates>
+          <touchedAccounts> _ => ?_ </touchedAccounts>
+          <callState>
+            <program> Vat_bin_runtime </program>
+            <jumpDests> #computeValidJumpDests(Vat_bin_runtime) </jumpDests>
+            <id> ACCT_ID </id>
+            <caller> CALLER_ID </caller>
+            <callData> #abiCallData("move", #address(ABI_src), #address(ABI_dst), #uint256(ABI_rad)) ++ CD => ?_ </callData>
+            <callValue> VCallValue </callValue>
+            <wordStack> .WordStack => ?_ </wordStack>
+            <localMem> .Memory => ?_ </localMem>
+            <pc> 0 => ?_ </pc>
+            <gas> #gas(VGas) => #gas ( ( ( ( VGas -Int Csstore( ISTANBUL , ( Dai_src -Int ABI_rad ) , Dai_src , Junk_1 ) ) -Int Csstore( ISTANBUL , ( Dai_dst +Int ABI_rad ) , Dai_dst , Junk_2 ) ) +Int -7943 ) ) </gas>
+            <memoryUsed> 0 => ?_ </memoryUsed>
+            <callGas> _ => ?_ </callGas>
+            <static> false </static>
+            <callDepth> VCallDepth </callDepth>
+          </callState>
+          <substate>
+            <selfDestruct> _VSelfDestruct </selfDestruct>
+            <log> _ => ?_ </log>
+            <refund> _Vrefund => ?_ </refund>
+          </substate>
+          <gasPrice> _ </gasPrice>
+          <origin> ORIGIN_ID </origin>
+          <blockhashes> _ </blockhashes>
+          <block>
+            <previousHash> _ </previousHash>
+            <ommersHash> _ </ommersHash>
+            <coinbase> _ </coinbase>
+            <stateRoot> _ </stateRoot>
+            <transactionsRoot> _ </transactionsRoot>
+            <receiptsRoot> _ </receiptsRoot>
+            <logsBloom> _ </logsBloom>
+            <difficulty> _ </difficulty>
+            <number> _BLOCK_NUMBER </number>
+            <gasLimit> _ </gasLimit>
+            <gasUsed> _ </gasUsed>
+            <timestamp> TIME </timestamp>
+            <extraData> _ </extraData>
+            <mixHash> _ </mixHash>
+            <blockNonce> _ </blockNonce>
+            <ommerBlockHeaders> _ </ommerBlockHeaders>
+          </block>
+        </evm>
+        <network>
+          <chainID> VChainId </chainID>
+          <activeAccounts> SetItem(ACCT_ID)
+          SetItem(1)
+          SetItem(2)
+          SetItem(3)
+          SetItem(4)
+          SetItem(5)
+          SetItem(6)
+          SetItem(7)
+          SetItem(8)
+          SetItem(9) _ </activeAccounts>
+          <accounts>
+            <account>
+              <acctID> ACCT_ID </acctID>
+              <balance> ACCT_ID_balance </balance>
+              <code> Vat_bin_runtime </code>
+              <storage> ACCT_ID_STORAGE => ACCT_ID_STORAGE [ #Vat.dai[ABI_src] <- Dai_src -Int ABI_rad ] [ #Vat.dai[ABI_dst] <- Dai_dst +Int ABI_rad ] </storage>
+              <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
+              <nonce> _Nonce_Vat => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> 1 </acctID>
+              <balance> ECREC_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 2 </acctID>
+              <balance> SHA256_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 3 </acctID>
+              <balance> RIP160_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 4 </acctID>
+              <balance> ID_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 5 </acctID>
+              <balance> MODEXP_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 6 </acctID>
+              <balance> ECADD_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 7 </acctID>
+              <balance> ECMUL_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 8 </acctID>
+              <balance> ECPAIRING_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 9 </acctID>
+              <balance> BLAKE2_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+           ...
+          </accounts>
+          <txOrder> _ </txOrder>
+          <txPending> _ </txPending>
+          <messages> _ </messages>
+        </network>
+      </ethereum>
+      requires #rangeAddress(ACCT_ID)
+       andBool ACCT_ID =/=Int 0
+       andBool #notPrecompileAddress(ACCT_ID)
+       andBool #rangeAddress(CALLER_ID)
+       andBool #rangeAddress(ORIGIN_ID)
+       andBool #rangeUInt(256, TIME)
+       andBool #rangeUInt(256, ACCT_ID_balance)
+       andBool #rangeUInt(256, ECREC_BAL)
+       andBool #rangeUInt(256, SHA256_BAL)
+       andBool #rangeUInt(256, RIP160_BAL)
+       andBool #rangeUInt(256, ID_BAL)
+       andBool #rangeUInt(256, MODEXP_BAL)
+       andBool #rangeUInt(256, ECADD_BAL)
+       andBool #rangeUInt(256, ECMUL_BAL)
+       andBool #rangeUInt(256, ECPAIRING_BAL)
+       andBool #rangeUInt(256, BLAKE2_BAL)
+       andBool VCallDepth <=Int 1024
+       andBool #rangeUInt(256, VCallValue)
+       andBool #rangeUInt(256, VChainId)
+
+       andBool (#rangeAddress(ABI_src)
+       andBool (#rangeAddress(ABI_dst)
+       andBool (#rangeUInt(256, ABI_rad)
+       andBool (#rangeUInt(256, Dai_dst)
+       andBool (#rangeUInt(256, Dai_src)
+       andBool (#rangeUInt(256, May)
+       andBool ((#sizeByteArray(CD) <=Int 1250000000)
+       andBool ((ABI_src =/=Int ABI_dst)
+       andBool (#rangeUInt(256, Junk_0)
+       andBool (#rangeUInt(256, Junk_1)
+       andBool (#rangeUInt(256, Junk_2)
+       andBool ((((May ==Int 1 orBool ABI_src ==Int CALLER_ID)))
+       andBool (((VCallValue ==Int 0))
+       andBool ((#rangeUInt(256, Dai_src -Int ABI_rad))
+       andBool ((#rangeUInt(256, Dai_dst +Int ABI_rad)))))))))))))))))
+
+       andBool #lookup(ACCT_ID_STORAGE, #Vat.can[ABI_src][CALLER_ID]) ==Int May
+       andBool #lookup(ACCT_ID_STORAGE, #Vat.dai[ABI_src]) ==Int Dai_src
+       andBool #lookup(ACCT_ID_STORAGE, #Vat.dai[ABI_dst]) ==Int Dai_dst
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Vat.can[ABI_src][CALLER_ID]) ==Int Junk_0
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Vat.dai[ABI_src]) ==Int Junk_1
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Vat.dai[ABI_dst]) ==Int Junk_2
+       andBool #Vat.can[ABI_src][CALLER_ID] =/=Int #Vat.dai[ABI_src]
+       andBool #Vat.can[ABI_src][CALLER_ID] =/=Int #Vat.dai[ABI_dst]
+       andBool #Vat.dai[ABI_src] =/=Int #Vat.dai[ABI_dst]
+    [trusted, matching(infGas)]
+
+
+endmodule

--- a/tests/specs/mcd/vat-addui-fail-rough-spec.k
+++ b/tests/specs/mcd/vat-addui-fail-rough-spec.k
@@ -27,7 +27,7 @@ module VAT-ADDUI-FAIL-ROUGH-SPEC
             <wordStack> chop(ABI_y) : ABI_x : JMPTO : WS  => ?_ </wordStack>
             <localMem> _ </localMem>
             <pc> 13112 => ?_ </pc>
-            <gas> VGas => ?_ </gas>
+            <gas> #gas(VGas) => ?_ </gas>
             <memoryUsed> VMemoryUsed </memoryUsed>
             <callGas> _ => ?_ </callGas>
             <static> _ </static>

--- a/tests/specs/mcd/vat-addui-fail-rough-spec.k
+++ b/tests/specs/mcd/vat-addui-fail-rough-spec.k
@@ -4,7 +4,7 @@ module VAT-ADDUI-FAIL-ROUGH-SPEC
     imports VERIFICATION
 
     // Vat_addui
-    rule [Vat.addui.fail.rough]:
+    claim [Vat.addui.fail.rough]:
       <k> #execute ~> CONTINUATION => #halt ~> CONTINUATION </k>
       <exit-code> 1 </exit-code>
       <mode> NORMAL </mode>

--- a/tests/specs/mcd/vat-deny-diff-fail-rough-spec.k
+++ b/tests/specs/mcd/vat-deny-diff-fail-rough-spec.k
@@ -27,7 +27,7 @@ module VAT-DENY-DIFF-FAIL-ROUGH-SPEC
             <wordStack> .WordStack => ?_ </wordStack>
             <localMem> .Memory => ?_ </localMem>
             <pc> 0 => ?_ </pc>
-            <gas> VGas => ?_ </gas>
+            <gas> #gas(VGas) => ?_ </gas>
             <memoryUsed> 0 => ?_ </memoryUsed>
             <callGas> _ => ?_ </callGas>
             <static> false </static>

--- a/tests/specs/mcd/vat-deny-diff-fail-rough-spec.k
+++ b/tests/specs/mcd/vat-deny-diff-fail-rough-spec.k
@@ -4,7 +4,7 @@ module VAT-DENY-DIFF-FAIL-ROUGH-SPEC
   imports VERIFICATION
 
     // Vat_deny-diff
-    rule [Vat.deny-diff.fail.rough]:
+    claim [Vat.deny-diff.fail.rough]:
       <k> #execute ~> CONTINUATION => #halt ~> CONTINUATION </k>
       <exit-code> 1 </exit-code>
       <mode> NORMAL </mode>

--- a/tests/specs/mcd/vat-move-diff-rough-spec.k
+++ b/tests/specs/mcd/vat-move-diff-rough-spec.k
@@ -388,7 +388,7 @@ module VAT-MOVE-DIFF-ROUGH-SPEC
      andBool ((#sizeWordStack(WS) <=Int 100)
      andBool (#rangeUInt(256, VMemoryUsed)
      andBool ((#rangeUInt(256, ABI_x +Int ABI_y)))))))
-    [trusted]
+    [trusted, matching(infGas)]
 
 
     // Vat_subuu
@@ -573,7 +573,7 @@ module VAT-MOVE-DIFF-ROUGH-SPEC
      andBool ((#sizeWordStack(WS) <=Int 100)
      andBool (#rangeUInt(256, VMemoryUsed)
      andBool ((#rangeUInt(256, ABI_x -Int ABI_y)))))))
-    [trusted]
+    [trusted, matching(infGas)]
 
 
 endmodule

--- a/tests/specs/mcd/vat-move-diff-rough-spec.k
+++ b/tests/specs/mcd/vat-move-diff-rough-spec.k
@@ -4,7 +4,7 @@ module VAT-MOVE-DIFF-ROUGH-SPEC
     imports VERIFICATION
 
     // Vat_move-diff
-    rule [Vat.move-diff.pass.rough]:
+    claim [Vat.move-diff.pass.rough]:
       <k> #execute ~> CONTINUATION => #halt ~> CONTINUATION </k>
       <exit-code> 1 </exit-code>
       <mode> NORMAL </mode>
@@ -207,7 +207,7 @@ module VAT-MOVE-DIFF-ROUGH-SPEC
      andBool #Vat.dai[ABI_src] =/=Int #Vat.dai[ABI_dst]
 
     // Vat_adduu
-    rule [Vat.adduu.pass]:
+    claim [Vat.adduu.pass]:
       <k> #execute ~> CONTINUATION => #execute ~> CONTINUATION </k>
       <exit-code> 1 </exit-code>
       <mode> NORMAL </mode>
@@ -392,7 +392,7 @@ module VAT-MOVE-DIFF-ROUGH-SPEC
 
 
     // Vat_subuu
-    rule [Vat.subuu.pass]:
+    claim [Vat.subuu.pass]:
       <k> #execute ~> CONTINUATION => #execute ~> CONTINUATION </k>
       <exit-code> 1 </exit-code>
       <mode> NORMAL </mode>

--- a/tests/specs/mcd/vat-mului-pass-spec.k
+++ b/tests/specs/mcd/vat-mului-pass-spec.k
@@ -27,7 +27,7 @@ module VAT-MULUI-PASS-SPEC
             <wordStack> chop(ABI_y) : ABI_x : JMPTO : WS  =>  JMPTO : chop(ABI_x *Int ABI_y) : WS </wordStack>
             <localMem> _ </localMem>
             <pc> 13175 => 13233 </pc>
-            <gas> VGas => VGas -Int ((#if ( ABI_y ==K 0 ) #then ( 96 ) #else ( 132 ) #fi)) </gas>
+            <gas> #gas(VGas) => #gas(VGas +Int ((#if ( ABI_y ==K 0 ) #then ( 96 ) #else ( 132 ) #fi))) </gas>
             <memoryUsed> VMemoryUsed </memoryUsed>
             <callGas> _ => ?_ </callGas>
             <static> _ </static>

--- a/tests/specs/mcd/vat-mului-pass-spec.k
+++ b/tests/specs/mcd/vat-mului-pass-spec.k
@@ -4,7 +4,7 @@ module VAT-MULUI-PASS-SPEC
     imports VERIFICATION
 
     // Vat_mului
-    rule [Vat.mului.pass]:
+    claim [Vat.mului.pass]:
       <k> #execute ~> CONTINUATION => #execute ~> CONTINUATION </k>
       <exit-code> 1 </exit-code>
       <mode> NORMAL </mode>

--- a/tests/specs/mcd/vat-mului-pass-spec.k
+++ b/tests/specs/mcd/vat-mului-pass-spec.k
@@ -27,7 +27,7 @@ module VAT-MULUI-PASS-SPEC
             <wordStack> chop(ABI_y) : ABI_x : JMPTO : WS  =>  JMPTO : chop(ABI_x *Int ABI_y) : WS </wordStack>
             <localMem> _ </localMem>
             <pc> 13175 => 13233 </pc>
-            <gas> #gas(VGas) => #gas(VGas +Int ((#if ( ABI_y ==K 0 ) #then ( 96 ) #else ( 132 ) #fi))) </gas>
+            <gas> #gas(VGas) => #gas(VGas -Int ((#if ( ABI_y ==K 0 ) #then ( 96 ) #else ( 132 ) #fi))) </gas>
             <memoryUsed> VMemoryUsed </memoryUsed>
             <callGas> _ => ?_ </callGas>
             <static> _ </static>

--- a/tests/specs/mcd/vat-slip-pass-rough-spec.k
+++ b/tests/specs/mcd/vat-slip-pass-rough-spec.k
@@ -380,7 +380,7 @@ module VAT-SLIP-PASS-ROUGH-SPEC
      andBool ((#sizeWordStack(WS) <=Int 1015)
      andBool (#rangeUInt(256, VMemoryUsed)
      andBool ((#rangeUInt(256, ABI_x +Int ABI_y)))))))
-    [trusted]
+    [trusted, matching(infGas)]
 
 
 endmodule

--- a/tests/specs/mcd/vat-slip-pass-rough-spec.k
+++ b/tests/specs/mcd/vat-slip-pass-rough-spec.k
@@ -4,7 +4,7 @@ module VAT-SLIP-PASS-ROUGH-SPEC
     imports VERIFICATION
 
     // Vat_slip
-    rule [Vat.slip.pass.rough]:
+    claim [Vat.slip.pass.rough]:
       <k> #execute ~> CONTINUATION => #halt ~> CONTINUATION </k>
       <exit-code> 1 </exit-code>
       <mode> NORMAL </mode>
@@ -199,7 +199,7 @@ module VAT-SLIP-PASS-ROUGH-SPEC
      andBool #Vat.wards[CALLER_ID] =/=Int #Vat.gem[ABI_ilk][ABI_usr]
 
     // Vat_addui
-    rule [Vat.addui.pass]:
+    claim [Vat.addui.pass]:
       <k> #execute ~> CONTINUATION => #execute ~> CONTINUATION </k>
       <exit-code> 1 </exit-code>
       <mode> NORMAL </mode>

--- a/tests/specs/mcd/vat-subui-fail-rough-spec.k
+++ b/tests/specs/mcd/vat-subui-fail-rough-spec.k
@@ -27,7 +27,7 @@ module VAT-SUBUI-FAIL-ROUGH-SPEC
             <wordStack> chop(ABI_y) : ABI_x : JMPTO : WS  => ?_ </wordStack>
             <localMem> _ </localMem>
             <pc> 13304 => ?_ </pc>
-            <gas> VGas => ?_ </gas>
+            <gas> #gas(VGas) => ?_ </gas>
             <memoryUsed> VMemoryUsed </memoryUsed>
             <callGas> _ => ?_ </callGas>
             <static> _ </static>

--- a/tests/specs/mcd/vat-subui-fail-rough-spec.k
+++ b/tests/specs/mcd/vat-subui-fail-rough-spec.k
@@ -4,7 +4,7 @@ module VAT-SUBUI-FAIL-ROUGH-SPEC
     imports VERIFICATION
 
     // Vat_subui
-    rule [Vat.subui.fail.rough]:
+    claim [Vat.subui.fail.rough]:
       <k> #execute ~> CONTINUATION => #halt ~> CONTINUATION </k>
       <exit-code> 1 </exit-code>
       <mode> NORMAL </mode>

--- a/tests/specs/mcd/vat-subui-pass-rough-spec.k
+++ b/tests/specs/mcd/vat-subui-pass-rough-spec.k
@@ -27,7 +27,7 @@ module VAT-SUBUI-PASS-ROUGH-SPEC
             <wordStack> chop(ABI_y) : ABI_x : JMPTO : WS  =>  JMPTO : ABI_x -Int ABI_y : WS </wordStack>
             <localMem> _ </localMem>
             <pc> 13304 => 13366 </pc>
-            <gas> VGas => ?_ </gas>
+            <gas> #gas(VGas) => ?_ </gas>
             <memoryUsed> VMemoryUsed </memoryUsed>
             <callGas> _ => ?_ </callGas>
             <static> _ </static>

--- a/tests/specs/mcd/vat-subui-pass-rough-spec.k
+++ b/tests/specs/mcd/vat-subui-pass-rough-spec.k
@@ -4,7 +4,7 @@ module VAT-SUBUI-PASS-ROUGH-SPEC
     imports VERIFICATION
 
     // Vat_subui
-    rule [Vat.subui.pass.rough]:
+    claim [Vat.subui.pass.rough]:
       <k> #execute ~> CONTINUATION => #execute ~> CONTINUATION </k>
       <exit-code> 1 </exit-code>
       <mode> NORMAL </mode>

--- a/tests/specs/mcd/verification.k
+++ b/tests/specs/mcd/verification.k
@@ -299,10 +299,6 @@ module VERIFICATION
 
     rule chop(X *Int Y) => X *Int Y requires 0 <=Int X andBool 0 <=Int Y andBool X *Int Y <Int pow256 [simplification]
 
-    // ### Gas Simplification
-
-    rule I -Int I => 0 [simplification]
-
     // ### vat-slip-pass-rough
 
     rule chop(X +Int chop(Y)) => chop(X +Int Y) [simplification]
@@ -385,5 +381,9 @@ module VERIFICATION
     // (check-sat)
     // (pop)
     rule X -Word chop(Y) => chop(X -Int Y) [simplification]
+
+    // ### Gas Simplification
+
+    rule I -Int I => 0 [simplification]
 
 endmodule

--- a/tests/specs/mcd/verification.k
+++ b/tests/specs/mcd/verification.k
@@ -382,15 +382,15 @@ module VERIFICATION
     // (pop)
     rule X -Word chop(Y) => chop(X -Int Y) [simplification]
 
+    // ### end-pack-pass-rough
+
+    rule ADDR in (SetItem(I) REST) => ADDR in REST requires #notPrecompileAddress(ADDR) andBool notBool #notPrecompileAddress(I) [simplification]
+
     // ### Gas Simplification
 
     rule I -Int I => 0                                                                                                                                                              [simplification]
     rule (notBool (A andBool B)) andBool A => (notBool B) andBool A                                                                                                                 [simplification]
     rule chop(Y) ==K 0 => Y ==Int 0 requires #rangeSInt(256, Y)                                                                                                                     [simplification]
     rule ((I1 +Int I2) +Int I3) +Int I4 => (I1 +Int I3) +Int (I2 +Int I4) requires #isConcrete(I2) andBool #isConcrete(I4) andBool notBool (#isConcrete(I1) orBool #isConcrete(I3)) [simplification]
-
-    // ### end-pack-pass-rough
-
-    rule ADDR in (SetItem(I) REST) => ADDR in REST requires #notPrecompileAddress(ADDR) andBool notBool #notPrecompileAddress(I) [simplification]
 
 endmodule

--- a/tests/specs/mcd/verification.k
+++ b/tests/specs/mcd/verification.k
@@ -386,10 +386,4 @@ module VERIFICATION
 
     rule ADDR in (SetItem(I) REST) => ADDR in REST requires #notPrecompileAddress(ADDR) andBool notBool #notPrecompileAddress(I) [simplification]
 
-    // ### Gas Simplification
-
-    rule I -Int I => 0                                              [simplification]
-    rule (notBool (A andBool B)) andBool A => (notBool B) andBool A [simplification]
-    rule chop(Y) ==K 0 => Y ==Int 0 requires #rangeSInt(256, Y)     [simplification]
-
 endmodule

--- a/tests/specs/mcd/verification.k
+++ b/tests/specs/mcd/verification.k
@@ -384,6 +384,8 @@ module VERIFICATION
 
     // ### Gas Simplification
 
-    rule I -Int I => 0 [simplification]
+    rule I -Int I => 0                                              [simplification]
+    rule (notBool (A andBool B)) andBool A => (notBool B) andBool A [simplification]
+    rule chop(Y) ==K 0 => Y ==Int 0 requires #rangeSInt(256, Y)     [simplification]
 
 endmodule

--- a/tests/specs/mcd/verification.k
+++ b/tests/specs/mcd/verification.k
@@ -388,5 +388,11 @@ module VERIFICATION
     rule (notBool (A andBool B)) andBool A => (notBool B) andBool A                                                                                                                 [simplification]
     rule chop(Y) ==K 0 => Y ==Int 0 requires #rangeSInt(256, Y)                                                                                                                     [simplification]
     rule ((I1 +Int I2) +Int I3) +Int I4 => (I1 +Int I3) +Int (I2 +Int I4) requires #isConcrete(I2) andBool #isConcrete(I4) andBool notBool (#isConcrete(I1) orBool #isConcrete(I3)) [simplification]
+    rule I1 +Int I2 <Int I3 => I1 <Int I3 -Int I2 requires #isConcrete(I2) andBool #isConcrete(I3)                                                                                  [simplification]
+    rule I1 <Int I2 +Int I3 => I1 -Int I3 <Int I2 requires #isConcrete(I1) andBool #isConcrete(I3)                                                                                  [simplification]
+
+    // ### end-pack-pass-rough
+
+    rule ADDR in (SetItem(I) REST) => ADDR in REST requires #notPrecompileAddress(ADDR) andBool notBool #notPrecompileAddress(I) [simplification]
 
 endmodule

--- a/tests/specs/mcd/verification.k
+++ b/tests/specs/mcd/verification.k
@@ -388,9 +388,8 @@ module VERIFICATION
 
     // ### Gas Simplification
 
-    rule I -Int I => 0                                                                                                                                                              [simplification]
-    rule (notBool (A andBool B)) andBool A => (notBool B) andBool A                                                                                                                 [simplification]
-    rule chop(Y) ==K 0 => Y ==Int 0 requires #rangeSInt(256, Y)                                                                                                                     [simplification]
-    rule ((I1 +Int I2) +Int I3) +Int I4 => (I1 +Int I3) +Int (I2 +Int I4) requires #isConcrete(I2) andBool #isConcrete(I4) andBool notBool (#isConcrete(I1) orBool #isConcrete(I3)) [simplification]
+    rule I -Int I => 0                                              [simplification]
+    rule (notBool (A andBool B)) andBool A => (notBool B) andBool A [simplification]
+    rule chop(Y) ==K 0 => Y ==Int 0 requires #rangeSInt(256, Y)     [simplification]
 
 endmodule

--- a/tests/specs/mcd/verification.k
+++ b/tests/specs/mcd/verification.k
@@ -384,8 +384,9 @@ module VERIFICATION
 
     // ### Gas Simplification
 
-    rule I -Int I => 0                                              [simplification]
-    rule (notBool (A andBool B)) andBool A => (notBool B) andBool A [simplification]
-    rule chop(Y) ==K 0 => Y ==Int 0 requires #rangeSInt(256, Y)     [simplification]
+    rule I -Int I => 0                                                                                                                                                              [simplification]
+    rule (notBool (A andBool B)) andBool A => (notBool B) andBool A                                                                                                                 [simplification]
+    rule chop(Y) ==K 0 => Y ==Int 0 requires #rangeSInt(256, Y)                                                                                                                     [simplification]
+    rule ((I1 +Int I2) +Int I3) +Int I4 => (I1 +Int I3) +Int (I2 +Int I4) requires #isConcrete(I2) andBool #isConcrete(I4) andBool notBool (#isConcrete(I1) orBool #isConcrete(I3)) [simplification]
 
 endmodule

--- a/tests/specs/mcd/verification.k
+++ b/tests/specs/mcd/verification.k
@@ -388,8 +388,6 @@ module VERIFICATION
     rule (notBool (A andBool B)) andBool A => (notBool B) andBool A                                                                                                                 [simplification]
     rule chop(Y) ==K 0 => Y ==Int 0 requires #rangeSInt(256, Y)                                                                                                                     [simplification]
     rule ((I1 +Int I2) +Int I3) +Int I4 => (I1 +Int I3) +Int (I2 +Int I4) requires #isConcrete(I2) andBool #isConcrete(I4) andBool notBool (#isConcrete(I1) orBool #isConcrete(I3)) [simplification]
-    rule I1 +Int I2 <Int I3 => I1 <Int I3 -Int I2 requires #isConcrete(I2) andBool #isConcrete(I3)                                                                                  [simplification]
-    rule I1 <Int I2 +Int I3 => I1 -Int I3 <Int I2 requires #isConcrete(I1) andBool #isConcrete(I3)                                                                                  [simplification]
 
     // ### end-pack-pass-rough
 

--- a/tests/specs/mcd/vow-flog-fail-rough-spec.k
+++ b/tests/specs/mcd/vow-flog-fail-rough-spec.k
@@ -27,7 +27,7 @@ module VOW-FLOG-FAIL-ROUGH-SPEC
             <wordStack> .WordStack => ?_ </wordStack>
             <localMem> .Memory => ?_ </localMem>
             <pc> 0 => ?_ </pc>
-            <gas> VGas => ?_ </gas>
+            <gas> #gas(VGas) => ?_ </gas>
             <memoryUsed> 0 => ?_ </memoryUsed>
             <callGas> _ => ?_ </callGas>
             <static> false </static>
@@ -231,7 +231,7 @@ module VOW-FLOG-FAIL-ROUGH-SPEC
             <wordStack> ABI_y : ABI_x : JMPTO : WS  =>  JMPTO : ABI_x +Int ABI_y : WS </wordStack>
             <localMem> _ </localMem>
             <pc> 9777 => 9802 </pc>
-            <gas> VGas => ( VGas +Int -54 ) </gas>
+            <gas> #gas(VGas) => #gas( VGas +Int 54 ) </gas>
             <memoryUsed> VMemoryUsed </memoryUsed>
             <callGas> _ => ?_ </callGas>
             <static> _ </static>
@@ -390,7 +390,7 @@ module VOW-FLOG-FAIL-ROUGH-SPEC
      andBool (#rangeUInt(256, VMemoryUsed)
      andBool (2300 <Int ( VGas +Int -54 )
      andBool ((#rangeUInt(256, ABI_x +Int ABI_y))))))))
-    [trusted]
+    [trusted, matching(infGas)]
 
 
     // Vow_subuu
@@ -417,7 +417,7 @@ module VOW-FLOG-FAIL-ROUGH-SPEC
             <wordStack> ABI_y : ABI_x : JMPTO : WS  =>  JMPTO : ABI_x -Int ABI_y : WS </wordStack>
             <localMem> _ </localMem>
             <pc> 9803 => 9828 </pc>
-            <gas> VGas => ( VGas +Int -54 ) </gas>
+            <gas> #gas(VGas) => #gas( VGas +Int 54 ) </gas>
             <memoryUsed> VMemoryUsed </memoryUsed>
             <callGas> _ => ?_ </callGas>
             <static> _ </static>
@@ -576,7 +576,7 @@ module VOW-FLOG-FAIL-ROUGH-SPEC
      andBool (#rangeUInt(256, VMemoryUsed)
      andBool (2300 <Int ( VGas +Int -54 )
      andBool ((#rangeUInt(256, ABI_x -Int ABI_y))))))))
-    [trusted]
+    [trusted, matching(infGas)]
 
 
 endmodule

--- a/tests/specs/mcd/vow-flog-fail-rough-spec.k
+++ b/tests/specs/mcd/vow-flog-fail-rough-spec.k
@@ -4,7 +4,7 @@ module VOW-FLOG-FAIL-ROUGH-SPEC
     imports VERIFICATION
 
     // Vow_flog
-    rule [Vow.flog.fail.rough]:
+    claim [Vow.flog.fail.rough]:
       <k> #execute ~> CONTINUATION => #halt ~> CONTINUATION </k>
       <exit-code> 1 </exit-code>
       <mode> NORMAL </mode>
@@ -208,7 +208,7 @@ module VOW-FLOG-FAIL-ROUGH-SPEC
     ensures ?FAILURE =/=K EVMC_SUCCESS
 
     // Vow_adduu
-    rule [Vow.adduu.pass]:
+    claim [Vow.adduu.pass]:
       <k> #execute ~> CONTINUATION => #execute ~> CONTINUATION </k>
       <exit-code> 1 </exit-code>
       <mode> NORMAL </mode>
@@ -394,7 +394,7 @@ module VOW-FLOG-FAIL-ROUGH-SPEC
 
 
     // Vow_subuu
-    rule [Vow.subuu.pass]:
+    claim [Vow.subuu.pass]:
       <k> #execute ~> CONTINUATION => #execute ~> CONTINUATION </k>
       <exit-code> 1 </exit-code>
       <mode> NORMAL </mode>


### PR DESCRIPTION
-   Adds lemmas for reasoning about #gas around different constructs (eg. Cmem, minInt, /Int).
-   Makes separate modules for Haskell/Java lemmas about infinite gas which requires the `concrete` attribute.
-   Adds tests of the infinite gas abstraction (inspired by making the end-pack-pass-rough and pot-join-pass-rough proofs pass).
-   Adds the end-pack-pass-rough proof.
-   #gas abstraction now counts gas down, instead of up.
-   #gas should behave like a proper positive infinity now.