### PR TITLE
WordPack abstraction for Solidity-packed structs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -278,7 +278,7 @@ test: test-conformance test-prove test-interactive test-parse
 tests/ethereum-tests/VMTests/%: KEVM_MODE     = VMTESTS
 tests/ethereum-tests/VMTests/%: KEVM_SCHEDULE = DEFAULT
 
-tests/specs/mcd/functional-spec.k.prove: KPROVE_MODULE = FUNCTIONAL-SPEC-SYNTAX
+tests/specs/mcd/functional-spec.k%: KPROVE_MODULE = FUNCTIONAL-SPEC-SYNTAX
 
 tests/%.run: tests/%
 	MODE=$(KEVM_MODE) SCHEDULE=$(KEVM_SCHEDULE) CHAINID=$(KEVM_CHAINID)                                                \

--- a/Makefile
+++ b/Makefile
@@ -275,8 +275,10 @@ test: test-conformance test-prove test-interactive test-parse
 
 # Generic Test Harnesses
 
-tests/ethereum-tests/VMTests/%: KEVM_MODE=VMTESTS
-tests/ethereum-tests/VMTests/%: KEVM_SCHEDULE=DEFAULT
+tests/ethereum-tests/VMTests/%: KEVM_MODE     = VMTESTS
+tests/ethereum-tests/VMTests/%: KEVM_SCHEDULE = DEFAULT
+
+tests/specs/mcd/functional-spec.k.prove: KPROVE_MODULE = FUNCTIONAL-SPEC-SYNTAX
 
 tests/%.run: tests/%
 	MODE=$(KEVM_MODE) SCHEDULE=$(KEVM_SCHEDULE) CHAINID=$(KEVM_CHAINID)                                                \

--- a/tests/failing-symbolic.haskell
+++ b/tests/failing-symbolic.haskell
@@ -73,6 +73,7 @@ tests/specs/mcd/flipper-bids-pass-rough-spec.k
 tests/specs/mcd/flipper-tau-pass-spec.k
 tests/specs/mcd/flipper-ttl-pass-spec.k
 tests/specs/mcd/flopper-cage-pass-spec.k
+tests/specs/mcd/flopper-dent-guy-same-pass-rough-spec.k
 tests/specs/mcd/flopper-file-pass-rough-spec.k
 tests/specs/mcd/flopper-kick-pass-rough-spec.k
 tests/specs/mcd/flopper-tick-pass-rough-spec.k

--- a/tests/failing-symbolic.haskell
+++ b/tests/failing-symbolic.haskell
@@ -73,7 +73,9 @@ tests/specs/mcd/flipper-tau-pass-spec.k
 tests/specs/mcd/flipper-ttl-pass-spec.k
 tests/specs/mcd/flopper-cage-pass-spec.k
 tests/specs/mcd/flopper-file-pass-rough-spec.k
+tests/specs/mcd/flopper-kick-pass-rough-spec.k
 tests/specs/mcd/flopper-tick-pass-rough-spec.k
+tests/specs/mcd/functional-spec.k
 tests/specs/mcd/pot-join-pass-rough-spec.k
 tests/specs/mcd/vat-addui-fail-rough-spec.k
 tests/specs/mcd/vat-deny-diff-fail-rough-spec.k

--- a/tests/failing-symbolic.haskell
+++ b/tests/failing-symbolic.haskell
@@ -67,6 +67,7 @@ tests/specs/mcd/dsvalue-peek-pass-rough-spec.k
 tests/specs/mcd/dsvalue-read-pass-spec.k
 tests/specs/mcd/end-pack-pass-rough-spec.k
 tests/specs/mcd/end-subuu-pass-spec.k
+tests/specs/mcd/flapper-yank-pass-rough-spec.k
 tests/specs/mcd/flipper-addu48u48-fail-rough-spec.k
 tests/specs/mcd/flipper-bids-pass-rough-spec.k
 tests/specs/mcd/flipper-tau-pass-spec.k

--- a/tests/specs/mcd/flapper-yank-pass-rough-spec.k
+++ b/tests/specs/mcd/flapper-yank-pass-rough-spec.k
@@ -1,0 +1,477 @@
+requires "verification.k"
+
+module FLAPPER-YANK-PASS-ROUGH-SPEC
+    imports VERIFICATION
+
+    // Flapper_yank
+    claim [Flapper.yank.pass.rough]:
+      <k> #execute ~> CONTINUATION => #halt ~> CONTINUATION </k>
+      <exit-code> 1 </exit-code>
+      <mode> NORMAL </mode>
+      <schedule> ISTANBUL </schedule>
+      <ethereum>
+        <evm>
+          <output> .ByteArray </output>
+          <statusCode> _ => EVMC_SUCCESS </statusCode>
+          <endPC> _ => ?_ </endPC>
+          <callStack> _VCallStack </callStack>
+          <interimStates> _ </interimStates>
+          <touchedAccounts> _ => ?_ </touchedAccounts>
+          <callState>
+            <program> Flapper_bin_runtime </program>
+            <jumpDests> #computeValidJumpDests(Flapper_bin_runtime) </jumpDests>
+            <id> ACCT_ID </id>
+            <caller> CALLER_ID </caller>
+            <callData> #abiCallData("yank", #uint256(ABI_id)) ++ CD => ?_ </callData>
+            <callValue> VCallValue </callValue>
+            <wordStack> .WordStack => ?_ </wordStack>
+            <localMem> .Memory => ?_ </localMem>
+            <pc> 0 => ?_ </pc>
+            <gas> #gas(VGas) => ?_ </gas>
+            <memoryUsed> 0 => ?_ </memoryUsed>
+            <callGas> _ => ?_ </callGas>
+            <static> false </static>
+            <callDepth> VCallDepth </callDepth>
+          </callState>
+          <substate>
+            <selfDestruct> _VSelfDestruct </selfDestruct>
+            <log> _ => ?_ </log>
+            <refund> _Vrefund => ?_ </refund>
+          </substate>
+          <gasPrice> _ </gasPrice>
+          <origin> ORIGIN_ID </origin>
+          <blockhashes> _ </blockhashes>
+          <block>
+            <previousHash> _ </previousHash>
+            <ommersHash> _ </ommersHash>
+            <coinbase> _ </coinbase>
+            <stateRoot> _ </stateRoot>
+            <transactionsRoot> _ </transactionsRoot>
+            <receiptsRoot> _ </receiptsRoot>
+            <logsBloom> _ </logsBloom>
+            <difficulty> _ </difficulty>
+            <number> _BLOCK_NUMBER </number>
+            <gasLimit> _ </gasLimit>
+            <gasUsed> _ </gasUsed>
+            <timestamp> TIME </timestamp>
+            <extraData> _ </extraData>
+            <mixHash> _ </mixHash>
+            <blockNonce> _ </blockNonce>
+            <ommerBlockHeaders> _ </ommerBlockHeaders>
+          </block>
+        </evm>
+        <network>
+          <chainID> VChainId </chainID>
+          <activeAccounts> SetItem(ACCT_ID)
+          SetItem(DSToken)
+          SetItem(1)
+          SetItem(2)
+          SetItem(3)
+          SetItem(4)
+          SetItem(5)
+          SetItem(6)
+          SetItem(7)
+          SetItem(8)
+          SetItem(9) _ </activeAccounts>
+          <accounts>
+            <account>
+              <acctID> ACCT_ID </acctID>
+              <balance> ACCT_ID_balance </balance>
+              <code> Flapper_bin_runtime </code>
+              <storage> ACCT_ID_STORAGE => ACCT_ID_STORAGE [ #Flapper.bids[ABI_id].bid <- 0 ] [ #Flapper.bids[ABI_id].lot <- 0 ] [ #Flapper.bids[ABI_id].guy_tic_end <- 0 ] </storage>
+              <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
+              <nonce> _Nonce_Flapper => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> DSToken </acctID>
+              <balance> DSToken_balance </balance>
+              <code> DSToken_bin_runtime </code>
+              <storage> DSToken_STORAGE => DSToken_STORAGE [ #DSToken.balances[ACCT_ID] <- Gem_a -Int Bid ] [ #DSToken.balances[Guy] <- Gem_g +Int Bid ] </storage>
+              <origStorage> DSToken_ORIG_STORAGE </origStorage>
+              <nonce> _Nonce_DSToken => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> 1 </acctID>
+              <balance> ECREC_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 2 </acctID>
+              <balance> SHA256_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 3 </acctID>
+              <balance> RIP160_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 4 </acctID>
+              <balance> ID_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 5 </acctID>
+              <balance> MODEXP_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 6 </acctID>
+              <balance> ECADD_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 7 </acctID>
+              <balance> ECMUL_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 8 </acctID>
+              <balance> ECPAIRING_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 9 </acctID>
+              <balance> BLAKE2_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+           ...
+          </accounts>
+          <txOrder> _ </txOrder>
+          <txPending> _ </txPending>
+          <messages> _ </messages>
+        </network>
+      </ethereum>
+      requires #rangeAddress(ACCT_ID)
+       andBool ACCT_ID =/=Int 0
+       andBool #notPrecompileAddress(ACCT_ID)
+       andBool #rangeAddress(CALLER_ID)
+       andBool #rangeAddress(ORIGIN_ID)
+       andBool #rangeUInt(256, TIME)
+       andBool #rangeUInt(256, ACCT_ID_balance)
+       andBool #rangeUInt(256, ECREC_BAL)
+       andBool #rangeUInt(256, SHA256_BAL)
+       andBool #rangeUInt(256, RIP160_BAL)
+       andBool #rangeUInt(256, ID_BAL)
+       andBool #rangeUInt(256, MODEXP_BAL)
+       andBool #rangeUInt(256, ECADD_BAL)
+       andBool #rangeUInt(256, ECMUL_BAL)
+       andBool #rangeUInt(256, ECPAIRING_BAL)
+       andBool #rangeUInt(256, BLAKE2_BAL)
+       andBool VCallDepth <=Int 1024
+       andBool #rangeUInt(256, VCallValue)
+       andBool #rangeUInt(256, VChainId)
+
+       andBool (#rangeUInt(256, ABI_id)
+       andBool (#rangeUInt(256, Live)
+       andBool (#rangeAddress(DSToken)
+       andBool (#rangeUInt(256, Bid)
+       andBool (#rangeUInt(256, Lot)
+       andBool (#rangeAddress(Guy)
+       andBool (#rangeUInt(48, Tic)
+       andBool (#rangeUInt(48, End)
+       andBool (#rangeUInt(256, Gem_a)
+       andBool (#rangeUInt(256, Gem_g)
+       andBool (#rangeBool(Stopped)
+       andBool (#rangeAddress(Owner)
+       andBool (#rangeUInt(256, DSToken_balance)
+       andBool ((#sizeByteArray(CD) <=Int 1250000000)
+       andBool ((#notPrecompileAddress(DSToken))
+       andBool ((#notPrecompileAddress(Guy))
+       andBool ((#notPrecompileAddress(Owner))
+       andBool ((ACCT_ID =/=Int DSToken)
+       andBool (((DSToken =/=Int 0))
+       andBool ((ACCT_ID =/=Int Guy)
+       andBool (#rangeUInt(256, Junk_0)
+       andBool (#rangeUInt(256, Junk_1)
+       andBool (#rangeUInt(256, Junk_2)
+       andBool (#rangeUInt(256, Junk_3)
+       andBool (#rangeUInt(256, Junk_4)
+       andBool (#rangeUInt(256, Junk_5)
+       andBool (#rangeUInt(256, Junk_6)
+       andBool (#rangeUInt(256, Junk_7)
+       andBool (((Live ==Int 0))
+       andBool (((Guy =/=Int 0))
+       andBool (((Stopped ==Int 0))
+       andBool (((VCallDepth <Int 1024))
+       andBool (((VCallValue ==Int 0))
+       andBool ((#rangeUInt(256, Gem_a -Int Bid))
+       andBool ((#rangeUInt(256, Gem_g +Int Bid)))))))))))))))))))))))))))))))))))))
+
+       andBool #lookup(ACCT_ID_STORAGE, #Flapper.live) ==Int Live
+       andBool #lookup(ACCT_ID_STORAGE, #Flapper.gem) ==Int DSToken
+       andBool #lookup(ACCT_ID_STORAGE, #Flapper.bids[ABI_id].bid) ==Int Bid
+       andBool #lookup(ACCT_ID_STORAGE, #Flapper.bids[ABI_id].lot) ==Int Lot
+       andBool #lookup(ACCT_ID_STORAGE, #Flapper.bids[ABI_id].guy_tic_end) ==Int #WordPackAddrUInt48UInt48(Guy, Tic, End)
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Flapper.live) ==Int Junk_0
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Flapper.gem) ==Int Junk_1
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Flapper.bids[ABI_id].bid) ==Int Junk_2
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Flapper.bids[ABI_id].lot) ==Int Junk_3
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Flapper.bids[ABI_id].guy_tic_end) ==Int Junk_4
+       andBool #Flapper.live =/=Int #Flapper.gem
+       andBool #Flapper.live =/=Int #Flapper.bids[ABI_id].bid
+       andBool #Flapper.live =/=Int #Flapper.bids[ABI_id].lot
+       andBool #Flapper.live =/=Int #Flapper.bids[ABI_id].guy_tic_end
+       andBool #Flapper.gem =/=Int #Flapper.bids[ABI_id].bid
+       andBool #Flapper.gem =/=Int #Flapper.bids[ABI_id].lot
+       andBool #Flapper.gem =/=Int #Flapper.bids[ABI_id].guy_tic_end
+       andBool #Flapper.bids[ABI_id].bid =/=Int #Flapper.bids[ABI_id].lot
+       andBool #Flapper.bids[ABI_id].bid =/=Int #Flapper.bids[ABI_id].guy_tic_end
+       andBool #Flapper.bids[ABI_id].lot =/=Int #Flapper.bids[ABI_id].guy_tic_end
+       andBool #lookup(DSToken_STORAGE, #DSToken.balances[ACCT_ID]) ==Int Gem_a
+       andBool #lookup(DSToken_STORAGE, #DSToken.balances[Guy]) ==Int Gem_g
+       andBool #lookup(DSToken_STORAGE, #DSToken.owner_stopped) ==Int #WordPackAddrUInt8(Owner, Stopped)
+       andBool #lookup(DSToken_ORIG_STORAGE, #DSToken.balances[ACCT_ID]) ==Int Junk_5
+       andBool #lookup(DSToken_ORIG_STORAGE, #DSToken.balances[Guy]) ==Int Junk_6
+       andBool #lookup(DSToken_ORIG_STORAGE, #DSToken.owner_stopped) ==Int Junk_7
+       andBool #DSToken.balances[ACCT_ID] =/=Int #DSToken.balances[Guy]
+       andBool #DSToken.balances[ACCT_ID] =/=Int #DSToken.owner_stopped
+       andBool #DSToken.balances[Guy] =/=Int #DSToken.owner_stopped
+
+    // DSToken_move
+    claim [DSToken.move.pass]:
+      <k> #execute ~> CONTINUATION => #halt ~> CONTINUATION </k>
+      <exit-code> 1 </exit-code>
+      <mode> NORMAL </mode>
+      <schedule> ISTANBUL </schedule>
+      <ethereum>
+        <evm>
+          <output> .ByteArray </output>
+          <statusCode> _ => EVMC_SUCCESS </statusCode>
+          <endPC> _ => ?_ </endPC>
+          <callStack> _VCallStack </callStack>
+          <interimStates> _ </interimStates>
+          <touchedAccounts> _ => ?_ </touchedAccounts>
+          <callState>
+            <program> DSToken_bin_runtime </program>
+            <jumpDests> #computeValidJumpDests(DSToken_bin_runtime) </jumpDests>
+            <id> ACCT_ID </id>
+            <caller> CALLER_ID </caller>
+            <callData> #abiCallData("move", #address(ABI_src), #address(ABI_dst), #uint256(ABI_wad)) ++ CD => ?_ </callData>
+            <callValue> VCallValue </callValue>
+            <wordStack> .WordStack => ?_ </wordStack>
+            <localMem> .Memory => ?_ </localMem>
+            <pc> 0 => ?_ </pc>
+            <gas> #gas(VGas) => #if ( #lookup( ACCT_ID_STORAGE , hash2 ( CALLER_ID , hash2 ( ABI_src , 2 ) ) ) ==Int maxUInt256 andBool ( Allowance ==Int maxUInt256 andBool ( maxUInt256 ==Int maxUInt256 orBool ABI_wad <=Int maxUInt256 ) ) )
+              #then   #gas ( ( ( ( VGas -Int Csstore( ISTANBUL , ( Gem_s -Int ABI_wad ) , Gem_s , Junk_1 ) ) -Int Csstore( ISTANBUL , ( Gem_d +Int ABI_wad ) , Gem_d , Junk_2 ) ) +Int -7281 ) )
+              #else   #gas ( ( ( ( ( VGas -Int Csstore( ISTANBUL , ( Allowance -Int ABI_wad ) , Allowance , Junk_0 ) ) -Int Csstore( ISTANBUL , ( Gem_s -Int ABI_wad ) , Gem_s , Junk_1 ) ) -Int Csstore( ISTANBUL , ( Gem_d +Int ABI_wad ) , Gem_d , Junk_2 ) ) +Int -9538 ) )
+            #fi </gas>
+            <memoryUsed> 0 => ?_ </memoryUsed>
+            <callGas> _ => ?_ </callGas>
+            <static> false </static>
+            <callDepth> VCallDepth </callDepth>
+          </callState>
+          <substate>
+            <selfDestruct> _VSelfDestruct </selfDestruct>
+            <log> _ => ?_ </log>
+            <refund> _Vrefund => ?_ </refund>
+          </substate>
+          <gasPrice> _ </gasPrice>
+          <origin> ORIGIN_ID </origin>
+          <blockhashes> _ </blockhashes>
+          <block>
+            <previousHash> _ </previousHash>
+            <ommersHash> _ </ommersHash>
+            <coinbase> _ </coinbase>
+            <stateRoot> _ </stateRoot>
+            <transactionsRoot> _ </transactionsRoot>
+            <receiptsRoot> _ </receiptsRoot>
+            <logsBloom> _ </logsBloom>
+            <difficulty> _ </difficulty>
+            <number> _BLOCK_NUMBER </number>
+            <gasLimit> _ </gasLimit>
+            <gasUsed> _ </gasUsed>
+            <timestamp> TIME </timestamp>
+            <extraData> _ </extraData>
+            <mixHash> _ </mixHash>
+            <blockNonce> _ </blockNonce>
+            <ommerBlockHeaders> _ </ommerBlockHeaders>
+          </block>
+        </evm>
+        <network>
+          <chainID> VChainId </chainID>
+          <activeAccounts> SetItem(ACCT_ID)
+          SetItem(1)
+          SetItem(2)
+          SetItem(3)
+          SetItem(4)
+          SetItem(5)
+          SetItem(6)
+          SetItem(7)
+          SetItem(8)
+          SetItem(9) _ </activeAccounts>
+          <accounts>
+            <account>
+              <acctID> ACCT_ID </acctID>
+              <balance> ACCT_ID_balance </balance>
+              <code> DSToken_bin_runtime </code>
+              <storage> ACCT_ID_STORAGE => ACCT_ID_STORAGE [ #DSToken.allowance[ABI_src][CALLER_ID] <- #if (ABI_src ==Int CALLER_ID orBool Allowance ==Int maxUInt256) #then Allowance #else Allowance -Int ABI_wad #fi ] [ #DSToken.balances[ABI_src] <- Gem_s -Int ABI_wad ] [ #DSToken.balances[ABI_dst] <- Gem_d +Int ABI_wad ] </storage>
+              <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
+              <nonce> _Nonce_DSToken => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> 1 </acctID>
+              <balance> ECREC_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 2 </acctID>
+              <balance> SHA256_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 3 </acctID>
+              <balance> RIP160_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 4 </acctID>
+              <balance> ID_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 5 </acctID>
+              <balance> MODEXP_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 6 </acctID>
+              <balance> ECADD_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 7 </acctID>
+              <balance> ECMUL_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 8 </acctID>
+              <balance> ECPAIRING_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 9 </acctID>
+              <balance> BLAKE2_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+           ...
+          </accounts>
+          <txOrder> _ </txOrder>
+          <txPending> _ </txPending>
+          <messages> _ </messages>
+        </network>
+      </ethereum>
+      requires #rangeAddress(ACCT_ID)
+       andBool ACCT_ID =/=Int 0
+       andBool #notPrecompileAddress(ACCT_ID)
+       andBool #rangeAddress(CALLER_ID)
+       andBool #rangeAddress(ORIGIN_ID)
+       andBool #rangeUInt(256, TIME)
+       andBool #rangeUInt(256, ACCT_ID_balance)
+       andBool #rangeUInt(256, ECREC_BAL)
+       andBool #rangeUInt(256, SHA256_BAL)
+       andBool #rangeUInt(256, RIP160_BAL)
+       andBool #rangeUInt(256, ID_BAL)
+       andBool #rangeUInt(256, MODEXP_BAL)
+       andBool #rangeUInt(256, ECADD_BAL)
+       andBool #rangeUInt(256, ECMUL_BAL)
+       andBool #rangeUInt(256, ECPAIRING_BAL)
+       andBool #rangeUInt(256, BLAKE2_BAL)
+       andBool VCallDepth <=Int 1024
+       andBool #rangeUInt(256, VCallValue)
+       andBool #rangeUInt(256, VChainId)
+
+       andBool (#rangeAddress(ABI_src)
+       andBool (#rangeAddress(ABI_dst)
+       andBool (#rangeUInt(256, ABI_wad)
+       andBool (#rangeUInt(256, Gem_s)
+       andBool (#rangeUInt(256, Gem_d)
+       andBool (#rangeUInt(256, Allowance)
+       andBool (#rangeAddress(Owner)
+       andBool (#rangeBool(Stopped)
+       andBool ((#sizeByteArray(CD) <=Int 1250000000)
+       andBool ((#notPrecompileAddress(Owner))
+       andBool ((ABI_src =/=Int ABI_dst)
+       andBool ((ABI_src =/=Int CALLER_ID)
+       andBool (#rangeUInt(256, Junk_0)
+       andBool (#rangeUInt(256, Junk_1)
+       andBool (#rangeUInt(256, Junk_2)
+       andBool (#rangeUInt(256, Junk_3)
+       andBool (((#rangeUInt(256, Gem_s -Int ABI_wad)))
+       andBool (((#rangeUInt(256, Gem_d +Int ABI_wad)))
+       andBool (((Allowance ==Int maxUInt256) orBool (ABI_wad <=Int Allowance))
+       andBool ((VCallValue ==Int 0)
+       andBool ((Stopped ==Int 0))))))))))))))))))))))
+
+       andBool #lookup(ACCT_ID_STORAGE, #DSToken.allowance[ABI_src][CALLER_ID]) ==Int Allowance
+       andBool #lookup(ACCT_ID_STORAGE, #DSToken.balances[ABI_src]) ==Int Gem_s
+       andBool #lookup(ACCT_ID_STORAGE, #DSToken.balances[ABI_dst]) ==Int Gem_d
+       andBool #lookup(ACCT_ID_STORAGE, #DSToken.owner_stopped) ==Int #WordPackAddrUInt8(Owner, Stopped)
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #DSToken.allowance[ABI_src][CALLER_ID]) ==Int Junk_0
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #DSToken.balances[ABI_src]) ==Int Junk_1
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #DSToken.balances[ABI_dst]) ==Int Junk_2
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #DSToken.owner_stopped) ==Int Junk_3
+       andBool #DSToken.allowance[ABI_src][CALLER_ID] =/=Int #DSToken.balances[ABI_src]
+       andBool #DSToken.allowance[ABI_src][CALLER_ID] =/=Int #DSToken.balances[ABI_dst]
+       andBool #DSToken.allowance[ABI_src][CALLER_ID] =/=Int #DSToken.owner_stopped
+       andBool #DSToken.balances[ABI_src] =/=Int #DSToken.balances[ABI_dst]
+       andBool #DSToken.balances[ABI_src] =/=Int #DSToken.owner_stopped
+       andBool #DSToken.balances[ABI_dst] =/=Int #DSToken.owner_stopped
+    [trusted, matching(infGas)]
+
+
+endmodule

--- a/tests/specs/mcd/flopper-dent-guy-same-pass-rough-spec.k
+++ b/tests/specs/mcd/flopper-dent-guy-same-pass-rough-spec.k
@@ -1,0 +1,633 @@
+requires "verification.k"
+
+module FLOPPER-DENT-GUY-SAME-PASS-ROUGH-SPEC
+    imports VERIFICATION
+
+    // Flopper_dent-guy-same
+    claim [Flopper.dent-guy-same.pass.rough]:
+      <k> #execute ~> CONTINUATION => #halt ~> CONTINUATION </k>
+      <exit-code> 1 </exit-code>
+      <mode> NORMAL </mode>
+      <schedule> ISTANBUL </schedule>
+      <ethereum>
+        <evm>
+          <output> .ByteArray </output>
+          <statusCode> _ => EVMC_SUCCESS </statusCode>
+          <endPC> _ => ?_ </endPC>
+          <callStack> _VCallStack </callStack>
+          <interimStates> _ </interimStates>
+          <touchedAccounts> _ => ?_ </touchedAccounts>
+          <callState>
+            <program> Flopper_bin_runtime </program>
+            <jumpDests> #computeValidJumpDests(Flopper_bin_runtime) </jumpDests>
+            <id> ACCT_ID </id>
+            <caller> CALLER_ID </caller>
+            <callData> #abiCallData("dent", #uint256(ABI_id), #uint256(ABI_lot), #uint256(ABI_bid)) ++ CD => ?_ </callData>
+            <callValue> VCallValue </callValue>
+            <wordStack> .WordStack => ?_ </wordStack>
+            <localMem> .Memory => ?_ </localMem>
+            <pc> 0 => ?_ </pc>
+            <gas> #gas(VGas) => ?_ </gas>
+            <memoryUsed> 0 => ?_ </memoryUsed>
+            <callGas> _ => ?_ </callGas>
+            <static> false </static>
+            <callDepth> VCallDepth </callDepth>
+          </callState>
+          <substate>
+            <selfDestruct> _VSelfDestruct </selfDestruct>
+            <log> _ => ?_ </log>
+            <refund> _Vrefund => ?_ </refund>
+          </substate>
+          <gasPrice> _ </gasPrice>
+          <origin> ORIGIN_ID </origin>
+          <blockhashes> _ </blockhashes>
+          <block>
+            <previousHash> _ </previousHash>
+            <ommersHash> _ </ommersHash>
+            <coinbase> _ </coinbase>
+            <stateRoot> _ </stateRoot>
+            <transactionsRoot> _ </transactionsRoot>
+            <receiptsRoot> _ </receiptsRoot>
+            <logsBloom> _ </logsBloom>
+            <difficulty> _ </difficulty>
+            <number> _BLOCK_NUMBER </number>
+            <gasLimit> _ </gasLimit>
+            <gasUsed> _ </gasUsed>
+            <timestamp> TIME </timestamp>
+            <extraData> _ </extraData>
+            <mixHash> _ </mixHash>
+            <blockNonce> _ </blockNonce>
+            <ommerBlockHeaders> _ </ommerBlockHeaders>
+          </block>
+        </evm>
+        <network>
+          <chainID> VChainId </chainID>
+          <activeAccounts> SetItem(ACCT_ID)
+          SetItem(1)
+          SetItem(2)
+          SetItem(3)
+          SetItem(4)
+          SetItem(5)
+          SetItem(6)
+          SetItem(7)
+          SetItem(8)
+          SetItem(9) _ </activeAccounts>
+          <accounts>
+            <account>
+              <acctID> ACCT_ID </acctID>
+              <balance> ACCT_ID_balance </balance>
+              <code> Flopper_bin_runtime </code>
+              <storage> ACCT_ID_STORAGE => ACCT_ID_STORAGE [ #Flopper.bids[ABI_id].lot <- ABI_lot ] [ #Flopper.bids[ABI_id].guy_tic_end <- #WordPackAddrUInt48UInt48(Guy, TIME +Int Ttl, End) ] </storage>
+              <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
+              <nonce> _Nonce_Flopper => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> 1 </acctID>
+              <balance> ECREC_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 2 </acctID>
+              <balance> SHA256_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 3 </acctID>
+              <balance> RIP160_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 4 </acctID>
+              <balance> ID_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 5 </acctID>
+              <balance> MODEXP_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 6 </acctID>
+              <balance> ECADD_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 7 </acctID>
+              <balance> ECMUL_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 8 </acctID>
+              <balance> ECPAIRING_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 9 </acctID>
+              <balance> BLAKE2_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+           ...
+          </accounts>
+          <txOrder> _ </txOrder>
+          <txPending> _ </txPending>
+          <messages> _ </messages>
+        </network>
+      </ethereum>
+      requires #rangeAddress(ACCT_ID)
+       andBool ACCT_ID =/=Int 0
+       andBool #notPrecompileAddress(ACCT_ID)
+       andBool #rangeAddress(CALLER_ID)
+       andBool #rangeAddress(ORIGIN_ID)
+       andBool #rangeUInt(256, TIME)
+       andBool #rangeUInt(256, ACCT_ID_balance)
+       andBool #rangeUInt(256, ECREC_BAL)
+       andBool #rangeUInt(256, SHA256_BAL)
+       andBool #rangeUInt(256, RIP160_BAL)
+       andBool #rangeUInt(256, ID_BAL)
+       andBool #rangeUInt(256, MODEXP_BAL)
+       andBool #rangeUInt(256, ECADD_BAL)
+       andBool #rangeUInt(256, ECMUL_BAL)
+       andBool #rangeUInt(256, ECPAIRING_BAL)
+       andBool #rangeUInt(256, BLAKE2_BAL)
+       andBool VCallDepth <=Int 1024
+       andBool #rangeUInt(256, VCallValue)
+       andBool #rangeUInt(256, VChainId)
+
+       andBool (#rangeUInt(256, ABI_id)
+       andBool (#rangeUInt(256, ABI_lot)
+       andBool (#rangeUInt(256, ABI_bid)
+       andBool (#rangeUInt(256, Live)
+       andBool (#rangeAddress(Vat)
+       andBool (#rangeUInt(256, Beg)
+       andBool (#rangeUInt(48, Ttl)
+       andBool (#rangeUInt(48, Tau)
+       andBool (#rangeUInt(256, Bid)
+       andBool (#rangeUInt(256, Lot)
+       andBool (#rangeAddress(Guy)
+       andBool (#rangeUInt(48, Tic)
+       andBool (#rangeUInt(48, End)
+       andBool ((#sizeByteArray(CD) <=Int 1250000000)
+       andBool ((#notPrecompileAddress(Vat))
+       andBool ((#notPrecompileAddress(Guy))
+       andBool ((CALLER_ID =/=Int ACCT_ID)
+       andBool ((CALLER_ID ==Int Guy)
+       andBool ((#rangeUInt(48, TIME))
+       andBool (#rangeUInt(256, Junk_0)
+       andBool (#rangeUInt(256, Junk_1)
+       andBool (#rangeUInt(256, Junk_2)
+       andBool (#rangeUInt(256, Junk_3)
+       andBool (#rangeUInt(256, Junk_4)
+       andBool (#rangeUInt(256, Junk_5)
+       andBool (#rangeUInt(256, Junk_6)
+       andBool (((Live ==Int 1))
+       andBool (((Guy =/=Int 0))
+       andBool (((Tic >Int TIME orBool Tic ==Int 0))
+       andBool (((End >Int TIME))
+       andBool (((ABI_bid ==Int Bid))
+       andBool (((ABI_lot <Int  Lot))
+       andBool (((Lot *Int #Wad <=Int maxUInt256))
+       andBool (((Beg *Int ABI_lot <=Int Lot *Int #Wad))
+       andBool (((VCallValue ==Int 0))
+       andBool ((#rangeUInt(48, TIME +Int Ttl))))))))))))))))))))))))))))))))))))))
+
+       andBool #lookup(ACCT_ID_STORAGE, #Flopper.live) ==Int Live
+       andBool #lookup(ACCT_ID_STORAGE, #Flopper.vat) ==Int Vat
+       andBool #lookup(ACCT_ID_STORAGE, #Flopper.beg) ==Int Beg
+       andBool #lookup(ACCT_ID_STORAGE, #Flopper.ttl_tau) ==Int #WordPackUInt48UInt48(Ttl, Tau)
+       andBool #lookup(ACCT_ID_STORAGE, #Flopper.bids[ABI_id].bid) ==Int Bid
+       andBool #lookup(ACCT_ID_STORAGE, #Flopper.bids[ABI_id].lot) ==Int Lot
+       andBool #lookup(ACCT_ID_STORAGE, #Flopper.bids[ABI_id].guy_tic_end) ==Int #WordPackAddrUInt48UInt48(Guy, Tic, End)
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Flopper.live) ==Int Junk_0
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Flopper.vat) ==Int Junk_1
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Flopper.beg) ==Int Junk_2
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Flopper.ttl_tau) ==Int Junk_3
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Flopper.bids[ABI_id].bid) ==Int Junk_4
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Flopper.bids[ABI_id].lot) ==Int Junk_5
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Flopper.bids[ABI_id].guy_tic_end) ==Int Junk_6
+       andBool #Flopper.live =/=Int #Flopper.vat
+       andBool #Flopper.live =/=Int #Flopper.beg
+       andBool #Flopper.live =/=Int #Flopper.ttl_tau
+       andBool #Flopper.live =/=Int #Flopper.bids[ABI_id].bid
+       andBool #Flopper.live =/=Int #Flopper.bids[ABI_id].lot
+       andBool #Flopper.live =/=Int #Flopper.bids[ABI_id].guy_tic_end
+       andBool #Flopper.vat =/=Int #Flopper.beg
+       andBool #Flopper.vat =/=Int #Flopper.ttl_tau
+       andBool #Flopper.vat =/=Int #Flopper.bids[ABI_id].bid
+       andBool #Flopper.vat =/=Int #Flopper.bids[ABI_id].lot
+       andBool #Flopper.vat =/=Int #Flopper.bids[ABI_id].guy_tic_end
+       andBool #Flopper.beg =/=Int #Flopper.ttl_tau
+       andBool #Flopper.beg =/=Int #Flopper.bids[ABI_id].bid
+       andBool #Flopper.beg =/=Int #Flopper.bids[ABI_id].lot
+       andBool #Flopper.beg =/=Int #Flopper.bids[ABI_id].guy_tic_end
+       andBool #Flopper.ttl_tau =/=Int #Flopper.bids[ABI_id].bid
+       andBool #Flopper.ttl_tau =/=Int #Flopper.bids[ABI_id].lot
+       andBool #Flopper.ttl_tau =/=Int #Flopper.bids[ABI_id].guy_tic_end
+       andBool #Flopper.bids[ABI_id].bid =/=Int #Flopper.bids[ABI_id].lot
+       andBool #Flopper.bids[ABI_id].bid =/=Int #Flopper.bids[ABI_id].guy_tic_end
+       andBool #Flopper.bids[ABI_id].lot =/=Int #Flopper.bids[ABI_id].guy_tic_end
+
+    // Flopper_muluu
+    claim [Flopper.muluu.pass]:
+      <k> #execute ~> CONTINUATION => #execute ~> CONTINUATION </k>
+      <exit-code> 1 </exit-code>
+      <mode> NORMAL </mode>
+      <schedule> ISTANBUL </schedule>
+      <ethereum>
+        <evm>
+          <output> VOutput => VOutput </output>
+          <statusCode> _ => ?_ </statusCode>
+          <endPC> _ => ?_ </endPC>
+          <callStack> _VCallStack </callStack>
+          <interimStates> _ </interimStates>
+          <touchedAccounts> _ => ?_ </touchedAccounts>
+          <callState>
+            <program> Flopper_bin_runtime </program>
+            <jumpDests> #computeValidJumpDests(Flopper_bin_runtime) </jumpDests>
+            <id> ACCT_ID </id>
+            <caller> CALLER_ID </caller>
+            <callData> _ => ?_ </callData>
+            <callValue> VCallValue </callValue>
+            <wordStack> ABI_y : ABI_x : JMPTO : WS  =>  JMPTO : ABI_x *Int ABI_y : WS </wordStack>
+            <localMem> _ </localMem>
+            <pc> 8685 => 8728 </pc>
+            <gas> #gas(VGas) => #if ABI_y ==Int 0
+              #then   #gas ( ( VGas +Int -54 ) )
+              #else   #gas ( ( VGas +Int -106 ) )
+            #fi </gas>
+            <memoryUsed> VMemoryUsed </memoryUsed>
+            <callGas> _ => ?_ </callGas>
+            <static> _ </static>
+            <callDepth> VCallDepth </callDepth>
+          </callState>
+          <substate>
+            <selfDestruct> _VSelfDestruct </selfDestruct>
+            <log> _ => ?_ </log>
+            <refund> _Vrefund => ?_ </refund>
+          </substate>
+          <gasPrice> _ </gasPrice>
+          <origin> ORIGIN_ID </origin>
+          <blockhashes> _ </blockhashes>
+          <block>
+            <previousHash> _ </previousHash>
+            <ommersHash> _ </ommersHash>
+            <coinbase> _ </coinbase>
+            <stateRoot> _ </stateRoot>
+            <transactionsRoot> _ </transactionsRoot>
+            <receiptsRoot> _ </receiptsRoot>
+            <logsBloom> _ </logsBloom>
+            <difficulty> _ </difficulty>
+            <number> _BLOCK_NUMBER </number>
+            <gasLimit> _ </gasLimit>
+            <gasUsed> _ </gasUsed>
+            <timestamp> TIME </timestamp>
+            <extraData> _ </extraData>
+            <mixHash> _ </mixHash>
+            <blockNonce> _ </blockNonce>
+            <ommerBlockHeaders> _ </ommerBlockHeaders>
+          </block>
+        </evm>
+        <network>
+          <chainID> VChainId </chainID>
+          <activeAccounts> SetItem(ACCT_ID)
+          SetItem(1)
+          SetItem(2)
+          SetItem(3)
+          SetItem(4)
+          SetItem(5)
+          SetItem(6)
+          SetItem(7)
+          SetItem(8)
+          SetItem(9) _ </activeAccounts>
+          <accounts>
+            <account>
+              <acctID> ACCT_ID </acctID>
+              <balance> ACCT_ID_balance </balance>
+              <code> Flopper_bin_runtime </code>
+              <storage> ACCT_ID_STORAGE => ACCT_ID_STORAGE  </storage>
+              <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
+              <nonce> _Nonce_Flopper => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> 1 </acctID>
+              <balance> ECREC_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 2 </acctID>
+              <balance> SHA256_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 3 </acctID>
+              <balance> RIP160_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 4 </acctID>
+              <balance> ID_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 5 </acctID>
+              <balance> MODEXP_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 6 </acctID>
+              <balance> ECADD_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 7 </acctID>
+              <balance> ECMUL_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 8 </acctID>
+              <balance> ECPAIRING_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 9 </acctID>
+              <balance> BLAKE2_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+           ...
+          </accounts>
+          <txOrder> _ </txOrder>
+          <txPending> _ </txPending>
+          <messages> _ </messages>
+        </network>
+      </ethereum>
+      requires #rangeAddress(ACCT_ID)
+       andBool ACCT_ID =/=Int 0
+       andBool #notPrecompileAddress(ACCT_ID)
+       andBool #rangeAddress(CALLER_ID)
+       andBool #rangeAddress(ORIGIN_ID)
+       andBool #rangeUInt(256, TIME)
+       andBool #rangeUInt(256, ACCT_ID_balance)
+       andBool #rangeUInt(256, ECREC_BAL)
+       andBool #rangeUInt(256, SHA256_BAL)
+       andBool #rangeUInt(256, RIP160_BAL)
+       andBool #rangeUInt(256, ID_BAL)
+       andBool #rangeUInt(256, MODEXP_BAL)
+       andBool #rangeUInt(256, ECADD_BAL)
+       andBool #rangeUInt(256, ECMUL_BAL)
+       andBool #rangeUInt(256, ECPAIRING_BAL)
+       andBool #rangeUInt(256, BLAKE2_BAL)
+       andBool VCallDepth <=Int 1024
+       andBool #rangeUInt(256, VCallValue)
+       andBool #rangeUInt(256, VChainId)
+
+       andBool (#rangeUInt(256, ABI_x)
+       andBool (#rangeUInt(256, ABI_y)
+       andBool ((#sizeWordStack(WS) <=Int 1000)
+       andBool (#rangeUInt(256, VMemoryUsed)
+       andBool ((#rangeUInt(256, ABI_x *Int ABI_y)))))))
+
+
+    [trusted, matching(infGas)]
+
+
+    // Flopper_addu48u48
+    claim [Flopper.addu48u48.pass]:
+      <k> #execute ~> CONTINUATION => #execute ~> CONTINUATION </k>
+      <exit-code> 1 </exit-code>
+      <mode> NORMAL </mode>
+      <schedule> ISTANBUL </schedule>
+      <ethereum>
+        <evm>
+          <output> VOutput => VOutput </output>
+          <statusCode> _ => ?_ </statusCode>
+          <endPC> _ => ?_ </endPC>
+          <callStack> _VCallStack </callStack>
+          <interimStates> _ </interimStates>
+          <touchedAccounts> _ => ?_ </touchedAccounts>
+          <callState>
+            <program> Flopper_bin_runtime </program>
+            <jumpDests> #computeValidJumpDests(Flopper_bin_runtime) </jumpDests>
+            <id> ACCT_ID </id>
+            <caller> CALLER_ID </caller>
+            <callData> _ => ?_ </callData>
+            <callValue> VCallValue </callValue>
+            <wordStack> ABI_y : ABI_x : JMPTO : WS  =>  JMPTO : ABI_x +Int ABI_y : WS </wordStack>
+            <localMem> _ </localMem>
+            <pc> 8757 => 8798 </pc>
+            <gas> #gas(VGas) => #gas ( ( VGas +Int -66 ) ) </gas>
+            <memoryUsed> VMemoryUsed </memoryUsed>
+            <callGas> _ => ?_ </callGas>
+            <static> _ </static>
+            <callDepth> VCallDepth </callDepth>
+          </callState>
+          <substate>
+            <selfDestruct> _VSelfDestruct </selfDestruct>
+            <log> _ => ?_ </log>
+            <refund> _Vrefund => ?_ </refund>
+          </substate>
+          <gasPrice> _ </gasPrice>
+          <origin> ORIGIN_ID </origin>
+          <blockhashes> _ </blockhashes>
+          <block>
+            <previousHash> _ </previousHash>
+            <ommersHash> _ </ommersHash>
+            <coinbase> _ </coinbase>
+            <stateRoot> _ </stateRoot>
+            <transactionsRoot> _ </transactionsRoot>
+            <receiptsRoot> _ </receiptsRoot>
+            <logsBloom> _ </logsBloom>
+            <difficulty> _ </difficulty>
+            <number> _BLOCK_NUMBER </number>
+            <gasLimit> _ </gasLimit>
+            <gasUsed> _ </gasUsed>
+            <timestamp> TIME </timestamp>
+            <extraData> _ </extraData>
+            <mixHash> _ </mixHash>
+            <blockNonce> _ </blockNonce>
+            <ommerBlockHeaders> _ </ommerBlockHeaders>
+          </block>
+        </evm>
+        <network>
+          <chainID> VChainId </chainID>
+          <activeAccounts> SetItem(ACCT_ID)
+          SetItem(1)
+          SetItem(2)
+          SetItem(3)
+          SetItem(4)
+          SetItem(5)
+          SetItem(6)
+          SetItem(7)
+          SetItem(8)
+          SetItem(9) _ </activeAccounts>
+          <accounts>
+            <account>
+              <acctID> ACCT_ID </acctID>
+              <balance> ACCT_ID_balance </balance>
+              <code> Flopper_bin_runtime </code>
+              <storage> ACCT_ID_STORAGE => ACCT_ID_STORAGE  </storage>
+              <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
+              <nonce> _Nonce_Flopper => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> 1 </acctID>
+              <balance> ECREC_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 2 </acctID>
+              <balance> SHA256_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 3 </acctID>
+              <balance> RIP160_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 4 </acctID>
+              <balance> ID_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 5 </acctID>
+              <balance> MODEXP_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 6 </acctID>
+              <balance> ECADD_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 7 </acctID>
+              <balance> ECMUL_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 8 </acctID>
+              <balance> ECPAIRING_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 9 </acctID>
+              <balance> BLAKE2_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+           ...
+          </accounts>
+          <txOrder> _ </txOrder>
+          <txPending> _ </txPending>
+          <messages> _ </messages>
+        </network>
+      </ethereum>
+      requires #rangeAddress(ACCT_ID)
+       andBool ACCT_ID =/=Int 0
+       andBool #notPrecompileAddress(ACCT_ID)
+       andBool #rangeAddress(CALLER_ID)
+       andBool #rangeAddress(ORIGIN_ID)
+       andBool #rangeUInt(256, TIME)
+       andBool #rangeUInt(256, ACCT_ID_balance)
+       andBool #rangeUInt(256, ECREC_BAL)
+       andBool #rangeUInt(256, SHA256_BAL)
+       andBool #rangeUInt(256, RIP160_BAL)
+       andBool #rangeUInt(256, ID_BAL)
+       andBool #rangeUInt(256, MODEXP_BAL)
+       andBool #rangeUInt(256, ECADD_BAL)
+       andBool #rangeUInt(256, ECMUL_BAL)
+       andBool #rangeUInt(256, ECPAIRING_BAL)
+       andBool #rangeUInt(256, BLAKE2_BAL)
+       andBool VCallDepth <=Int 1024
+       andBool #rangeUInt(256, VCallValue)
+       andBool #rangeUInt(256, VChainId)
+
+       andBool (#rangeUInt(48, ABI_x)
+       andBool (#rangeUInt(48, ABI_y)
+       andBool ((#sizeWordStack(WS) <=Int 100)
+       andBool (#rangeUInt(256, VMemoryUsed)
+       andBool ((#rangeUInt(48, ABI_x +Int ABI_y)))))))
+
+
+    [trusted, matching(infGas)]
+
+
+endmodule

--- a/tests/specs/mcd/flopper-kick-pass-rough-spec.k
+++ b/tests/specs/mcd/flopper-kick-pass-rough-spec.k
@@ -1,0 +1,435 @@
+requires "verification.k"
+
+module FLOPPER-KICK-PASS-ROUGH-SPEC
+    imports VERIFICATION
+
+    // Flopper_kick
+    claim [Flopper.kick.pass.rough]:
+      <k> #execute ~> CONTINUATION => #halt ~> CONTINUATION </k>
+      <exit-code> 1 </exit-code>
+      <mode> NORMAL </mode>
+      <schedule> ISTANBUL </schedule>
+      <ethereum>
+        <evm>
+          <output> _ => #buf(32, 1 +Int Kicks) </output>
+          <statusCode> _ => EVMC_SUCCESS </statusCode>
+          <endPC> _ => ?_ </endPC>
+          <callStack> _VCallStack </callStack>
+          <interimStates> _ </interimStates>
+          <touchedAccounts> _ => ?_ </touchedAccounts>
+          <callState>
+            <program> Flopper_bin_runtime </program>
+            <jumpDests> #computeValidJumpDests(Flopper_bin_runtime) </jumpDests>
+            <id> ACCT_ID </id>
+            <caller> CALLER_ID </caller>
+            <callData> #abiCallData("kick", #address(ABI_gal), #uint256(ABI_lot), #uint256(ABI_bid)) ++ CD => ?_ </callData>
+            <callValue> VCallValue </callValue>
+            <wordStack> .WordStack => ?_ </wordStack>
+            <localMem> .Memory => ?_ </localMem>
+            <pc> 0 => ?_ </pc>
+            <gas> #gas(VGas) => ?_ </gas>
+            <memoryUsed> 0 => ?_ </memoryUsed>
+            <callGas> _ => ?_ </callGas>
+            <static> false </static>
+            <callDepth> VCallDepth </callDepth>
+          </callState>
+          <substate>
+            <selfDestruct> _VSelfDestruct </selfDestruct>
+            <log> _ => ?_ </log>
+            <refund> _Vrefund => ?_ </refund>
+          </substate>
+          <gasPrice> _ </gasPrice>
+          <origin> ORIGIN_ID </origin>
+          <blockhashes> _ </blockhashes>
+          <block>
+            <previousHash> _ </previousHash>
+            <ommersHash> _ </ommersHash>
+            <coinbase> _ </coinbase>
+            <stateRoot> _ </stateRoot>
+            <transactionsRoot> _ </transactionsRoot>
+            <receiptsRoot> _ </receiptsRoot>
+            <logsBloom> _ </logsBloom>
+            <difficulty> _ </difficulty>
+            <number> _BLOCK_NUMBER </number>
+            <gasLimit> _ </gasLimit>
+            <gasUsed> _ </gasUsed>
+            <timestamp> TIME </timestamp>
+            <extraData> _ </extraData>
+            <mixHash> _ </mixHash>
+            <blockNonce> _ </blockNonce>
+            <ommerBlockHeaders> _ </ommerBlockHeaders>
+          </block>
+        </evm>
+        <network>
+          <chainID> VChainId </chainID>
+          <activeAccounts> SetItem(ACCT_ID)
+          SetItem(1)
+          SetItem(2)
+          SetItem(3)
+          SetItem(4)
+          SetItem(5)
+          SetItem(6)
+          SetItem(7)
+          SetItem(8)
+          SetItem(9) _ </activeAccounts>
+          <accounts>
+            <account>
+              <acctID> ACCT_ID </acctID>
+              <balance> ACCT_ID_balance </balance>
+              <code> Flopper_bin_runtime </code>
+              <storage> ACCT_ID_STORAGE => ACCT_ID_STORAGE [ #Flopper.kicks <- 1 +Int Kicks ]  [ #Flopper.bids[1 +Int Kicks].bid <- ABI_bid ] [ #Flopper.bids[1 +Int Kicks].lot <- ABI_lot ] [ #Flopper.bids[1 +Int Kicks].guy_tic_end <- #WordPackAddrUInt48UInt48(ABI_gal, Old_tic, TIME +Int Tau) ] </storage>
+              <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
+              <nonce> _Nonce_Flopper => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> 1 </acctID>
+              <balance> ECREC_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 2 </acctID>
+              <balance> SHA256_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 3 </acctID>
+              <balance> RIP160_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 4 </acctID>
+              <balance> ID_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 5 </acctID>
+              <balance> MODEXP_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 6 </acctID>
+              <balance> ECADD_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 7 </acctID>
+              <balance> ECMUL_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 8 </acctID>
+              <balance> ECPAIRING_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 9 </acctID>
+              <balance> BLAKE2_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+           ...
+          </accounts>
+          <txOrder> _ </txOrder>
+          <txPending> _ </txPending>
+          <messages> _ </messages>
+        </network>
+      </ethereum>
+      requires #rangeAddress(ACCT_ID)
+       andBool ACCT_ID =/=Int 0
+       andBool #notPrecompileAddress(ACCT_ID)
+       andBool #rangeAddress(CALLER_ID)
+       andBool #rangeAddress(ORIGIN_ID)
+       andBool #rangeUInt(256, TIME)
+       andBool #rangeUInt(256, ACCT_ID_balance)
+       andBool #rangeUInt(256, ECREC_BAL)
+       andBool #rangeUInt(256, SHA256_BAL)
+       andBool #rangeUInt(256, RIP160_BAL)
+       andBool #rangeUInt(256, ID_BAL)
+       andBool #rangeUInt(256, MODEXP_BAL)
+       andBool #rangeUInt(256, ECADD_BAL)
+       andBool #rangeUInt(256, ECMUL_BAL)
+       andBool #rangeUInt(256, ECPAIRING_BAL)
+       andBool #rangeUInt(256, BLAKE2_BAL)
+       andBool VCallDepth <=Int 1024
+       andBool #rangeUInt(256, VCallValue)
+       andBool #rangeUInt(256, VChainId)
+
+       andBool (#rangeAddress(ABI_gal)
+       andBool (#rangeUInt(256, ABI_lot)
+       andBool (#rangeUInt(256, ABI_bid)
+       andBool (#rangeUInt(256, Live)
+       andBool (#rangeUInt(256, Kicks)
+       andBool (#rangeUInt(48, Ttl)
+       andBool (#rangeUInt(48, Tau)
+       andBool (#rangeUInt(256, Old_lot)
+       andBool (#rangeUInt(256, Old_bid)
+       andBool (#rangeAddress(Old_guy)
+       andBool (#rangeUInt(48, Old_tic)
+       andBool (#rangeUInt(48, Old_end)
+       andBool (#rangeUInt(256, Ward)
+       andBool ((#sizeByteArray(CD) <=Int 1250000000)
+       andBool ((#notPrecompileAddress(Old_guy))
+       andBool ((#rangeUInt(48, TIME))
+       andBool (#rangeUInt(256, Junk_0)
+       andBool (#rangeUInt(256, Junk_1)
+       andBool (#rangeUInt(256, Junk_2)
+       andBool (#rangeUInt(256, Junk_3)
+       andBool (#rangeUInt(256, Junk_4)
+       andBool (#rangeUInt(256, Junk_5)
+       andBool (#rangeUInt(256, Junk_6)
+       andBool ((((Ward ==Int 1)))
+       andBool ((((Live ==Int 1)))
+       andBool ((((VCallValue ==Int 0)))
+       andBool (((#rangeUInt(256, Kicks +Int 1)))
+       andBool ((#rangeUInt(48, TIME +Int Tau))))))))))))))))))))))))))))))
+
+       andBool #lookup(ACCT_ID_STORAGE, #Flopper.wards[CALLER_ID]) ==Int Ward
+       andBool #lookup(ACCT_ID_STORAGE, #Flopper.live) ==Int Live
+       andBool #lookup(ACCT_ID_STORAGE, #Flopper.kicks) ==Int Kicks
+       andBool #lookup(ACCT_ID_STORAGE, #Flopper.ttl_tau) ==Int #WordPackUInt48UInt48(Ttl, Tau)
+       andBool #lookup(ACCT_ID_STORAGE, #Flopper.bids[1 +Int Kicks].bid) ==Int Old_bid
+       andBool #lookup(ACCT_ID_STORAGE, #Flopper.bids[1 +Int Kicks].lot) ==Int Old_lot
+       andBool #lookup(ACCT_ID_STORAGE, #Flopper.bids[1 +Int Kicks].guy_tic_end) ==Int #WordPackAddrUInt48UInt48(Old_guy, Old_tic, Old_end)
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Flopper.wards[CALLER_ID]) ==Int Junk_0
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Flopper.live) ==Int Junk_1
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Flopper.kicks) ==Int Junk_2
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Flopper.ttl_tau) ==Int Junk_3
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Flopper.bids[1 +Int Kicks].bid) ==Int Junk_4
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Flopper.bids[1 +Int Kicks].lot) ==Int Junk_5
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Flopper.bids[1 +Int Kicks].guy_tic_end) ==Int Junk_6
+       andBool #Flopper.wards[CALLER_ID] =/=Int #Flopper.live
+       andBool #Flopper.wards[CALLER_ID] =/=Int #Flopper.kicks
+       andBool #Flopper.wards[CALLER_ID] =/=Int #Flopper.ttl_tau
+       andBool #Flopper.wards[CALLER_ID] =/=Int #Flopper.bids[1 +Int Kicks].bid
+       andBool #Flopper.wards[CALLER_ID] =/=Int #Flopper.bids[1 +Int Kicks].lot
+       andBool #Flopper.wards[CALLER_ID] =/=Int #Flopper.bids[1 +Int Kicks].guy_tic_end
+       andBool #Flopper.live =/=Int #Flopper.kicks
+       andBool #Flopper.live =/=Int #Flopper.ttl_tau
+       andBool #Flopper.live =/=Int #Flopper.bids[1 +Int Kicks].bid
+       andBool #Flopper.live =/=Int #Flopper.bids[1 +Int Kicks].lot
+       andBool #Flopper.live =/=Int #Flopper.bids[1 +Int Kicks].guy_tic_end
+       andBool #Flopper.kicks =/=Int #Flopper.ttl_tau
+       andBool #Flopper.kicks =/=Int #Flopper.bids[1 +Int Kicks].bid
+       andBool #Flopper.kicks =/=Int #Flopper.bids[1 +Int Kicks].lot
+       andBool #Flopper.kicks =/=Int #Flopper.bids[1 +Int Kicks].guy_tic_end
+       andBool #Flopper.ttl_tau =/=Int #Flopper.bids[1 +Int Kicks].bid
+       andBool #Flopper.ttl_tau =/=Int #Flopper.bids[1 +Int Kicks].lot
+       andBool #Flopper.ttl_tau =/=Int #Flopper.bids[1 +Int Kicks].guy_tic_end
+       andBool #Flopper.bids[1 +Int Kicks].bid =/=Int #Flopper.bids[1 +Int Kicks].lot
+       andBool #Flopper.bids[1 +Int Kicks].bid =/=Int #Flopper.bids[1 +Int Kicks].guy_tic_end
+       andBool #Flopper.bids[1 +Int Kicks].lot =/=Int #Flopper.bids[1 +Int Kicks].guy_tic_end
+
+    // Flopper_addu48u48
+    claim [Flopper.addu48u48.pass]:
+      <k> #execute ~> CONTINUATION => #execute ~> CONTINUATION </k>
+      <exit-code> 1 </exit-code>
+      <mode> NORMAL </mode>
+      <schedule> ISTANBUL </schedule>
+      <ethereum>
+        <evm>
+          <output> VOutput => VOutput </output>
+          <statusCode> _ => ?_ </statusCode>
+          <endPC> _ => ?_ </endPC>
+          <callStack> _VCallStack </callStack>
+          <interimStates> _ </interimStates>
+          <touchedAccounts> _ => ?_ </touchedAccounts>
+          <callState>
+            <program> Flopper_bin_runtime </program>
+            <jumpDests> #computeValidJumpDests(Flopper_bin_runtime) </jumpDests>
+            <id> ACCT_ID </id>
+            <caller> CALLER_ID </caller>
+            <callData> _ => ?_ </callData>
+            <callValue> VCallValue </callValue>
+            <wordStack> ABI_y : ABI_x : JMPTO : WS  =>  JMPTO : ABI_x +Int ABI_y : WS </wordStack>
+            <localMem> _ </localMem>
+            <pc> 8757 => 8798 </pc>
+            <gas> #gas(VGas) => #gas ( ( VGas +Int -66 ) ) </gas>
+            <memoryUsed> VMemoryUsed </memoryUsed>
+            <callGas> _ => ?_ </callGas>
+            <static> _ </static>
+            <callDepth> VCallDepth </callDepth>
+          </callState>
+          <substate>
+            <selfDestruct> _VSelfDestruct </selfDestruct>
+            <log> _ => ?_ </log>
+            <refund> _Vrefund => ?_ </refund>
+          </substate>
+          <gasPrice> _ </gasPrice>
+          <origin> ORIGIN_ID </origin>
+          <blockhashes> _ </blockhashes>
+          <block>
+            <previousHash> _ </previousHash>
+            <ommersHash> _ </ommersHash>
+            <coinbase> _ </coinbase>
+            <stateRoot> _ </stateRoot>
+            <transactionsRoot> _ </transactionsRoot>
+            <receiptsRoot> _ </receiptsRoot>
+            <logsBloom> _ </logsBloom>
+            <difficulty> _ </difficulty>
+            <number> _BLOCK_NUMBER </number>
+            <gasLimit> _ </gasLimit>
+            <gasUsed> _ </gasUsed>
+            <timestamp> TIME </timestamp>
+            <extraData> _ </extraData>
+            <mixHash> _ </mixHash>
+            <blockNonce> _ </blockNonce>
+            <ommerBlockHeaders> _ </ommerBlockHeaders>
+          </block>
+        </evm>
+        <network>
+          <chainID> VChainId </chainID>
+          <activeAccounts> SetItem(ACCT_ID)
+          SetItem(1)
+          SetItem(2)
+          SetItem(3)
+          SetItem(4)
+          SetItem(5)
+          SetItem(6)
+          SetItem(7)
+          SetItem(8)
+          SetItem(9) _ </activeAccounts>
+          <accounts>
+            <account>
+              <acctID> ACCT_ID </acctID>
+              <balance> ACCT_ID_balance </balance>
+              <code> Flopper_bin_runtime </code>
+              <storage> ACCT_ID_STORAGE => ACCT_ID_STORAGE  </storage>
+              <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
+              <nonce> _Nonce_Flopper => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> 1 </acctID>
+              <balance> ECREC_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 2 </acctID>
+              <balance> SHA256_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 3 </acctID>
+              <balance> RIP160_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 4 </acctID>
+              <balance> ID_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 5 </acctID>
+              <balance> MODEXP_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 6 </acctID>
+              <balance> ECADD_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 7 </acctID>
+              <balance> ECMUL_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 8 </acctID>
+              <balance> ECPAIRING_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 9 </acctID>
+              <balance> BLAKE2_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+           ...
+          </accounts>
+          <txOrder> _ </txOrder>
+          <txPending> _ </txPending>
+          <messages> _ </messages>
+        </network>
+      </ethereum>
+      requires #rangeAddress(ACCT_ID)
+       andBool ACCT_ID =/=Int 0
+       andBool #notPrecompileAddress(ACCT_ID)
+       andBool #rangeAddress(CALLER_ID)
+       andBool #rangeAddress(ORIGIN_ID)
+       andBool #rangeUInt(256, TIME)
+       andBool #rangeUInt(256, ACCT_ID_balance)
+       andBool #rangeUInt(256, ECREC_BAL)
+       andBool #rangeUInt(256, SHA256_BAL)
+       andBool #rangeUInt(256, RIP160_BAL)
+       andBool #rangeUInt(256, ID_BAL)
+       andBool #rangeUInt(256, MODEXP_BAL)
+       andBool #rangeUInt(256, ECADD_BAL)
+       andBool #rangeUInt(256, ECMUL_BAL)
+       andBool #rangeUInt(256, ECPAIRING_BAL)
+       andBool #rangeUInt(256, BLAKE2_BAL)
+       andBool VCallDepth <=Int 1024
+       andBool #rangeUInt(256, VCallValue)
+       andBool #rangeUInt(256, VChainId)
+
+       andBool (#rangeUInt(48, ABI_x)
+       andBool (#rangeUInt(48, ABI_y)
+       andBool ((#sizeWordStack(WS) <=Int 100)
+       andBool (#rangeUInt(256, VMemoryUsed)
+       andBool ((#rangeUInt(48, ABI_x +Int ABI_y)))))))
+
+
+    [trusted, matching(infGas)]
+
+
+endmodule

--- a/tests/specs/mcd/functional-spec.k
+++ b/tests/specs/mcd/functional-spec.k
@@ -1,0 +1,36 @@
+requires "verification.k"
+
+module FUNCTIONAL-SPEC-SYNTAX
+    imports VERIFICATION
+
+    syntax KItem ::= runLemma ( Step ) | doneLemma ( Step )
+ // -------------------------------------------------------
+    rule <k> runLemma(S) => doneLemma(S) ... </k>
+
+    syntax Step ::= Bool | Int
+ // --------------------------
+
+endmodule
+
+module FUNCTIONAL-SPEC
+    imports FUNCTIONAL-SPEC-SYNTAX
+
+    // WordPack
+
+    claim <k> runLemma((GAL |Int (notAddrMask &Int GUY_TIC_END)) modInt pow256) => doneLemma(GAL |Int (notAddrMask &Int GUY_TIC_END)) ... </k>
+      requires #rangeUInt(256, GUY_TIC_END)
+       andBool #rangeAddress(GAL)
+
+    claim <k> runLemma(TIME +Int (TTL_TAU /Int pow48)) => doneLemma(TIME +Int TAU) ... </k>
+      requires TTL_TAU ==Int #WordPackUInt48UInt48(TTL, TAU)
+       andBool #rangeUInt(48, TIME +Int TAU)
+
+    claim <k> runLemma(maxUInt48 &Int ((GAL |Int (notAddrMask &Int GUY_TIC_END)) /Int pow160)) => doneLemma(TIC) ... </k>
+      requires GUY_TIC_END ==Int #WordPackAddrUInt48UInt48(GUY, TIC, END)
+       andBool #rangeAddress(GAL)
+
+    claim <k> runLemma(maxUInt160 &Int (GAL |Int (notAddrMask &Int GUY_TIC_END))) => doneLemma(GAL) ... </k>
+      requires GUY_TIC_END ==Int #WordPackAddrUInt48UInt48(GUY, TIC, END)
+       andBool #rangeAddress(GAL)
+
+endmodule

--- a/tests/specs/mcd/functional-spec.k
+++ b/tests/specs/mcd/functional-spec.k
@@ -17,7 +17,7 @@ module FUNCTIONAL-SPEC
 
     // WordPack
 
-    claim <k> runLemma((GAL |Int (notAddrMask &Int GUY_TIC_END)) modInt pow256) => doneLemma(GAL |Int (notAddrMask &Int GUY_TIC_END)) ... </k>
+    claim <k> runLemma((GAL |Int (maskWordPackAddrUInt48UInt48_1 &Int GUY_TIC_END)) modInt pow256) => doneLemma(GAL |Int (maskWordPackAddrUInt48UInt48_1 &Int GUY_TIC_END)) ... </k>
       requires #rangeUInt(256, GUY_TIC_END)
        andBool #rangeAddress(GAL)
 
@@ -25,24 +25,21 @@ module FUNCTIONAL-SPEC
       requires TTL_TAU ==Int #WordPackUInt48UInt48(TTL, TAU)
        andBool #rangeUInt(48, TIME +Int TAU)
 
-    claim <k> runLemma(maxUInt48 &Int ((GAL |Int (notAddrMask &Int GUY_TIC_END)) /Int pow160)) => doneLemma(TIC) ... </k>
+    claim <k> runLemma(maxUInt48 &Int ((GAL |Int (maskWordPackAddrUInt48UInt48_1 &Int GUY_TIC_END)) /Int pow160)) => doneLemma(TIC) ... </k>
       requires GUY_TIC_END ==Int #WordPackAddrUInt48UInt48(GUY, TIC, END)
        andBool #rangeAddress(GAL)
 
-    claim <k> runLemma(maxUInt160 &Int (GAL |Int (notAddrMask &Int GUY_TIC_END))) => doneLemma(GAL) ... </k>
+    claim <k> runLemma(maxUInt160 &Int (GAL |Int (maskWordPackAddrUInt48UInt48_1 &Int GUY_TIC_END))) => doneLemma(GAL) ... </k>
       requires GUY_TIC_END ==Int #WordPackAddrUInt48UInt48(GUY, TIC, END)
        andBool #rangeAddress(GAL)
 
-    claim <k> runLemma((((TIME +Int (maxUInt48 &Int (TTL_TAU /Int pow48))) *Int pow208) |Int (maxUInt208 &Int (GAL |Int (notAddrMask &Int GUY_TIC_END)))))
-           => doneLemma(#WordPackAddrUInt48UInt48(GAL, TIC, TIME +Int TAU))
-          ...
-          </k>
+    claim <k> runLemma((((TIME +Int (maxUInt48 &Int (TTL_TAU /Int pow48))) *Int pow208) |Int (maxUInt208 &Int (GAL |Int (maskWordPackAddrUInt48UInt48_1 &Int GUY_TIC_END))))) => doneLemma(#WordPackAddrUInt48UInt48(GAL, TIC, TIME +Int TAU)) ... </k>
       requires TTL_TAU     ==Int #WordPackUInt48UInt48(TTL, TAU)
        andBool GUY_TIC_END ==Int #WordPackAddrUInt48UInt48(GUY, TIC, END)
        andBool #rangeAddress(GAL)
        andBool #rangeUInt(48, TIME +Int TAU)
 
-    claim <k> runLemma((((TIME +Int (maxUInt48 &Int TTL_TAU)) *Int pow160) |Int (mask3 &Int GUY_TIC_END))) => doneLemma(#WordPackAddrUInt48UInt48(GUY, TIME +Int TTL, END)) ... </k>
+    claim <k> runLemma((((TIME +Int (maxUInt48 &Int TTL_TAU)) *Int pow160) |Int (maskWordPackAddrUInt48UInt48_2 &Int GUY_TIC_END))) => doneLemma(#WordPackAddrUInt48UInt48(GUY, TIME +Int TTL, END)) ... </k>
       requires TTL_TAU     ==Int #WordPackUInt48UInt48(TTL, TAU)
        andBool GUY_TIC_END ==Int #WordPackAddrUInt48UInt48(GUY, TIC, END)
        andBool #rangeUInt(48, TIME +Int TTL)

--- a/tests/specs/mcd/functional-spec.k
+++ b/tests/specs/mcd/functional-spec.k
@@ -33,4 +33,13 @@ module FUNCTIONAL-SPEC
       requires GUY_TIC_END ==Int #WordPackAddrUInt48UInt48(GUY, TIC, END)
        andBool #rangeAddress(GAL)
 
+    claim <k> runLemma((((TIME +Int (maxUInt48 &Int (TTL_TAU /Int pow48))) *Int pow208) |Int (maxUInt208 &Int (GAL |Int (notAddrMask &Int GUY_TIC_END)))))
+           => doneLemma(#WordPackAddrUInt48UInt48(GAL, TIC, TIME +Int TAU))
+          ...
+          </k>
+      requires TTL_TAU     ==Int #WordPackUInt48UInt48(TTL, TAU)
+       andBool GUY_TIC_END ==Int #WordPackAddrUInt48UInt48(GUY, TIC, END)
+       andBool #rangeAddress(GAL)
+       andBool #rangeUInt(48, TIME +Int TAU)
+
 endmodule

--- a/tests/specs/mcd/functional-spec.k
+++ b/tests/specs/mcd/functional-spec.k
@@ -42,6 +42,11 @@ module FUNCTIONAL-SPEC
        andBool #rangeAddress(GAL)
        andBool #rangeUInt(48, TIME +Int TAU)
 
+    claim <k> runLemma((((TIME +Int (maxUInt48 &Int TTL_TAU)) *Int pow160) |Int (mask3 &Int GUY_TIC_END))) => doneLemma(#WordPackAddrUInt48UInt48(GUY, TIME +Int TTL, END)) ... </k>
+      requires TTL_TAU     ==Int #WordPackUInt48UInt48(TTL, TAU)
+       andBool GUY_TIC_END ==Int #WordPackAddrUInt48UInt48(GUY, TIC, END)
+       andBool #rangeUInt(48, TIME +Int TTL)
+
     // Memory operations
 
     claim <k> runLemma(#range(M:Memory [ 0 := #buf(4, X) ] [ 0 <- 10 ] [ 1 <- 11 ] [ 2 <- 12 ] [ 3 <- 13 ], 0, 4)) => doneLemma(10 : 11 : 12 : 13 : .ByteArray) ... </k>

--- a/tests/specs/mcd/functional-spec.k
+++ b/tests/specs/mcd/functional-spec.k
@@ -7,8 +7,8 @@ module FUNCTIONAL-SPEC-SYNTAX
  // -------------------------------------------------------
     rule <k> runLemma(S) => doneLemma(S) ... </k>
 
-    syntax Step ::= Bool | Int
- // --------------------------
+    syntax Step ::= Bool | Int | ByteArray | Memory
+ // -----------------------------------------------
 
 endmodule
 
@@ -41,5 +41,12 @@ module FUNCTIONAL-SPEC
        andBool GUY_TIC_END ==Int #WordPackAddrUInt48UInt48(GUY, TIC, END)
        andBool #rangeAddress(GAL)
        andBool #rangeUInt(48, TIME +Int TAU)
+
+    // Memory operations
+
+    claim <k> runLemma(#range(M:Memory [ 0 := #buf(4, X) ] [ 0 <- 10 ] [ 1 <- 11 ] [ 2 <- 12 ] [ 3 <- 13 ], 0, 4)) => doneLemma(10 : 11 : 12 : 13 : .ByteArray) ... </k>
+
+    claim <k> runLemma(M:Memory [ 128 := (B1 : B2 : B3 : B4 : _     : .ByteArray) ] [ 132 := BA':ByteArray ]) => doneLemma(M [ 128 := (B1 : B2 : B3 : B4 : .ByteArray) ] [ 132 := BA' ]) ... </k> requires #sizeByteArray(BA') ==Int 32
+    claim <k> runLemma(M:Memory [ 128 := (B1 : B2 : B3 : B4 : _ : _ : .ByteArray) ] [ 132 := BA':ByteArray ]) => doneLemma(M [ 128 := (B1 : B2 : B3 : B4 : .ByteArray) ] [ 132 := BA' ]) ... </k> requires #sizeByteArray(BA') ==Int 32
 
 endmodule

--- a/tests/specs/mcd/verification.k
+++ b/tests/specs/mcd/verification.k
@@ -4,6 +4,11 @@ requires "storage.k"
 requires "../infinite-gas.k"
 requires "word-pack.k"
 
+module VERIFICATION
+    imports VERIFICATION-HASKELL
+    imports VERIFICATION-JAVA
+endmodule
+
 module HASKELL-HASH2 [symbolic, kore]
     imports INT
 
@@ -46,7 +51,45 @@ module VERIFICATION-SYNTAX
 
 endmodule
 
-module VERIFICATION
+module VERIFICATION-HASKELL [symbolic, kore]
+    imports VERIFICATION-COMMON
+
+    // ### flapper-yank-pass-rough
+
+    rule #range(M:Memory [ K <- V ], START, WIDTH) => #range(M [ K := (V : .ByteArray) ], START, WIDTH)
+      requires START <=Int K andBool K +Int 1 ==Int START +Int WIDTH
+       andBool 0 <Int WIDTH andBool 0 <=Int START
+       [concrete(K, V), simplification]
+
+    rule #range(M:Memory [ K <- V ] [ K' := VS':ByteArray ], START, WIDTH) => #range(M [ K := (V : VS') ], START, WIDTH)
+      requires START <=Int K andBool K' +Int #sizeByteArray(VS') ==Int START +Int WIDTH
+       andBool 0 <Int WIDTH andBool 0 <=Int START
+       andBool K +Int 1 ==Int K'
+      [concrete(K, K', V, VS'), simplification]
+
+endmodule
+
+module VERIFICATION-JAVA [symbolic, kast]
+    imports VERIFICATION-COMMON
+
+    // ### flapper-yank-pass-rough
+
+    rule #range(M:Memory [ K <- V ], START, WIDTH) => #range(M [ K := (V : .ByteArray) ], START, WIDTH)
+      requires #isConcrete(K) andBool #isConcrete(V)
+       andBool START <=Int K andBool K +Int 1 ==Int START +Int WIDTH
+       andBool 0 <Int WIDTH andBool 0 <=Int START
+       [simplification]
+
+    rule #range(M:Memory [ K <- V ] [ K' := VS':ByteArray ], START, WIDTH) => #range(M [ K := (V : VS') ], START, WIDTH)
+      requires #isConcrete(K) andBool #isConcrete(K') andBool #isConcrete(V) andBool #isConcrete(VS')
+       andBool START <=Int K andBool K' +Int #sizeByteArray(VS') ==Int START +Int WIDTH
+       andBool 0 <Int WIDTH andBool 0 <=Int START
+       andBool K +Int 1 ==Int K'
+      [simplification]
+
+endmodule
+
+module VERIFICATION-COMMON
     imports VERIFICATION-SYNTAX
     imports INFINITE-GAS
     imports WORD-PACK
@@ -333,19 +376,6 @@ module VERIFICATION
     rule #WordPackAddrUInt48UInt48(ADDR, maxUInt48 &Int (ADDR_UINT48_UINT48 /Int pow160), UINT48_2) => #WordPackAddrUInt48UInt48(ADDR, 0, UINT48_2) requires maxUInt48 &Int (ADDR_UINT48_UINT48 /Int pow160) ==Int 0 [simplification]
 
     // ### flapper-yank-pass-rough
-
-    rule #range(M:Memory [ K <- V ], START, WIDTH) => #range(M [ K := (V : .ByteArray) ], START, WIDTH)
-      requires #isConcrete(K) andBool #isConcrete(V)
-       andBool START <=Int K andBool K +Int 1 ==Int START +Int WIDTH
-       andBool 0 <Int WIDTH andBool 0 <=Int START
-       [simplification]
-
-    rule #range(M:Memory [ K <- V ] [ K' := VS':ByteArray ], START, WIDTH) => #range(M [ K := (V : VS') ], START, WIDTH)
-      requires #isConcrete(K) andBool #isConcrete(K') andBool #isConcrete(V) andBool #isConcrete(VS')
-       andBool START <=Int K andBool K' +Int #sizeByteArray(VS') ==Int START +Int WIDTH
-       andBool 0 <Int WIDTH andBool 0 <=Int START
-       andBool K +Int 1 ==Int K'
-      [simplification]
 
     rule M:Memory [ K := BUF:ByteArray ] [ K' := BUF':ByteArray ] => M [ K := (BUF [ 0 .. K' -Int K ]) ] [ K' := BUF' ]
       requires K <Int K'

--- a/tests/specs/mcd/verification.k
+++ b/tests/specs/mcd/verification.k
@@ -63,11 +63,13 @@ module VERIFICATION-SYNTAX
     // Here we provide the masks which are used by the Solidity compiler, and rules which fold these bitwise updates back up into semantic `#WordPack*` arguments for the purposes of matching the RHS of proofs.
     //
 
-    syntax Int ::= "maskWordPackUInt48UInt48_1" // pow256 -Int pow96 +Int pow48 -Int 1 == 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF000000000000FFFFFFFFFFFF
-                 | "maskWordPackUInt48UInt48_2" // pow256 -Int pow48                   == 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF000000000000
- // --------------------------------------------------------------------------------------------------------------------------------------------------------
+    syntax Int ::= "maskWordPackUInt48UInt48_1" // 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF000000000000FFFFFFFFFFFF
+                 | "maskWordPackUInt48UInt48_2" // 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF000000000000
+                 | "mask3"                      // 0xFFFFFFFFFFFF000000000000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
+ // -----------------------------------------------------------------------------------------------------------------
     rule maskWordPackUInt48UInt48_1 => 115792089237316195423570985008687907853269984665561335876943319951794562400255 [macro]
     rule maskWordPackUInt48UInt48_2 => 115792089237316195423570985008687907853269984665640564039457583726438152929280 [macro]
+    rule mask3                      => 115792089237315784047431654708638870748305248246218003188207458632603225030655 [macro]
 
     rule  UINT48_1             |Int (maskWordPackUInt48UInt48_2 &Int UINT48_UINT48) => #WordPackUInt48UInt48( UINT48_1 , (maskWordPackUInt48UInt48_2 &Int UINT48_UINT48) /Int pow48 ) requires #rangeUInt(96, UINT48_UINT48) andBool #rangeUInt(48, UINT48_1) [simplification]
     rule (UINT48_2 *Int pow48) |Int (maxUInt48                  &Int UINT48_UINT48) => #WordPackUInt48UInt48( maxUInt48 &Int UINT48_UINT48 , UINT48_2                               ) requires #rangeUInt(96, UINT48_UINT48) andBool #rangeUInt(48, UINT48_2) [simplification]
@@ -78,6 +80,8 @@ module VERIFICATION-SYNTAX
     rule (ADDR |Int (notAddrMask &Int ADDR_UINT48_UINT48)) /Int pow160 => ADDR_UINT48_UINT48 /Int pow160 requires #rangeUInt(256, ADDR_UINT48_UINT48) andBool #rangeAddress(ADDR) [simplification]
 
     rule (UINT48_2 *Int pow208) |Int (maxUInt208 &Int ADDR_UINT48_UINT48) => #WordPackAddrUInt48UInt48(maxUInt160 &Int ADDR_UINT48_UINT48, maxUInt48 &Int (ADDR_UINT48_UINT48 /Int pow160), UINT48_2) requires #rangeUInt(256, ADDR_UINT48_UINT48) andBool #rangeUInt(48, UINT48_2) [simplification]
+
+    rule (UINT48_1 *Int pow160) |Int (mask3 &Int ADDR_UINT48_UINT48) => #WordPackAddrUInt48UInt48(maxUInt160 &Int ADDR_UINT48_UINT48, UINT48_1, maxUInt48 &Int (ADDR_UINT48_UINT48 /Int pow208)) requires #rangeUInt(256, ADDR_UINT48_UINT48) andBool #rangeUInt(48, UINT48_1) [simplification]
 
     syntax Int ::= #string2Word ( String ) [function]
  // -------------------------------------------------

--- a/tests/specs/mcd/verification.k
+++ b/tests/specs/mcd/verification.k
@@ -64,7 +64,7 @@ module VERIFICATION
 
     // ### cat-file-addr-pass-rough
 
-    rule notAddrMask &Int ADDR => 0 requires #rangeAddress(ADDR) [simplification]
+    rule maskWordPackAddrUInt48UInt48_1 &Int ADDR => 0 requires #rangeAddress(ADDR) [simplification]
 
     // ### PERFORMANCE: dai-adduu-fail-rough
     // 99s -> 48s

--- a/tests/specs/mcd/verification.k
+++ b/tests/specs/mcd/verification.k
@@ -77,15 +77,7 @@ module VERIFICATION-SYNTAX
 
     rule (ADDR |Int (notAddrMask &Int ADDR_UINT48_UINT48)) /Int pow160 => ADDR_UINT48_UINT48 /Int pow160 requires #rangeUInt(256, ADDR_UINT48_UINT48) andBool #rangeAddress(ADDR) [simplification]
 
-    //
-    // **TODO**: Avoid splitting these lemmas in the 0 second-argument case.
-    // The proof which uses these lemmas (flopper-tick-pass-rough) ends up with side-conditions which look like this:
-    //  Tic ==K 0 andBool 0 ==K maxUInt48 &Int (#lookup(STORAGE, ADDR) /Int pow160)
-    // So if we just have the one rule, then structural matching on the RHS cannot determine that `0` matches `maxUInt48 &Int #lookup(STORAGE, ADDR) /Int pow160)`.
-    // This is a consequence of how the Java backend decides to treat substitutions in the side-condition.
-    //
-    rule (UINT48_2 *Int pow208) |Int (maxUInt208 &Int ADDR_UINT48_UINT48) => #WordPackAddrUInt48UInt48(maxUInt160 &Int ADDR_UINT48_UINT48, maxUInt48 &Int (ADDR_UINT48_UINT48 /Int pow160), UINT48_2) requires #rangeUInt(256, ADDR_UINT48_UINT48) andBool #rangeUInt(48, UINT48_2) andBool maxUInt48 &Int (ADDR_UINT48_UINT48 /Int pow160) =/=Int 0 [simplification]
-    rule (UINT48_2 *Int pow208) |Int (maxUInt208 &Int ADDR_UINT48_UINT48) => #WordPackAddrUInt48UInt48(maxUInt160 &Int ADDR_UINT48_UINT48, 0                                              , UINT48_2) requires #rangeUInt(256, ADDR_UINT48_UINT48) andBool #rangeUInt(48, UINT48_2) andBool maxUInt48 &Int (ADDR_UINT48_UINT48 /Int pow160)  ==Int 0 [simplification]
+    rule (UINT48_2 *Int pow208) |Int (maxUInt208 &Int ADDR_UINT48_UINT48) => #WordPackAddrUInt48UInt48(maxUInt160 &Int ADDR_UINT48_UINT48, maxUInt48 &Int (ADDR_UINT48_UINT48 /Int pow160), UINT48_2) requires #rangeUInt(256, ADDR_UINT48_UINT48) andBool #rangeUInt(48, UINT48_2) [simplification]
 
     syntax Int ::= #string2Word ( String ) [function]
  // -------------------------------------------------
@@ -297,10 +289,6 @@ module VERIFICATION
     // (check-sat)
     rule chop(X *Int Y) /sWord chop(Y) => X requires #rangeUInt(256, X) andBool #rangeSInt(256, Y) andBool #rangeSInt(256, X *Int Y) andBool Y =/=Int 0 [simplification]
 
-    // ### flopper-tick-pass-rough
-
-    rule chop(X *Int Y) => X *Int Y requires 0 <=Int X andBool 0 <=Int Y andBool X *Int Y <Int pow256 [simplification]
-
     // ### vat-slip-pass-rough
 
     rule chop(X +Int chop(Y)) => chop(X +Int Y) [simplification]
@@ -397,5 +385,14 @@ module VERIFICATION
     rule X &Int Y <Int pow256 => true requires X <Int pow256 andBool Y <Int pow256 [simplification]
 
     rule (maxUInt160 &Int (X |Int Y)) => (maxUInt160 &Int X) |Int (maxUInt160 &Int Y) [simplification]
+
+    // ### flopper-tick-pass-rough
+
+    rule chop(X *Int Y) => X *Int Y requires 0 <=Int X andBool 0 <=Int Y andBool X *Int Y <Int pow256 [simplification]
+
+    // This proof ends up with side-conditions which look like this:
+    // Tic ==K 0 andBool 0 ==K maxUInt48 &Int (#lookup(STORAGE, ADDR) /Int pow160) andBool Tic ==K maxUInt48 &Int (#lookup(STORAGE, ADDR) /Int pow160)
+    // So we need this rule to do the structural simplification because the Java backend will not use this string of equalities to do the simplification directly.
+    rule #WordPackAddrUInt48UInt48(ADDR, maxUInt48 &Int (ADDR_UINT48_UINT48 /Int pow160), UINT48_2) => #WordPackAddrUInt48UInt48(ADDR, 0, UINT48_2) requires maxUInt48 &Int (ADDR_UINT48_UINT48 /Int pow160) ==Int 0 [simplification]
 
 endmodule

--- a/tests/specs/mcd/verification.k
+++ b/tests/specs/mcd/verification.k
@@ -2,6 +2,7 @@ requires "../lemmas.k"
 requires "bin_runtime.k"
 requires "storage.k"
 requires "../infinite-gas.k"
+requires "word-pack.k"
 
 module HASKELL-HASH2 [symbolic, kore]
     imports INT
@@ -20,77 +21,9 @@ module VERIFICATION-SYNTAX
  // --------------------------------------------------------
     rule #notPrecompileAddress ( X ) => 0 ==Int X orBool (10 <=Int X andBool #rangeAddress(X))
 
-    //
-    // The Solidity compiler sometimes packs together multiple arguments into one storage location, for optimized reads/writes.
-    // Because the packed variables are all smaller than a `uint256`, they can fit into one word.
-    // If you use the pattern `SOMETHING ==K #WordPack*(ARG1, ..., ARGN)` in your side-conditions, you're actually making several assertions about `SOMETHING` and `ARG1 ... ARGN`.
-    // First, you're asserting that each `ARGi` can be unpacked from the variable `SOMETHING` using the correct accessors.
-    // Second, you're asserting that `SOMETHING` contains no other values than the packed `ARGi` (so we add a range condition to `SOMETHING`).
-    // This allows us to turn the side-condition SOMETHING ==K #WordPack*(ARG1, ..., ARGN)` into the more useful side-conditions `ARG1 ==K access1(SOMETHING) andBool ... andBool ARGN ==K accessN(SOMETHING)`.
-    // The arguments are packed in reverse order, so that the highest bits are set by the last argument.
-    //
-
-    syntax Int ::= #WordPackUInt48UInt48     (       Int , Int ) [function, no-evaluators, smtlib(WordPackUInt48UInt48)]
-                 | #WordPackAddrUInt48UInt48 ( Int , Int , Int ) [function, no-evaluators, smtlib(WordPackAddrUInt48UInt48)]
-                 | #WordPackAddrUInt8        (       Int , Int ) [function, no-evaluators, smtlib(WordPackAddrUInt8)]
- // -----------------------------------------------------------------------------------------------------------------
-    // rule #WordPackUInt48UInt48     (            UINT48_1 , UINT48_2 ) => UINT48_2 *Int pow48 +Int UINT48_1                        requires #rangeUInt(48, UINT48_1) andBool #rangeUInt(48, UINT48_2)
-    // rule #WordPackAddrUInt48UInt48 (     ADDR , UINT48_1 , UINT48_2 ) => UINT48_2 *Int pow208 +Int UINT48_1 *Int pow160 +Int ADDR requires #rangeAddress(ADDR) andBool #rangeUInt(48, UINT48_1) andBool #rangeUInt(48, UINT48_2)
-    // rule #WordPackAddrUInt8        (     ADDR , UINT8               ) => UINT8 *Int pow160 +Int ADDR                              requires #rangeAddress(ADDR) andBool #rangeUInt(8, UINT_8)
-
-    rule    ADDR_UINT48_UINT48 ==K #WordPackAddrUInt48UInt48(ADDR, UINT48_1, UINT48_2)
-         => ADDR     ==Int maxUInt160 &Int  ADDR_UINT48_UINT48
-    andBool UINT48_1 ==Int maxUInt48  &Int (ADDR_UINT48_UINT48 /Int pow160)
-    andBool UINT48_2 ==Int maxUInt48  &Int (ADDR_UINT48_UINT48 /Int pow208)
-    andBool #rangeUInt(256, ADDR_UINT48_UINT48)
-      [simplification]
-
-    rule    UINT48_UINT48 ==K #WordPackUInt48UInt48(UINT48_1, UINT48_2)
-         => UINT48_1 ==Int maxUInt48 &Int  UINT48_UINT48
-    andBool UINT48_2 ==Int maxUInt48 &Int (UINT48_UINT48 /Int pow48)
-    andBool #rangeUInt(96, UINT48_UINT48)
-      [simplification]
-
-    rule    ADDR_UINT8 ==K #WordPackAddrUInt8(ADDR, UINT8)
-         => ADDR  ==Int maxUInt160 &Int  ADDR_UINT8
-    andBool UINT8 ==Int maxUInt8   &Int (ADDR_UINT8 /Int pow160)
-    andBool #rangeUInt(168, ADDR_UINT8)
-      [simplification]
-
-    //
-    // When updating variables which originally contained `WordPack*`, the Solidity compiler will mask the original value everywhere _except_ where you're updating.
-    // Then the update will be bitwise `|Int` with the masked value, and the new value written back.
-    // Here we provide the masks which are used by the Solidity compiler, and rules which fold these bitwise updates back up into semantic `#WordPack*` arguments for the purposes of matching the RHS of proofs.
-    //
-
-    syntax Int ::= "maskWordPackUInt48UInt48_1" // 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF000000000000FFFFFFFFFFFF
-                 | "maskWordPackUInt48UInt48_2" // 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF000000000000
-                 | "mask3"                      // 0xFFFFFFFFFFFF000000000000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
- // -----------------------------------------------------------------------------------------------------------------
-    rule maskWordPackUInt48UInt48_1 => 115792089237316195423570985008687907853269984665561335876943319951794562400255 [macro]
-    rule maskWordPackUInt48UInt48_2 => 115792089237316195423570985008687907853269984665640564039457583726438152929280 [macro]
-    rule mask3                      => 115792089237315784047431654708638870748305248246218003188207458632603225030655 [macro]
-
-    rule  UINT48_1             |Int (maskWordPackUInt48UInt48_2 &Int UINT48_UINT48) => #WordPackUInt48UInt48( UINT48_1 , (maskWordPackUInt48UInt48_2 &Int UINT48_UINT48) /Int pow48 ) requires #rangeUInt(96, UINT48_UINT48) andBool #rangeUInt(48, UINT48_1) [simplification]
-    rule (UINT48_2 *Int pow48) |Int (maxUInt48                  &Int UINT48_UINT48) => #WordPackUInt48UInt48( maxUInt48 &Int UINT48_UINT48 , UINT48_2                               ) requires #rangeUInt(96, UINT48_UINT48) andBool #rangeUInt(48, UINT48_2) [simplification]
-
-    rule (maskWordPackUInt48UInt48_2 &Int UINT48_UINT48) /Int pow48 => maxUInt48 &Int (UINT48_UINT48 /Int pow48) requires #rangeUInt(96, UINT48_UINT48) [simplification]
-    rule  maskWordPackUInt48UInt48_1 &Int UINT48_UINT48             => maxUInt48 &Int  UINT48_UINT48             requires #rangeUInt(96, UINT48_UINT48) [simplification]
-
-    rule (ADDR |Int (notAddrMask &Int ADDR_UINT48_UINT48)) /Int pow160 => ADDR_UINT48_UINT48 /Int pow160 requires #rangeUInt(256, ADDR_UINT48_UINT48) andBool #rangeAddress(ADDR) [simplification]
-
-    rule (UINT48_2 *Int pow208) |Int (maxUInt208 &Int ADDR_UINT48_UINT48) => #WordPackAddrUInt48UInt48(maxUInt160 &Int ADDR_UINT48_UINT48, maxUInt48 &Int (ADDR_UINT48_UINT48 /Int pow160), UINT48_2) requires #rangeUInt(256, ADDR_UINT48_UINT48) andBool #rangeUInt(48, UINT48_2) [simplification]
-
-    rule (UINT48_1 *Int pow160) |Int (mask3 &Int ADDR_UINT48_UINT48) => #WordPackAddrUInt48UInt48(maxUInt160 &Int ADDR_UINT48_UINT48, UINT48_1, maxUInt48 &Int (ADDR_UINT48_UINT48 /Int pow208)) requires #rangeUInt(256, ADDR_UINT48_UINT48) andBool #rangeUInt(48, UINT48_1) [simplification]
-
     syntax Int ::= #string2Word ( String ) [function]
  // -------------------------------------------------
     rule #string2Word(S) => #asWord(#padRightToWidth(32, #parseByteStackRaw(S)))
-
-    // in binary: 100 1s followed by 160 0s
-    syntax Int ::= "notAddrMask" // 0xFFFFFFFFFFFFFFFFFFFFFFFF0000000000000000000000000000000000000000
- // --------------------------------------------------------------------------------------------------
-    rule notAddrMask => 115792089237316195423570985007226406215939081747436879206741300988257197096960 [macro]
 
     syntax Int ::= "#Wad" | "#Ray" | "#Rad"
  // ---------------------------------------
@@ -116,6 +49,7 @@ endmodule
 module VERIFICATION
     imports VERIFICATION-SYNTAX
     imports INFINITE-GAS
+    imports WORD-PACK
 
     // ### vat-move-diff
 

--- a/tests/specs/mcd/verification.k
+++ b/tests/specs/mcd/verification.k
@@ -136,9 +136,8 @@ module VERIFICATION
     // ### PERFORMANCE: vat-deny-diff-fail-rough
     // 27.21m -> 3.16m
 
-    rule M:Memory [ K := (W : WS) ]                   => M [ K <- W ] [ K +Int 1 := WS ] requires 0 <=Int K                                            [simplification]
-    rule M:Memory [ K <- V ] [ K' <- V' ]             => M [ K' <- V' ] [ K <- V ]       requires K' <Int K                                            [simplification]
-    rule M:Memory [ K := BUF:ByteArray ] [ K' <- V' ] => M [ K' <- V' ] [ K := BUF ]     requires K' <Int K orBool K +Int #sizeByteArray(BUF) <=Int K' [simplification]
+    rule M:Memory [ K <- V ]             [ K' <- V' ] => M [ K' <- V' ] [ K <- V ]   requires K' <Int K                                            [simplification]
+    rule M:Memory [ K := BUF:ByteArray ] [ K' <- V' ] => M [ K' <- V' ] [ K := BUF ] requires K' <Int K orBool K +Int #sizeByteArray(BUF) <=Int K' [simplification]
 
     // ### dstoken-transferfrom-fail-rough
 
@@ -394,5 +393,29 @@ module VERIFICATION
     // Tic ==K 0 andBool 0 ==K maxUInt48 &Int (#lookup(STORAGE, ADDR) /Int pow160) andBool Tic ==K maxUInt48 &Int (#lookup(STORAGE, ADDR) /Int pow160)
     // So we need this rule to do the structural simplification because the Java backend will not use this string of equalities to do the simplification directly.
     rule #WordPackAddrUInt48UInt48(ADDR, maxUInt48 &Int (ADDR_UINT48_UINT48 /Int pow160), UINT48_2) => #WordPackAddrUInt48UInt48(ADDR, 0, UINT48_2) requires maxUInt48 &Int (ADDR_UINT48_UINT48 /Int pow160) ==Int 0 [simplification]
+
+    // ### flapper-yank-pass-rough
+
+    rule #range(M:Memory [ K <- V ], START, WIDTH) => #range(M [ K := (V : .ByteArray) ], START, WIDTH)
+      requires #isConcrete(K) andBool #isConcrete(V)
+       andBool START <=Int K andBool K +Int 1 ==Int START +Int WIDTH
+       andBool 0 <Int WIDTH andBool 0 <=Int START
+       [simplification]
+
+    rule #range(M:Memory [ K <- V ] [ K' := VS':ByteArray ], START, WIDTH) => #range(M [ K := (V : VS') ], START, WIDTH)
+      requires #isConcrete(K) andBool #isConcrete(K') andBool #isConcrete(V) andBool #isConcrete(VS')
+       andBool START <=Int K andBool K' +Int #sizeByteArray(VS') ==Int START +Int WIDTH
+       andBool 0 <Int WIDTH andBool 0 <=Int START
+       andBool K +Int 1 ==Int K'
+      [simplification]
+
+    rule M:Memory [ K := BUF:ByteArray ] [ K' := BUF':ByteArray ] => M [ K := (BUF [ 0 .. K' -Int K ]) ] [ K' := BUF' ]
+      requires K <Int K'
+       andBool K' <Int K +Int #sizeByteArray(BUF)
+       andBool K +Int #sizeByteArray(BUF) <Int K' +Int #sizeByteArray(BUF')
+      [simplification]
+
+    rule X <Int X -Int Y => false requires 0 <=Int Y [simplification]
+    rule X +Int Y <Int X => false requires 0 <=Int Y [simplification]
 
 endmodule

--- a/tests/specs/mcd/verification.k
+++ b/tests/specs/mcd/verification.k
@@ -75,6 +75,8 @@ module VERIFICATION-SYNTAX
     rule (maskWordPackUInt48UInt48_2 &Int UINT48_UINT48) /Int pow48 => maxUInt48 &Int (UINT48_UINT48 /Int pow48) requires #rangeUInt(96, UINT48_UINT48) [simplification]
     rule  maskWordPackUInt48UInt48_1 &Int UINT48_UINT48             => maxUInt48 &Int  UINT48_UINT48             requires #rangeUInt(96, UINT48_UINT48) [simplification]
 
+    rule (ADDR |Int (notAddrMask &Int ADDR_UINT48_UINT48)) /Int pow160 => ADDR_UINT48_UINT48 /Int pow160 requires #rangeUInt(256, ADDR_UINT48_UINT48) andBool #rangeAddress(ADDR) [simplification]
+
     //
     // **TODO**: Avoid splitting these lemmas in the 0 second-argument case.
     // The proof which uses these lemmas (flopper-tick-pass-rough) ends up with side-conditions which look like this:
@@ -90,8 +92,8 @@ module VERIFICATION-SYNTAX
     rule #string2Word(S) => #asWord(#padRightToWidth(32, #parseByteStackRaw(S)))
 
     // in binary: 100 1s followed by 160 0s
-    syntax Int ::= "notAddrMask"
- // ----------------------------
+    syntax Int ::= "notAddrMask" // 0xFFFFFFFFFFFFFFFFFFFFFFFF0000000000000000000000000000000000000000
+ // --------------------------------------------------------------------------------------------------
     rule notAddrMask => 115792089237316195423570985007226406215939081747436879206741300988257197096960 [macro]
 
     syntax Int ::= "#Wad" | "#Ray" | "#Rad"
@@ -385,5 +387,15 @@ module VERIFICATION
     // ### end-pack-pass-rough
 
     rule ADDR in (SetItem(I) REST) => ADDR in REST requires #notPrecompileAddress(ADDR) andBool notBool #notPrecompileAddress(I) [simplification]
+
+    // ### flopper-kick-pass-rough
+
+    rule 0 <=Int X |Int Y => true requires 0 <=Int X andBool 0 <=Int Y [simplification]
+    rule 0 <=Int X &Int Y => true requires 0 <=Int X andBool 0 <=Int Y [simplification]
+
+    rule X |Int Y <Int pow256 => true requires X <Int pow256 andBool Y <Int pow256 [simplification]
+    rule X &Int Y <Int pow256 => true requires X <Int pow256 andBool Y <Int pow256 [simplification]
+
+    rule (maxUInt160 &Int (X |Int Y)) => (maxUInt160 &Int X) |Int (maxUInt160 &Int Y) [simplification]
 
 endmodule

--- a/tests/specs/mcd/word-pack.k
+++ b/tests/specs/mcd/word-pack.k
@@ -64,7 +64,7 @@ module WORD-PACK
     rule maskWordPackAddrUInt48UInt48_2 => 115792089237315784047431654708638870748305248246218003188207458632603225030655 [macro]
     rule maskWordPackAddrUInt48UInt48_3 => 411376139330301510538742295639337626245683966408394965837152255                [macro]
 
-    rule (ADDR |Int (maskWordPackAddrUInt48UInt48_3 &Int ADDR_UINT48_UINT48)) /Int pow160 => ADDR_UINT48_UINT48 /Int pow160 requires #rangeUInt(256, ADDR_UINT48_UINT48) andBool #rangeAddress(ADDR) [simplification]
+    rule (ADDR |Int (maskWordPackAddrUInt48UInt48_1 &Int ADDR_UINT48_UINT48)) /Int pow160 => ADDR_UINT48_UINT48 /Int pow160 requires #rangeUInt(256, ADDR_UINT48_UINT48) andBool #rangeAddress(ADDR) [simplification]
 
     rule (UINT48_2 *Int pow208) |Int (maskWordPackAddrUInt48UInt48_3 &Int ADDR_UINT48_UINT48) => #WordPackAddrUInt48UInt48(maxUInt160 &Int ADDR_UINT48_UINT48, maxUInt48 &Int (ADDR_UINT48_UINT48 /Int pow160), UINT48_2) requires #rangeUInt(256, ADDR_UINT48_UINT48) andBool #rangeUInt(48, UINT48_2) [simplification]
     rule (UINT48_1 *Int pow160) |Int (maskWordPackAddrUInt48UInt48_2 &Int ADDR_UINT48_UINT48) => #WordPackAddrUInt48UInt48(maxUInt160 &Int ADDR_UINT48_UINT48, UINT48_1, maxUInt48 &Int (ADDR_UINT48_UINT48 /Int pow208)) requires #rangeUInt(256, ADDR_UINT48_UINT48) andBool #rangeUInt(48, UINT48_1) [simplification]

--- a/tests/specs/mcd/word-pack.k
+++ b/tests/specs/mcd/word-pack.k
@@ -1,0 +1,73 @@
+requires "evm-types.md"
+
+    //
+    // The Solidity compiler sometimes packs together multiple arguments into one storage location, for optimized reads/writes.
+    // Because the packed variables are all smaller than a `uint256`, they can fit into one word.
+    // If you use the pattern `SOMETHING ==K #WordPack*(ARG1, ..., ARGN)` in your side-conditions, you're actually making several assertions about `SOMETHING` and `ARG1 ... ARGN`.
+    // First, you're asserting that each `ARGi` can be unpacked from the variable `SOMETHING` using the correct accessors.
+    // Second, you're asserting that `SOMETHING` contains no other values than the packed `ARGi` (so we add a range condition to `SOMETHING`).
+    // This allows us to turn the side-condition SOMETHING ==K #WordPack*(ARG1, ..., ARGN)` into the more useful side-conditions `ARG1 ==K access1(SOMETHING) andBool ... andBool ARGN ==K accessN(SOMETHING)`.
+    // The arguments are packed in reverse order, so that the highest bits are set by the last argument.
+    //
+
+module WORD-PACK
+    imports EVM-TYPES
+
+    syntax Int ::= #WordPackUInt48UInt48     (       Int , Int ) [function, no-evaluators, smtlib(WordPackUInt48UInt48)]
+                 | #WordPackAddrUInt48UInt48 ( Int , Int , Int ) [function, no-evaluators, smtlib(WordPackAddrUInt48UInt48)]
+                 | #WordPackAddrUInt8        (       Int , Int ) [function, no-evaluators, smtlib(WordPackAddrUInt8)]
+ // -----------------------------------------------------------------------------------------------------------------
+    // rule #WordPackUInt48UInt48     (            UINT48_1 , UINT48_2 ) => UINT48_2 *Int pow48 +Int UINT48_1                        requires #rangeUInt(48, UINT48_1) andBool #rangeUInt(48, UINT48_2)
+    // rule #WordPackAddrUInt48UInt48 (     ADDR , UINT48_1 , UINT48_2 ) => UINT48_2 *Int pow208 +Int UINT48_1 *Int pow160 +Int ADDR requires #rangeAddress(ADDR) andBool #rangeUInt(48, UINT48_1) andBool #rangeUInt(48, UINT48_2)
+    // rule #WordPackAddrUInt8        (     ADDR , UINT8               ) => UINT8 *Int pow160 +Int ADDR                              requires #rangeAddress(ADDR) andBool #rangeUInt(8, UINT_8)
+
+    rule    ADDR_UINT48_UINT48 ==K #WordPackAddrUInt48UInt48(ADDR, UINT48_1, UINT48_2)
+         => ADDR     ==Int maxUInt160 &Int  ADDR_UINT48_UINT48
+    andBool UINT48_1 ==Int maxUInt48  &Int (ADDR_UINT48_UINT48 /Int pow160)
+    andBool UINT48_2 ==Int maxUInt48  &Int (ADDR_UINT48_UINT48 /Int pow208)
+    andBool #rangeUInt(256, ADDR_UINT48_UINT48)
+      [simplification]
+
+    rule    UINT48_UINT48 ==K #WordPackUInt48UInt48(UINT48_1, UINT48_2)
+         => UINT48_1 ==Int maxUInt48 &Int  UINT48_UINT48
+    andBool UINT48_2 ==Int maxUInt48 &Int (UINT48_UINT48 /Int pow48)
+    andBool #rangeUInt(96, UINT48_UINT48)
+      [simplification]
+
+    rule    ADDR_UINT8 ==K #WordPackAddrUInt8(ADDR, UINT8)
+         => ADDR  ==Int maxUInt160 &Int  ADDR_UINT8
+    andBool UINT8 ==Int maxUInt8   &Int (ADDR_UINT8 /Int pow160)
+    andBool #rangeUInt(168, ADDR_UINT8)
+      [simplification]
+
+    //
+    // When updating variables which originally contained `WordPack*`, the Solidity compiler will mask the original value everywhere _except_ where you're updating.
+    // Then the update will be bitwise `|Int` with the masked value, and the new value written back.
+    // Here we provide the masks which are used by the Solidity compiler, and rules which fold these bitwise updates back up into semantic `#WordPack*` arguments for the purposes of matching the RHS of proofs.
+    //
+
+    syntax Int ::= "maskWordPackUInt48UInt48_1" // 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF000000000000FFFFFFFFFFFF
+                 | "maskWordPackUInt48UInt48_2" // 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF000000000000
+                 | "mask3"                      // 0xFFFFFFFFFFFF000000000000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
+ // -----------------------------------------------------------------------------------------------------------------
+    rule maskWordPackUInt48UInt48_1 => 115792089237316195423570985008687907853269984665561335876943319951794562400255 [macro]
+    rule maskWordPackUInt48UInt48_2 => 115792089237316195423570985008687907853269984665640564039457583726438152929280 [macro]
+    rule mask3                      => 115792089237315784047431654708638870748305248246218003188207458632603225030655 [macro]
+
+    rule  UINT48_1             |Int (maskWordPackUInt48UInt48_2 &Int UINT48_UINT48) => #WordPackUInt48UInt48( UINT48_1 , (maskWordPackUInt48UInt48_2 &Int UINT48_UINT48) /Int pow48 ) requires #rangeUInt(96, UINT48_UINT48) andBool #rangeUInt(48, UINT48_1) [simplification]
+    rule (UINT48_2 *Int pow48) |Int (maxUInt48                  &Int UINT48_UINT48) => #WordPackUInt48UInt48( maxUInt48 &Int UINT48_UINT48 , UINT48_2                               ) requires #rangeUInt(96, UINT48_UINT48) andBool #rangeUInt(48, UINT48_2) [simplification]
+
+    rule (maskWordPackUInt48UInt48_2 &Int UINT48_UINT48) /Int pow48 => maxUInt48 &Int (UINT48_UINT48 /Int pow48) requires #rangeUInt(96, UINT48_UINT48) [simplification]
+    rule  maskWordPackUInt48UInt48_1 &Int UINT48_UINT48             => maxUInt48 &Int  UINT48_UINT48             requires #rangeUInt(96, UINT48_UINT48) [simplification]
+
+    rule (ADDR |Int (notAddrMask &Int ADDR_UINT48_UINT48)) /Int pow160 => ADDR_UINT48_UINT48 /Int pow160 requires #rangeUInt(256, ADDR_UINT48_UINT48) andBool #rangeAddress(ADDR) [simplification]
+
+    rule (UINT48_2 *Int pow208) |Int (maxUInt208 &Int ADDR_UINT48_UINT48) => #WordPackAddrUInt48UInt48(maxUInt160 &Int ADDR_UINT48_UINT48, maxUInt48 &Int (ADDR_UINT48_UINT48 /Int pow160), UINT48_2) requires #rangeUInt(256, ADDR_UINT48_UINT48) andBool #rangeUInt(48, UINT48_2) [simplification]
+
+    rule (UINT48_1 *Int pow160) |Int (mask3 &Int ADDR_UINT48_UINT48) => #WordPackAddrUInt48UInt48(maxUInt160 &Int ADDR_UINT48_UINT48, UINT48_1, maxUInt48 &Int (ADDR_UINT48_UINT48 /Int pow208)) requires #rangeUInt(256, ADDR_UINT48_UINT48) andBool #rangeUInt(48, UINT48_1) [simplification]
+
+    // in binary: 100 1s followed by 160 0s
+    syntax Int ::= "notAddrMask" // 0xFFFFFFFFFFFFFFFFFFFFFFFF0000000000000000000000000000000000000000
+ // --------------------------------------------------------------------------------------------------
+    rule notAddrMask => 115792089237316195423570985007226406215939081747436879206741300988257197096960 [macro]
+endmodule

--- a/tests/specs/mcd/word-pack.k
+++ b/tests/specs/mcd/word-pack.k
@@ -9,6 +9,10 @@ requires "evm-types.md"
     // This allows us to turn the side-condition SOMETHING ==K #WordPack*(ARG1, ..., ARGN)` into the more useful side-conditions `ARG1 ==K access1(SOMETHING) andBool ... andBool ARGN ==K accessN(SOMETHING)`.
     // The arguments are packed in reverse order, so that the highest bits are set by the last argument.
     //
+    // When updating variables which originally contained `WordPack*`, the Solidity compiler will mask the original value everywhere _except_ where you're updating.
+    // Then the update will be bitwise `|Int` with the masked value, and the new value written back.
+    // Here we provide the masks which are used by the Solidity compiler, and rules which fold these bitwise updates back up into semantic `#WordPack*` arguments for the purposes of matching the RHS of proofs.
+    //
 
 module WORD-PACK
     imports EVM-TYPES
@@ -40,34 +44,28 @@ module WORD-PACK
     andBool #rangeUInt(168, ADDR_UINT8)
       [simplification]
 
-    //
-    // When updating variables which originally contained `WordPack*`, the Solidity compiler will mask the original value everywhere _except_ where you're updating.
-    // Then the update will be bitwise `|Int` with the masked value, and the new value written back.
-    // Here we provide the masks which are used by the Solidity compiler, and rules which fold these bitwise updates back up into semantic `#WordPack*` arguments for the purposes of matching the RHS of proofs.
-    //
-
     syntax Int ::= "maskWordPackUInt48UInt48_1" // 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF000000000000FFFFFFFFFFFF
                  | "maskWordPackUInt48UInt48_2" // 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF000000000000
-                 | "mask3"                      // 0xFFFFFFFFFFFF000000000000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
  // -----------------------------------------------------------------------------------------------------------------
     rule maskWordPackUInt48UInt48_1 => 115792089237316195423570985008687907853269984665561335876943319951794562400255 [macro]
     rule maskWordPackUInt48UInt48_2 => 115792089237316195423570985008687907853269984665640564039457583726438152929280 [macro]
-    rule mask3                      => 115792089237315784047431654708638870748305248246218003188207458632603225030655 [macro]
-
-    rule  UINT48_1             |Int (maskWordPackUInt48UInt48_2 &Int UINT48_UINT48) => #WordPackUInt48UInt48( UINT48_1 , (maskWordPackUInt48UInt48_2 &Int UINT48_UINT48) /Int pow48 ) requires #rangeUInt(96, UINT48_UINT48) andBool #rangeUInt(48, UINT48_1) [simplification]
-    rule (UINT48_2 *Int pow48) |Int (maxUInt48                  &Int UINT48_UINT48) => #WordPackUInt48UInt48( maxUInt48 &Int UINT48_UINT48 , UINT48_2                               ) requires #rangeUInt(96, UINT48_UINT48) andBool #rangeUInt(48, UINT48_2) [simplification]
 
     rule (maskWordPackUInt48UInt48_2 &Int UINT48_UINT48) /Int pow48 => maxUInt48 &Int (UINT48_UINT48 /Int pow48) requires #rangeUInt(96, UINT48_UINT48) [simplification]
     rule  maskWordPackUInt48UInt48_1 &Int UINT48_UINT48             => maxUInt48 &Int  UINT48_UINT48             requires #rangeUInt(96, UINT48_UINT48) [simplification]
 
-    rule (ADDR |Int (notAddrMask &Int ADDR_UINT48_UINT48)) /Int pow160 => ADDR_UINT48_UINT48 /Int pow160 requires #rangeUInt(256, ADDR_UINT48_UINT48) andBool #rangeAddress(ADDR) [simplification]
+    rule  UINT48_1             |Int (maskWordPackUInt48UInt48_2 &Int UINT48_UINT48) => #WordPackUInt48UInt48( UINT48_1 , (maskWordPackUInt48UInt48_2 &Int UINT48_UINT48) /Int pow48 ) requires #rangeUInt(96, UINT48_UINT48) andBool #rangeUInt(48, UINT48_1) [simplification]
+    rule (UINT48_2 *Int pow48) |Int (maxUInt48                  &Int UINT48_UINT48) => #WordPackUInt48UInt48( maxUInt48 &Int UINT48_UINT48 , UINT48_2                               ) requires #rangeUInt(96, UINT48_UINT48) andBool #rangeUInt(48, UINT48_2) [simplification]
 
-    rule (UINT48_2 *Int pow208) |Int (maxUInt208 &Int ADDR_UINT48_UINT48) => #WordPackAddrUInt48UInt48(maxUInt160 &Int ADDR_UINT48_UINT48, maxUInt48 &Int (ADDR_UINT48_UINT48 /Int pow160), UINT48_2) requires #rangeUInt(256, ADDR_UINT48_UINT48) andBool #rangeUInt(48, UINT48_2) [simplification]
+    syntax Int ::= "maskWordPackAddrUInt48UInt48_1" // 0xFFFFFFFFFFFFFFFFFFFFFFFF0000000000000000000000000000000000000000
+                 | "maskWordPackAddrUInt48UInt48_2" // 0xFFFFFFFFFFFF000000000000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
+                 | "maskWordPackAddrUInt48UInt48_3" // 0x000000000000FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
+ // ---------------------------------------------------------------------------------------------------------------------
+    rule maskWordPackAddrUInt48UInt48_1 => 115792089237316195423570985007226406215939081747436879206741300988257197096960 [macro]
+    rule maskWordPackAddrUInt48UInt48_2 => 115792089237315784047431654708638870748305248246218003188207458632603225030655 [macro]
+    rule maskWordPackAddrUInt48UInt48_3 => 411376139330301510538742295639337626245683966408394965837152255                [macro]
 
-    rule (UINT48_1 *Int pow160) |Int (mask3 &Int ADDR_UINT48_UINT48) => #WordPackAddrUInt48UInt48(maxUInt160 &Int ADDR_UINT48_UINT48, UINT48_1, maxUInt48 &Int (ADDR_UINT48_UINT48 /Int pow208)) requires #rangeUInt(256, ADDR_UINT48_UINT48) andBool #rangeUInt(48, UINT48_1) [simplification]
+    rule (ADDR |Int (maskWordPackAddrUInt48UInt48_3 &Int ADDR_UINT48_UINT48)) /Int pow160 => ADDR_UINT48_UINT48 /Int pow160 requires #rangeUInt(256, ADDR_UINT48_UINT48) andBool #rangeAddress(ADDR) [simplification]
 
-    // in binary: 100 1s followed by 160 0s
-    syntax Int ::= "notAddrMask" // 0xFFFFFFFFFFFFFFFFFFFFFFFF0000000000000000000000000000000000000000
- // --------------------------------------------------------------------------------------------------
-    rule notAddrMask => 115792089237316195423570985007226406215939081747436879206741300988257197096960 [macro]
+    rule (UINT48_2 *Int pow208) |Int (maskWordPackAddrUInt48UInt48_3 &Int ADDR_UINT48_UINT48) => #WordPackAddrUInt48UInt48(maxUInt160 &Int ADDR_UINT48_UINT48, maxUInt48 &Int (ADDR_UINT48_UINT48 /Int pow160), UINT48_2) requires #rangeUInt(256, ADDR_UINT48_UINT48) andBool #rangeUInt(48, UINT48_2) [simplification]
+    rule (UINT48_1 *Int pow160) |Int (maskWordPackAddrUInt48UInt48_2 &Int ADDR_UINT48_UINT48) => #WordPackAddrUInt48UInt48(maxUInt160 &Int ADDR_UINT48_UINT48, UINT48_1, maxUInt48 &Int (ADDR_UINT48_UINT48 /Int pow208)) requires #rangeUInt(256, ADDR_UINT48_UINT48) andBool #rangeUInt(48, UINT48_1) [simplification]
 endmodule


### PR DESCRIPTION
-   Add 3 tests from MKR regression suite: flapper-yank-pass-rough, flopper-dent-guy-same-pass, flopper-kick-pass-rough.
-   Adds a `mcd/functional` test to write claims about functional lemmas (with some tests about WordPack abstraction added).
-   Moves wordpack abstraction into separate file `word-pack.k`.
-   Renames masks to more sensible names (relating them to their word-pack abstractions they apply to).
-   Adds lemmas for simplifying the repacking of WordPackAddrUInt48UInt48.