### PR TITLE
Improved infinite gas reasoning

### DIFF
--- a/evm.md
+++ b/evm.md
@@ -2151,7 +2151,7 @@ There are several helpers for calculating gas (most of them also specified in th
 
     syntax Int ::= #allBut64th ( Int ) [function, functional]
  // ---------------------------------------------------------
-    rule #allBut64th(N) => N -Int (N /Int 64)
+    rule [allBut64th]: #allBut64th(N) => N -Int (N /Int 64)
 ```
 
 ```{.k .nobytes}

--- a/evm.md
+++ b/evm.md
@@ -2149,8 +2149,8 @@ There are several helpers for calculating gas (most of them also specified in th
  // --------------------------------------------------------------------------------------------------
     rule #accountEmpty(CODE, NONCE, BAL) => CODE ==K .ByteArray andBool NONCE ==Int 0 andBool BAL ==Int 0
 
-    syntax Int ::= #allBut64th ( Int ) [function, functional]
- // ---------------------------------------------------------
+    syntax Int ::= #allBut64th ( Int ) [function, functional, smtlib(gas_allBut64th)]
+ // ---------------------------------------------------------------------------------
     rule [allBut64th]: #allBut64th(N) => N -Int (N /Int 64)
 ```
 

--- a/evm.md
+++ b/evm.md
@@ -2151,7 +2151,8 @@ There are several helpers for calculating gas (most of them also specified in th
 
     syntax Int ::= #allBut64th ( Int ) [function, functional, smtlib(gas_allBut64th)]
  // ---------------------------------------------------------------------------------
-    rule [allBut64th]: #allBut64th(N) => N -Int (N /Int 64)
+    rule [allBut64th.pos]: #allBut64th(N) => N -Int (N /Int 64) requires 0 <=Int N
+    rule [allBut64th.neg]: #allBut64th(N) => 0                  requires N  <Int 0
 ```
 
 ```{.k .nobytes}

--- a/tests/specs/concrete-rules.txt
+++ b/tests/specs/concrete-rules.txt
@@ -1,11 +1,11 @@
 EDSL.#ceil32
 EDSL.keccakIntList
+EVM.allBut64th.pos
 EVM.Cextra
 EVM.Cgascap
 EVM.Cmem
 EVM.Csstore.new
 EVM.Csstore.old
-EVM.allBut64th
 EVM.#memoryUsageUpdate.some
 EVM.Rsstore.new
 EVM.Rsstore.old

--- a/tests/specs/concrete-rules.txt
+++ b/tests/specs/concrete-rules.txt
@@ -5,6 +5,7 @@ EVM.Cgascap
 EVM.Cmem
 EVM.Csstore.new
 EVM.Csstore.old
+EVM.allBut64th
 EVM.#memoryUsageUpdate.some
 EVM.Rsstore.new
 EVM.Rsstore.old

--- a/tests/specs/functional/infinite-gas-spec.k
+++ b/tests/specs/functional/infinite-gas-spec.k
@@ -36,7 +36,7 @@ module INFINITE-GAS-SPEC
 
     claim <k> runLemma(#gas((((VGas +Int -1259) -Int Csstore(ISTANBUL, 1, 1, Junk_0)) +Int -4339))) => doneLemma(#gas((VGas -Int Csstore(ISTANBUL, 1, 1, Junk_0)) +Int -5598)) ... </k>
 
-    claim <k> runLemma(#gas(#gas(G1) +Int #allBut64th(G2 +Int -3454))) => doneLemma(#gas(G1 +Int #allBut64th(G2 +Int -3454))) ... </k>
+    claim <k> runLemma(#gas(#gas(G1) +Int #allBut64th(G2 +Int -3454))) => doneLemma(#gas(G1 +Int #allBut64th(G2 +Int -3454))) ... </k> requires #rangeUInt(256, G2)
 
     claim <k> runLemma(#gas(#gas(G1 -Int G2) +Int #allBut64th(G3))) => doneLemma(#gas((G1 -Int G2) +Int #allBut64th(G3))) ... </k> requires 0 <Int G3
     claim <k> runLemma(#gas(#gas(G1 -Int G2) -Int #allBut64th(G3))) => doneLemma(#gas((G1 -Int G2) -Int #allBut64th(G3))) ... </k> requires 0 <Int G3 andBool G3 <Int #gas(G1 -Int G2)
@@ -70,5 +70,7 @@ module INFINITE-GAS-SPEC
 
     claim <k> runLemma(#if _:Int ==Int 0 #then #gas(VGas -Int Csstore(_, _, _,_)) #else #gas(VGas +Int -344) #fi <Int minInt(#if _ #then #gas(_) #else #gas(_) #fi, #gas(_)))  => doneLemma(false) ... </k>
     claim <k> runLemma(minInt(#if _ #then #gas(_) #else #gas(_) #fi, #gas(_)) <=Int #if _:Int ==Int 0 #then #gas(VGas -Int Csstore(_, _, _,_)) #else #gas(VGas +Int -344) #fi) => doneLemma(true)  ... </k>
+
+    claim <k> runLemma(#allBut64th(#gas(G)) <Int #gas(G')) => doneLemma(false) ... </k>
 
 endmodule

--- a/tests/specs/functional/infinite-gas-spec.k
+++ b/tests/specs/functional/infinite-gas-spec.k
@@ -15,13 +15,34 @@ endmodule
 module INFINITE-GAS-SPEC
     imports VERIFICATION
 
- // Gas arithmetic
- // --------------
+ // Gas simplifications
+ // -------------------
+
+    claim <k> runLemma(#if B #then (VGas -Int Csstore(ISTANBUL, V1, V2, V3)) +Int -435 #else (VGas -Int Csstore(ISTANBUL, V1, V2, V3)) +Int -4342 #fi)
+           => doneLemma((VGas -Int Csstore(ISTANBUL, V1, V2, V3)) +Int #if B #then -435 #else -4342 #fi)
+          ...
+          </k>
+
+    claim <k> runLemma((VGas +Int -3844) -Int ((VGas -Int ((VGas +Int -4544) /Int 64)) +Int -3844)) => doneLemma((VGas +Int -4544) /Int 64) ... </k>
+
+ // Infinite Gas simplifications
+ // ----------------------------
 
     claim <k> runLemma(#gas(8) -Int 3) => doneLemma(#gas(5)) ... </k>
 
- // Gas comparisons
- // ---------------
+    claim <k> runLemma(#gas(G) -Int #gas(G')) => doneLemma(#gas(G -Int G')) ... </k>
+
+    claim <k> runLemma(#gas((((((VGas +Int -1148) -Int G1) +Int -866) -Int G2) +Int -4337))) => doneLemma(#gas(((VGas -Int G1) -Int G2) +Int -6351)) ... </k>
+
+    claim <k> runLemma(#gas((((VGas +Int -1259) -Int Csstore(ISTANBUL, 1, 1, Junk_0)) +Int -4339))) => doneLemma(#gas((VGas -Int Csstore(ISTANBUL, 1, 1, Junk_0)) +Int -5598)) ... </k>
+
+    claim <k> runLemma(#gas(#gas(G1) +Int #allBut64th(G2 +Int -3454))) => doneLemma(#gas(G1 +Int #allBut64th(G2 +Int -3454))) ... </k>
+
+    claim <k> runLemma(#gas(#gas(G1 -Int G2) +Int #allBut64th(G3))) => doneLemma(#gas((G1 -Int G2) +Int #allBut64th(G3))) ... </k> requires 0 <Int G3
+    claim <k> runLemma(#gas(#gas(G1 -Int G2) -Int #allBut64th(G3))) => doneLemma(#gas((G1 -Int G2) -Int #allBut64th(G3))) ... </k> requires 0 <Int G3 andBool G3 <Int #gas(G1 -Int G2)
+
+ // Infinite Gas comparisons
+ // ------------------------
 
     claim <k> runLemma(#gas(_)  <Int 11     ) => doneLemma(false) ... </k>
     claim <k> runLemma(#gas(_) <=Int 11     ) => doneLemma(false) ... </k>
@@ -38,19 +59,11 @@ module INFINITE-GAS-SPEC
     claim <k> runLemma(3 <Int minInt(#gas(VGas), 2)) => doneLemma(false) ... </k>
     claim <k> runLemma(2 <Int minInt(#gas(VGas), 3)) => doneLemma(true ) ... </k>
 
-    claim <k> runLemma(#gas(G) -Int #gas(G')) => doneLemma(#gas(G -Int G')) ... </k>
-
     claim <k> runLemma(#gas(G) -Int Csstore(_, _, _, _) <Int 2) => doneLemma(false) ... </k>
     claim <k> runLemma(minInt(#gas(G), #gas(G'')) +Int -2522 <Int Csstore(_, _, _, _)) => doneLemma(false) ... </k>
 
     claim <k> runLemma(#gas(G) <Int #gas(G' +Int 700))  => doneLemma(false) ... </k>
     claim <k> runLemma(#gas(G' +Int 700) <=Int #gas(G)) => doneLemma(true)  ... </k>
-
-    claim <k> runLemma(#gas((((VGas +Int -1259) -Int Csstore(ISTANBUL, 1, 1, Junk_0)) +Int -4339))) => doneLemma(#gas((VGas -Int Csstore(ISTANBUL, 1, 1, Junk_0)) +Int -5598)) ... </k>
-
-    claim <k> runLemma((VGas +Int -3844) -Int ((VGas -Int ((VGas +Int -4544) /Int 64)) +Int -3844)) => doneLemma((VGas +Int -4544) /Int 64) ... </k>
-
-    claim <k> runLemma(#gas((((((VGas +Int -1148) -Int G1) +Int -866) -Int G2) +Int -4337))) => doneLemma(#gas(((VGas -Int G1) -Int G2) +Int -6351)) ... </k>
 
     claim <k> runLemma(#if _:Int ==Int 0 #then #gas(VGas -Int Csstore(_, _, _,_)) #else #gas(VGas +Int -344) #fi <Int 8)  => doneLemma(false) ... </k>
     claim <k> runLemma(8 <=Int #if _:Int ==Int 0 #then #gas(VGas -Int Csstore(_, _, _,_)) #else #gas(VGas +Int -344) #fi) => doneLemma(true)  ... </k>

--- a/tests/specs/functional/infinite-gas-spec.k
+++ b/tests/specs/functional/infinite-gas-spec.k
@@ -29,6 +29,8 @@ module INFINITE-GAS-SPEC
 
     claim <k> runLemma(((VGas -Int #allBut64th(VGas +Int -9487)) +Int -9487) +Int #allBut64th(VGas +Int -9487)) => doneLemma(VGas +Int -9487) ... </k>
 
+    claim <k> runLemma(((VGas -Int (#allBut64th(VGas +Int -2655) +Int 700)) +Int #allBut64th(VGas +Int -2655)) +Int -7244) => doneLemma(VGas +Int -7944) ... </k>
+
  // Infinite Gas simplifications
  // ----------------------------
 

--- a/tests/specs/functional/infinite-gas-spec.k
+++ b/tests/specs/functional/infinite-gas-spec.k
@@ -41,6 +41,9 @@ module INFINITE-GAS-SPEC
     claim <k> runLemma(#gas(#gas(G1 -Int G2) +Int #allBut64th(G3))) => doneLemma(#gas((G1 -Int G2) +Int #allBut64th(G3))) ... </k> requires 0 <Int G3
     claim <k> runLemma(#gas(#gas(G1 -Int G2) -Int #allBut64th(G3))) => doneLemma(#gas((G1 -Int G2) -Int #allBut64th(G3))) ... </k> requires 0 <Int G3 andBool G3 <Int #gas(G1 -Int G2)
 
+    claim <k> runLemma(#gas(G) +Int (#allBut64th((VGas -Int Csstore(ISTANBUL, V1, V2, V3)) +Int -3232) +Int -3232)) => doneLemma(#gas(G +Int (#allBut64th((VGas -Int Csstore(ISTANBUL, V1, V2, V3)) +Int -3232) +Int -3232))) ... </k>
+    claim <k> runLemma(#gas(G) +Int ((#allBut64th(VGas -Int Csstore(ISTANBUL, V1, V2, V3)) -Int Csstore(ISTANBUL, V1', V2', V3')) +Int -3232)) => doneLemma(#gas(G +Int ((#allBut64th(VGas -Int Csstore(ISTANBUL, V1, V2, V3)) -Int Csstore(ISTANBUL, V1', V2', V3')) +Int -3232))) ... </k>
+
  // Infinite Gas comparisons
  // ------------------------
 

--- a/tests/specs/functional/infinite-gas-spec.k
+++ b/tests/specs/functional/infinite-gas-spec.k
@@ -44,6 +44,8 @@ module INFINITE-GAS-SPEC
     claim <k> runLemma(#gas(G) +Int (#allBut64th((VGas -Int Csstore(ISTANBUL, V1, V2, V3)) +Int -3232) +Int -3232)) => doneLemma(#gas(G +Int (#allBut64th((VGas -Int Csstore(ISTANBUL, V1, V2, V3)) +Int -3232) +Int -3232))) ... </k>
     claim <k> runLemma(#gas(G) +Int ((#allBut64th(VGas -Int Csstore(ISTANBUL, V1, V2, V3)) -Int Csstore(ISTANBUL, V1', V2', V3')) +Int -3232)) => doneLemma(#gas(G +Int ((#allBut64th(VGas -Int Csstore(ISTANBUL, V1, V2, V3)) -Int Csstore(ISTANBUL, V1', V2', V3')) +Int -3232))) ... </k>
 
+    claim <k> runLemma((VGas -Int #allBut64th(VGas +Int -2732)) +Int #allBut64th(VGas +Int -2732)) => doneLemma(VGas) ... </k>
+
  // Infinite Gas comparisons
  // ------------------------
 

--- a/tests/specs/functional/infinite-gas-spec.k
+++ b/tests/specs/functional/infinite-gas-spec.k
@@ -25,6 +25,10 @@ module INFINITE-GAS-SPEC
 
     claim <k> runLemma((VGas +Int -3844) -Int ((VGas -Int ((VGas +Int -4544) /Int 64)) +Int -3844)) => doneLemma((VGas +Int -4544) /Int 64) ... </k>
 
+    claim <k> runLemma((VGas -Int #allBut64th(VGas +Int -2732)) +Int #allBut64th(VGas +Int -2732)) => doneLemma(VGas) ... </k>
+
+    claim <k> runLemma(((VGas -Int #allBut64th(VGas +Int -9487)) +Int -9487) +Int #allBut64th(VGas +Int -9487)) => doneLemma(VGas +Int -9487) ... </k>
+
  // Infinite Gas simplifications
  // ----------------------------
 
@@ -43,8 +47,6 @@ module INFINITE-GAS-SPEC
 
     claim <k> runLemma(#gas(G) +Int (#allBut64th((VGas -Int Csstore(ISTANBUL, V1, V2, V3)) +Int -3232) +Int -3232)) => doneLemma(#gas(G +Int (#allBut64th((VGas -Int Csstore(ISTANBUL, V1, V2, V3)) +Int -3232) +Int -3232))) ... </k>
     claim <k> runLemma(#gas(G) +Int ((#allBut64th(VGas -Int Csstore(ISTANBUL, V1, V2, V3)) -Int Csstore(ISTANBUL, V1', V2', V3')) +Int -3232)) => doneLemma(#gas(G +Int ((#allBut64th(VGas -Int Csstore(ISTANBUL, V1, V2, V3)) -Int Csstore(ISTANBUL, V1', V2', V3')) +Int -3232))) ... </k>
-
-    claim <k> runLemma((VGas -Int #allBut64th(VGas +Int -2732)) +Int #allBut64th(VGas +Int -2732)) => doneLemma(VGas) ... </k>
 
  // Infinite Gas comparisons
  // ------------------------

--- a/tests/specs/infinite-gas.k
+++ b/tests/specs/infinite-gas.k
@@ -56,6 +56,7 @@ module INFINITE-GAS-COMMON
 
     rule I -Int I => 0                                                                   [simplification]
     rule I1 -Int (I1 -Int I2) => I2                                                      [simplification]
+    rule (I1 -Int I2) +Int I2 => I1                                                      [simplification]
     rule (notBool (A andBool B)) andBool A => (notBool B) andBool A                      [simplification]
     rule #if B #then C +Int C1 #else C +Int C2 #fi => C +Int #if B #then C1 #else C2 #fi [simplification]
 

--- a/tests/specs/infinite-gas.k
+++ b/tests/specs/infinite-gas.k
@@ -68,16 +68,16 @@ module INFINITE-GAS-COMMON
  // ---------------------------------------------------------------------------------------------------------
     rule #gas(_, _, _) => #gas(0)
 
-    rule #gas(G) +Int G' => #gas(G +Int G') requires 0 <Int G' orBool 0 -Int G' <Int #gas(G)  [simplification]
-    rule G +Int #gas(G') => #gas(G +Int G') requires 0 <Int G  orBool 0 -Int G  <Int #gas(G') [simplification]
+    rule #gas(G) +Int G' => #gas(G +Int G') requires 0 <=Int G' orBool 0 -Int G' <Int #gas(G)  [simplification]
+    rule G +Int #gas(G') => #gas(G +Int G') requires 0 <=Int G  orBool 0 -Int G  <Int #gas(G') [simplification]
 
-    rule #gas(G) -Int G' => #gas(G -Int G') requires 0 <Int G' andBool G' <Int #gas(G) [simplification]
+    rule #gas(G) -Int G' => #gas(G -Int G') requires 0 <=Int G' andBool G' <Int #gas(G) [simplification]
 
-    rule #gas(G) *Int G' => #gas(G *Int G') requires 0 <Int G' [simplification]
-    rule G *Int #gas(G') => #gas(G *Int G') requires 0 <Int G  [simplification]
+    rule #gas(G) *Int G' => #gas(G *Int G') requires 0 <=Int G' [simplification]
+    rule G *Int #gas(G') => #gas(G *Int G') requires 0 <=Int G  [simplification]
 
-    rule #gas(G) /Int G' => #gas(G /Int G') requires 0 <Int G' andBool G' <Int #gas(G)  [simplification]
-    rule G /Int #gas(G') => 0               requires 0 <Int G  andBool G  <Int #gas(G') [simplification]
+    rule #gas(G) /Int G' => #gas(G /Int G') requires 0  <Int G' andBool G' <Int #gas(G)  [simplification]
+    rule G /Int #gas(G') => 0               requires 0 <=Int G  andBool G  <Int #gas(G') [simplification]
 
     rule #gas(#gas(G)) => #gas(G) [simplification]
 
@@ -117,7 +117,7 @@ module INFINITE-GAS-COMMON
     rule G  <Int minInt(G', G'') => G  <Int G' andBool G  <Int G'' [simplification]
     rule G <=Int minInt(G', G'') => G <=Int G' andBool G <=Int G'' [simplification]
 
-    rule 0 <Int Csstore(_, _, _, _)        => true  [simplification]
+    rule 0 <=Int Csstore(_, _, _, _)       => true  [simplification]
     rule Csstore(_, _, _, _) <Int #gas(_)  => true  [simplification]
     rule #gas(_)  <Int Csstore(_, _, _, _) => false [simplification]
     rule #gas(_) >=Int Csstore(_, _, _, _) => true  [simplification]
@@ -125,7 +125,7 @@ module INFINITE-GAS-COMMON
     rule #gas(_) <Int Cmem(_, _)  => false [simplification]
     rule Cmem(_, _) <=Int #gas(_) => true  [simplification]
 
-    rule 0 <Int #allBut64th(_)       => true [simplification]
-    rule #allBut64th(_) <Int #gas(_) => true [simplification]
+    rule 0 <=Int #allBut64th(G)       => true                          [simplification]
+    rule #allBut64th(G) <Int #gas(G') => true requires G <Int #gas(G') [simplification]
 
 endmodule

--- a/tests/specs/infinite-gas.k
+++ b/tests/specs/infinite-gas.k
@@ -26,6 +26,13 @@ module INFINITE-GAS-HASKELL [kore]
     rule I1          <Int I2 +Int I3 => I1 -Int I3  <Int I2         [concrete(I1, I3), simplification]
     rule I1         <=Int I2 +Int I3 => I1 -Int I3 <=Int I2         [concrete(I1, I3), simplification]
 
+    rule I1 +Int I2 => I2 +Int I1 [concrete(I1), symbolic(I2), simplification]
+
+    rule I1 +Int (I2 +Int I3) => (I1 +Int I2) +Int I3 [symbolic(I1, I2), simplification]
+    rule I1 +Int (I2 -Int I3) => (I1 +Int I2) -Int I3 [symbolic(I1, I2), simplification]
+    rule I1 -Int (I2 +Int I3) => (I1 -Int I2) -Int I3 [symbolic(I1, I2), simplification]
+    rule I1 -Int (I2 -Int I3) => (I1 -Int I2) +Int I3 [symbolic(I1, I2), simplification]
+
     rule (I1 +Int I2) +Int I3 => (I1 +Int I3) +Int I2 [concrete(I2), symbolic(I3), simplification]
     rule (I1 +Int I2) -Int I3 => (I1 -Int I3) +Int I2 [concrete(I2), symbolic(I3), simplification]
     rule (I1 -Int I2) +Int I3 => (I1 +Int I3) -Int I2 [concrete(I2), symbolic(I3), simplification]
@@ -50,6 +57,13 @@ module INFINITE-GAS-JAVA [kast]
     rule I1          <Int I2 +Int I3 => I1 -Int I3  <Int I2         requires #isConcrete(I1) andBool #isConcrete(I3) [simplification]
     rule I1         <=Int I2 +Int I3 => I1 -Int I3 <=Int I2         requires #isConcrete(I1) andBool #isConcrete(I3) [simplification]
 
+    rule I1 +Int I2 => I2 +Int I1 requires #isConcrete(I1) andBool notBool #isConcrete(I2) [simplification]
+
+    rule I1 +Int (I2 +Int I3) => (I1 +Int I2) +Int I3 requires (notBool #isConcrete(I1)) andBool (notBool #isConcrete(I2)) [simplification]
+    rule I1 +Int (I2 -Int I3) => (I1 +Int I2) -Int I3 requires (notBool #isConcrete(I1)) andBool (notBool #isConcrete(I2)) [simplification]
+    rule I1 -Int (I2 +Int I3) => (I1 -Int I2) -Int I3 requires (notBool #isConcrete(I1)) andBool (notBool #isConcrete(I2)) [simplification]
+    rule I1 -Int (I2 -Int I3) => (I1 -Int I2) +Int I3 requires (notBool #isConcrete(I1)) andBool (notBool #isConcrete(I2)) [simplification]
+
     rule (I1 +Int I2) +Int I3 => (I1 +Int I3) +Int I2 requires #isConcrete(I2) andBool notBool #isConcrete(I3) [simplification]
     rule (I1 +Int I2) -Int I3 => (I1 -Int I3) +Int I2 requires #isConcrete(I2) andBool notBool #isConcrete(I3) [simplification]
     rule (I1 -Int I2) +Int I3 => (I1 +Int I3) -Int I2 requires #isConcrete(I2) andBool notBool #isConcrete(I3) [simplification]
@@ -71,11 +85,6 @@ module INFINITE-GAS-COMMON
 
     rule I -Int I => 0              [simplification]
     rule (I1 -Int I2) +Int I2 => I1 [simplification]
-
-    rule I1 +Int (I2 +Int I3) => (I1 +Int I2) +Int I3 [simplification]
-    rule I1 +Int (I2 -Int I3) => (I1 +Int I2) -Int I3 [simplification]
-    rule I1 -Int (I2 +Int I3) => (I1 -Int I2) -Int I3 [simplification]
-    rule I1 -Int (I2 -Int I3) => (I1 -Int I2) +Int I3 [simplification]
 
  // Symbolic Gas
 

--- a/tests/specs/infinite-gas.k
+++ b/tests/specs/infinite-gas.k
@@ -66,12 +66,16 @@ module INFINITE-GAS-COMMON
 
  // Generic rules
 
-    rule I -Int I => 0                                                                   [simplification]
-    rule I1 -Int (I1 -Int I2) => I2                                                      [simplification]
-    rule (I1 -Int I2) +Int I2 => I1                                                      [simplification]
-    rule I1 -Int (I2 +Int I3) => (I1 -Int I2) -Int I3                                    [simplification]
     rule (notBool (A andBool B)) andBool A => (notBool B) andBool A                      [simplification]
     rule #if B #then C +Int C1 #else C +Int C2 #fi => C +Int #if B #then C1 #else C2 #fi [simplification]
+
+    rule I -Int I => 0              [simplification]
+    rule (I1 -Int I2) +Int I2 => I1 [simplification]
+
+    rule I1 +Int (I2 +Int I3) => (I1 +Int I2) +Int I3 [simplification]
+    rule I1 +Int (I2 -Int I3) => (I1 +Int I2) -Int I3 [simplification]
+    rule I1 -Int (I2 +Int I3) => (I1 -Int I2) -Int I3 [simplification]
+    rule I1 -Int (I2 -Int I3) => (I1 -Int I2) +Int I3 [simplification]
 
  // Symbolic Gas
 

--- a/tests/specs/infinite-gas.k
+++ b/tests/specs/infinite-gas.k
@@ -26,15 +26,17 @@ module INFINITE-GAS-HASKELL [kore]
     rule I1          <Int I2 +Int I3 => I1 -Int I3  <Int I2         [concrete(I1, I3), simplification]
     rule I1         <=Int I2 +Int I3 => I1 -Int I3 <=Int I2         [concrete(I1, I3), simplification]
 
+    rule I1 +Int I2 => I2 +Int I1 [concrete(I1), symbolic(I2), simplification]
+
     rule (I1 +Int I2) +Int I3 => (I1 +Int I3) +Int I2 [concrete(I2), symbolic(I3), simplification]
     rule (I1 +Int I2) -Int I3 => (I1 -Int I3) +Int I2 [concrete(I2), symbolic(I3), simplification]
     rule (I1 -Int I2) +Int I3 => (I1 +Int I3) -Int I2 [concrete(I2), symbolic(I3), simplification]
     rule (I1 -Int I2) -Int I3 => (I1 -Int I3) -Int I2 [concrete(I2), symbolic(I3), simplification]
 
-    rule (I1 +Int I2) +Int I3 => I1 +Int (I2 +Int I3) [concrete(I2, I3), symbolic(I1), simplification]
-    rule (I1 +Int I2) -Int I3 => I1 +Int (I2 -Int I3) [concrete(I2, I3), symbolic(I1), simplification]
-    rule (I1 -Int I2) +Int I3 => I1 +Int (I3 -Int I2) [concrete(I2, I3), symbolic(I1), simplification]
-    rule (I1 -Int I2) -Int I3 => I1 -Int (I2 +Int I3) [concrete(I2, I3), symbolic(I1), simplification]
+    rule (I1 +Int I2) +Int I3 => (I2 +Int I3)          +Int I1 [concrete(I2, I3), symbolic(I1), simplification]
+    rule (I1 +Int I2) -Int I3 => (I2 -Int I3)          +Int I1 [concrete(I2, I3), symbolic(I1), simplification]
+    rule (I1 -Int I2) +Int I3 => (I3 -Int I2)          +Int I1 [concrete(I2, I3), symbolic(I1), simplification]
+    rule (I1 -Int I2) -Int I3 => ((0 -Int I2) -Int I3) +Int I1 [concrete(I2, I3), symbolic(I1), simplification]
 endmodule
 
 module INFINITE-GAS-JAVA [kast]
@@ -50,15 +52,17 @@ module INFINITE-GAS-JAVA [kast]
     rule I1          <Int I2 +Int I3 => I1 -Int I3  <Int I2         requires #isConcrete(I1) andBool #isConcrete(I3) [simplification]
     rule I1         <=Int I2 +Int I3 => I1 -Int I3 <=Int I2         requires #isConcrete(I1) andBool #isConcrete(I3) [simplification]
 
+    rule I1 +Int I2 => I2 +Int I1 requires #isConcrete(I1) andBool notBool #isConcrete(I2) [simplification]
+
     rule (I1 +Int I2) +Int I3 => (I1 +Int I3) +Int I2 requires #isConcrete(I2) andBool notBool #isConcrete(I3) [simplification]
     rule (I1 +Int I2) -Int I3 => (I1 -Int I3) +Int I2 requires #isConcrete(I2) andBool notBool #isConcrete(I3) [simplification]
     rule (I1 -Int I2) +Int I3 => (I1 +Int I3) -Int I2 requires #isConcrete(I2) andBool notBool #isConcrete(I3) [simplification]
     rule (I1 -Int I2) -Int I3 => (I1 -Int I3) -Int I2 requires #isConcrete(I2) andBool notBool #isConcrete(I3) [simplification]
 
-    rule (I1 +Int I2) +Int I3 => I1 +Int (I2 +Int I3) requires #isConcrete(I2) andBool #isConcrete(I3) andBool notBool #isConcrete(I1) [simplification]
-    rule (I1 +Int I2) -Int I3 => I1 +Int (I2 -Int I3) requires #isConcrete(I2) andBool #isConcrete(I3) andBool notBool #isConcrete(I1) [simplification]
-    rule (I1 -Int I2) +Int I3 => I1 +Int (I3 -Int I2) requires #isConcrete(I2) andBool #isConcrete(I3) andBool notBool #isConcrete(I1) [simplification]
-    rule (I1 -Int I2) -Int I3 => I1 -Int (I2 +Int I3) requires #isConcrete(I2) andBool #isConcrete(I3) andBool notBool #isConcrete(I1) [simplification]
+    rule (I1 +Int I2) +Int I3 => (I2 +Int I3)          +Int I1 requires #isConcrete(I2) andBool #isConcrete(I3) andBool notBool #isConcrete(I1) [simplification]
+    rule (I1 +Int I2) -Int I3 => (I2 -Int I3)          +Int I1 requires #isConcrete(I2) andBool #isConcrete(I3) andBool notBool #isConcrete(I1) [simplification]
+    rule (I1 -Int I2) +Int I3 => (I3 -Int I2)          +Int I1 requires #isConcrete(I2) andBool #isConcrete(I3) andBool notBool #isConcrete(I1) [simplification]
+    rule (I1 -Int I2) -Int I3 => ((0 -Int I2) -Int I3) +Int I1 requires #isConcrete(I2) andBool #isConcrete(I3) andBool notBool #isConcrete(I1) [simplification]
 endmodule
 
 module INFINITE-GAS-COMMON

--- a/tests/specs/infinite-gas.k
+++ b/tests/specs/infinite-gas.k
@@ -27,13 +27,14 @@ module INFINITE-GAS-HASKELL [kore]
     rule I1         <=Int I2 +Int I3 => I1 -Int I3 <=Int I2         [concrete(I1, I3), simplification]
 
     rule (I1 +Int I2) +Int I3 => (I1 +Int I3) +Int I2 [concrete(I2), symbolic(I3), simplification]
+    rule (I1 +Int I2) -Int I3 => (I1 -Int I3) +Int I2 [concrete(I2), symbolic(I3), simplification]
+    rule (I1 -Int I2) +Int I3 => (I1 +Int I3) -Int I2 [concrete(I2), symbolic(I3), simplification]
+    rule (I1 -Int I2) -Int I3 => (I1 -Int I3) -Int I2 [concrete(I2), symbolic(I3), simplification]
 
-    rule (I1 +Int I2) +Int I3 => (I1 +Int I3) +Int I2 [concrete(I2),     symbolic(I3), simplification]
-    rule (I1 -Int I2) +Int I3 => (I1 +Int I3) -Int I2 [concrete(I2),     symbolic(I3), simplification]
     rule (I1 +Int I2) +Int I3 => I1 +Int (I2 +Int I3) [concrete(I2, I3), symbolic(I1), simplification]
-    rule (I1 +Int I2) -Int I3 => (I1 -Int I3) +Int I2 [concrete(I2),     symbolic(I3), simplification]
-
-    rule (I1 +Int I2) -Int (I3 +Int I4) => (I1 -Int I3) +Int (I2 -Int I4) [concrete(I2, I4), symbolic(I1, I3), simplification]
+    rule (I1 +Int I2) -Int I3 => I1 +Int (I2 -Int I3) [concrete(I2, I3), symbolic(I1), simplification]
+    rule (I1 -Int I2) +Int I3 => I1 +Int (I3 -Int I2) [concrete(I2, I3), symbolic(I1), simplification]
+    rule (I1 -Int I2) -Int I3 => I1 -Int (I2 +Int I3) [concrete(I2, I3), symbolic(I1), simplification]
 endmodule
 
 module INFINITE-GAS-JAVA [kast]
@@ -49,12 +50,15 @@ module INFINITE-GAS-JAVA [kast]
     rule I1          <Int I2 +Int I3 => I1 -Int I3  <Int I2         requires #isConcrete(I1) andBool #isConcrete(I3) [simplification]
     rule I1         <=Int I2 +Int I3 => I1 -Int I3 <=Int I2         requires #isConcrete(I1) andBool #isConcrete(I3) [simplification]
 
-    rule (I1 +Int I2) +Int I3 => (I1 +Int I3) +Int I2 requires #isConcrete(I2)                         andBool notBool #isConcrete(I3) [simplification]
-    rule (I1 -Int I2) +Int I3 => (I1 +Int I3) -Int I2 requires #isConcrete(I2)                         andBool notBool #isConcrete(I3) [simplification]
-    rule (I1 +Int I2) +Int I3 => I1 +Int (I2 +Int I3) requires #isConcrete(I2) andBool #isConcrete(I3) andBool notBool #isConcrete(I1) [simplification]
-    rule (I1 +Int I2) -Int I3 => (I1 -Int I3) +Int I2 requires #isConcrete(I2)                         andBool notBool #isConcrete(I3) [simplification]
+    rule (I1 +Int I2) +Int I3 => (I1 +Int I3) +Int I2 requires #isConcrete(I2) andBool notBool #isConcrete(I3) [simplification]
+    rule (I1 +Int I2) -Int I3 => (I1 -Int I3) +Int I2 requires #isConcrete(I2) andBool notBool #isConcrete(I3) [simplification]
+    rule (I1 -Int I2) +Int I3 => (I1 +Int I3) -Int I2 requires #isConcrete(I2) andBool notBool #isConcrete(I3) [simplification]
+    rule (I1 -Int I2) -Int I3 => (I1 -Int I3) -Int I2 requires #isConcrete(I2) andBool notBool #isConcrete(I3) [simplification]
 
-    rule (I1 +Int I2) -Int (I3 +Int I4) => (I1 -Int I3) +Int (I2 -Int I4) requires #isConcrete(I2) andBool #isConcrete(I4) andBool notBool (#isConcrete(I1) orBool #isConcrete(I3)) [simplification]
+    rule (I1 +Int I2) +Int I3 => I1 +Int (I2 +Int I3) requires #isConcrete(I2) andBool #isConcrete(I3) andBool notBool #isConcrete(I1) [simplification]
+    rule (I1 +Int I2) -Int I3 => I1 +Int (I2 -Int I3) requires #isConcrete(I2) andBool #isConcrete(I3) andBool notBool #isConcrete(I1) [simplification]
+    rule (I1 -Int I2) +Int I3 => I1 +Int (I3 -Int I2) requires #isConcrete(I2) andBool #isConcrete(I3) andBool notBool #isConcrete(I1) [simplification]
+    rule (I1 -Int I2) -Int I3 => I1 -Int (I2 +Int I3) requires #isConcrete(I2) andBool #isConcrete(I3) andBool notBool #isConcrete(I1) [simplification]
 endmodule
 
 module INFINITE-GAS-COMMON
@@ -65,6 +69,7 @@ module INFINITE-GAS-COMMON
     rule I -Int I => 0                                                                   [simplification]
     rule I1 -Int (I1 -Int I2) => I2                                                      [simplification]
     rule (I1 -Int I2) +Int I2 => I1                                                      [simplification]
+    rule I1 -Int (I2 +Int I3) => (I1 -Int I2) -Int I3                                    [simplification]
     rule (notBool (A andBool B)) andBool A => (notBool B) andBool A                      [simplification]
     rule #if B #then C +Int C1 #else C +Int C2 #fi => C +Int #if B #then C1 #else C2 #fi [simplification]
 

--- a/tests/specs/infinite-gas.k
+++ b/tests/specs/infinite-gas.k
@@ -26,17 +26,15 @@ module INFINITE-GAS-HASKELL [kore]
     rule I1          <Int I2 +Int I3 => I1 -Int I3  <Int I2         [concrete(I1, I3), simplification]
     rule I1         <=Int I2 +Int I3 => I1 -Int I3 <=Int I2         [concrete(I1, I3), simplification]
 
-    rule I1 +Int I2 => I2 +Int I1 [concrete(I1), symbolic(I2), simplification]
-
     rule (I1 +Int I2) +Int I3 => (I1 +Int I3) +Int I2 [concrete(I2), symbolic(I3), simplification]
     rule (I1 +Int I2) -Int I3 => (I1 -Int I3) +Int I2 [concrete(I2), symbolic(I3), simplification]
     rule (I1 -Int I2) +Int I3 => (I1 +Int I3) -Int I2 [concrete(I2), symbolic(I3), simplification]
     rule (I1 -Int I2) -Int I3 => (I1 -Int I3) -Int I2 [concrete(I2), symbolic(I3), simplification]
 
-    rule (I1 +Int I2) +Int I3 => (I2 +Int I3)          +Int I1 [concrete(I2, I3), symbolic(I1), simplification]
-    rule (I1 +Int I2) -Int I3 => (I2 -Int I3)          +Int I1 [concrete(I2, I3), symbolic(I1), simplification]
-    rule (I1 -Int I2) +Int I3 => (I3 -Int I2)          +Int I1 [concrete(I2, I3), symbolic(I1), simplification]
-    rule (I1 -Int I2) -Int I3 => ((0 -Int I2) -Int I3) +Int I1 [concrete(I2, I3), symbolic(I1), simplification]
+    rule (I1 +Int I2) +Int I3 => I1 +Int (I2 +Int I3) [concrete(I2, I3), symbolic(I1), simplification]
+    rule (I1 +Int I2) -Int I3 => I1 +Int (I2 -Int I3) [concrete(I2, I3), symbolic(I1), simplification]
+    rule (I1 -Int I2) +Int I3 => I1 +Int (I3 -Int I2) [concrete(I2, I3), symbolic(I1), simplification]
+    rule (I1 -Int I2) -Int I3 => I1 -Int (I2 +Int I3) [concrete(I2, I3), symbolic(I1), simplification]
 endmodule
 
 module INFINITE-GAS-JAVA [kast]
@@ -52,17 +50,15 @@ module INFINITE-GAS-JAVA [kast]
     rule I1          <Int I2 +Int I3 => I1 -Int I3  <Int I2         requires #isConcrete(I1) andBool #isConcrete(I3) [simplification]
     rule I1         <=Int I2 +Int I3 => I1 -Int I3 <=Int I2         requires #isConcrete(I1) andBool #isConcrete(I3) [simplification]
 
-    rule I1 +Int I2 => I2 +Int I1 requires #isConcrete(I1) andBool notBool #isConcrete(I2) [simplification]
-
     rule (I1 +Int I2) +Int I3 => (I1 +Int I3) +Int I2 requires #isConcrete(I2) andBool notBool #isConcrete(I3) [simplification]
     rule (I1 +Int I2) -Int I3 => (I1 -Int I3) +Int I2 requires #isConcrete(I2) andBool notBool #isConcrete(I3) [simplification]
     rule (I1 -Int I2) +Int I3 => (I1 +Int I3) -Int I2 requires #isConcrete(I2) andBool notBool #isConcrete(I3) [simplification]
     rule (I1 -Int I2) -Int I3 => (I1 -Int I3) -Int I2 requires #isConcrete(I2) andBool notBool #isConcrete(I3) [simplification]
 
-    rule (I1 +Int I2) +Int I3 => (I2 +Int I3)          +Int I1 requires #isConcrete(I2) andBool #isConcrete(I3) andBool notBool #isConcrete(I1) [simplification]
-    rule (I1 +Int I2) -Int I3 => (I2 -Int I3)          +Int I1 requires #isConcrete(I2) andBool #isConcrete(I3) andBool notBool #isConcrete(I1) [simplification]
-    rule (I1 -Int I2) +Int I3 => (I3 -Int I2)          +Int I1 requires #isConcrete(I2) andBool #isConcrete(I3) andBool notBool #isConcrete(I1) [simplification]
-    rule (I1 -Int I2) -Int I3 => ((0 -Int I2) -Int I3) +Int I1 requires #isConcrete(I2) andBool #isConcrete(I3) andBool notBool #isConcrete(I1) [simplification]
+    rule (I1 +Int I2) +Int I3 => I1 +Int (I2 +Int I3) requires #isConcrete(I2) andBool #isConcrete(I3) andBool notBool #isConcrete(I1) [simplification]
+    rule (I1 +Int I2) -Int I3 => I1 +Int (I2 -Int I3) requires #isConcrete(I2) andBool #isConcrete(I3) andBool notBool #isConcrete(I1) [simplification]
+    rule (I1 -Int I2) +Int I3 => I1 +Int (I3 -Int I2) requires #isConcrete(I2) andBool #isConcrete(I3) andBool notBool #isConcrete(I1) [simplification]
+    rule (I1 -Int I2) -Int I3 => I1 -Int (I2 +Int I3) requires #isConcrete(I2) andBool #isConcrete(I3) andBool notBool #isConcrete(I1) [simplification]
 endmodule
 
 module INFINITE-GAS-COMMON

--- a/tests/specs/infinite-gas.k
+++ b/tests/specs/infinite-gas.k
@@ -146,7 +146,4 @@ module INFINITE-GAS-COMMON
     rule 0 <=Int #allBut64th(G)       => true                          [simplification]
     rule #allBut64th(G) <Int #gas(G') => true requires G <Int #gas(G') [simplification]
 
-    rule #gas(G1) +Int (G2 +Int G3) => (#gas(G1) +Int G2) +Int G3 [simplification]
-    rule #gas(G1) +Int (G2 -Int G3) => (#gas(G1) +Int G2) -Int G3 [simplification]
-
 endmodule

--- a/tests/specs/infinite-gas.k
+++ b/tests/specs/infinite-gas.k
@@ -26,8 +26,13 @@ module INFINITE-GAS-HASKELL [kore]
     rule I1          <Int I2 +Int I3 => I1 -Int I3  <Int I2         [concrete(I1, I3), simplification]
     rule I1         <=Int I2 +Int I3 => I1 -Int I3 <=Int I2         [concrete(I1, I3), simplification]
 
-    rule ((I1 +Int I2) +Int I3) +Int I4 => (I1 +Int I3) +Int (I2 +Int I4) [concrete(I2, I4), symbolic(I1, I3), simplification]
-    rule ((I1 +Int I2) -Int I3) +Int I4 => (I1 -Int I3) +Int (I2 +Int I4) [concrete(I2, I4), symbolic(I1, I3), simplification]
+    rule (I1 +Int I2) +Int I3 => (I1 +Int I3) +Int I2 [concrete(I2), symbolic(I3), simplification]
+
+    rule (I1 +Int I2) +Int I3 => (I1 +Int I3) +Int I2 [concrete(I2),     symbolic(I3), simplification]
+    rule (I1 -Int I2) +Int I3 => (I1 +Int I3) -Int I2 [concrete(I2),     symbolic(I3), simplification]
+    rule (I1 +Int I2) +Int I3 => I1 +Int (I2 +Int I3) [concrete(I2, I3), symbolic(I1), simplification]
+    rule (I1 +Int I2) -Int I3 => (I1 -Int I3) +Int I2 [concrete(I2),     symbolic(I3), simplification]
+
     rule (I1 +Int I2) -Int (I3 +Int I4) => (I1 -Int I3) +Int (I2 -Int I4) [concrete(I2, I4), symbolic(I1, I3), simplification]
 endmodule
 
@@ -44,8 +49,11 @@ module INFINITE-GAS-JAVA [kast]
     rule I1          <Int I2 +Int I3 => I1 -Int I3  <Int I2         requires #isConcrete(I1) andBool #isConcrete(I3) [simplification]
     rule I1         <=Int I2 +Int I3 => I1 -Int I3 <=Int I2         requires #isConcrete(I1) andBool #isConcrete(I3) [simplification]
 
-    rule ((I1 +Int I2) +Int I3) +Int I4 => (I1 +Int I3) +Int (I2 +Int I4) requires #isConcrete(I2) andBool #isConcrete(I4) andBool notBool (#isConcrete(I1) orBool #isConcrete(I3)) [simplification]
-    rule ((I1 +Int I2) -Int I3) +Int I4 => (I1 -Int I3) +Int (I2 +Int I4) requires #isConcrete(I2) andBool #isConcrete(I4) andBool notBool (#isConcrete(I1) orBool #isConcrete(I3)) [simplification]
+    rule (I1 +Int I2) +Int I3 => (I1 +Int I3) +Int I2 requires #isConcrete(I2)                         andBool notBool #isConcrete(I3) [simplification]
+    rule (I1 -Int I2) +Int I3 => (I1 +Int I3) -Int I2 requires #isConcrete(I2)                         andBool notBool #isConcrete(I3) [simplification]
+    rule (I1 +Int I2) +Int I3 => I1 +Int (I2 +Int I3) requires #isConcrete(I2) andBool #isConcrete(I3) andBool notBool #isConcrete(I1) [simplification]
+    rule (I1 +Int I2) -Int I3 => (I1 -Int I3) +Int I2 requires #isConcrete(I2)                         andBool notBool #isConcrete(I3) [simplification]
+
     rule (I1 +Int I2) -Int (I3 +Int I4) => (I1 -Int I3) +Int (I2 -Int I4) requires #isConcrete(I2) andBool #isConcrete(I4) andBool notBool (#isConcrete(I1) orBool #isConcrete(I3)) [simplification]
 endmodule
 

--- a/tests/specs/infinite-gas.k
+++ b/tests/specs/infinite-gas.k
@@ -125,7 +125,7 @@ module INFINITE-GAS-COMMON
     rule #gas(_) <Int Cmem(_, _)  => false [simplification]
     rule Cmem(_, _) <=Int #gas(_) => true  [simplification]
 
-    rule 0 <Int #allBut64th(G)        => true requires 0 <Int G        [simplification]
-    rule #allBut64th(G) <Int #gas(G') => true requires G <Int #gas(G') [simplification]
+    rule 0 <Int #allBut64th(_)       => true [simplification]
+    rule #allBut64th(_) <Int #gas(_) => true [simplification]
 
 endmodule

--- a/tests/specs/infinite-gas.k
+++ b/tests/specs/infinite-gas.k
@@ -54,9 +54,10 @@ module INFINITE-GAS-COMMON
 
  // Generic rules
 
-    rule I -Int I => 0                                              [simplification]
-    rule I1 -Int (I1 -Int I2) => I2                                 [simplification]
-    rule (notBool (A andBool B)) andBool A => (notBool B) andBool A [simplification]
+    rule I -Int I => 0                                                                   [simplification]
+    rule I1 -Int (I1 -Int I2) => I2                                                      [simplification]
+    rule (notBool (A andBool B)) andBool A => (notBool B) andBool A                      [simplification]
+    rule #if B #then C +Int C1 #else C +Int C2 #fi => C +Int #if B #then C1 #else C2 #fi [simplification]
 
  // Symbolic Gas
 
@@ -84,6 +85,8 @@ module INFINITE-GAS-COMMON
 
     rule minInt(#gas(G), #gas(G'))              => #gas(minInt(G, G'))              [simplification]
     rule #if B #then #gas(G) #else #gas(G') #fi => #gas(#if B #then G #else G' #fi) [simplification]
+
+    rule #allBut64th(#gas(G)) => #gas(#allBut64th(G)) [simplification]
 
     rule #gas(_)  <Int #gas(_) => false [simplification]
     rule #gas(_) <=Int #gas(_) => true  [simplification]
@@ -121,4 +124,8 @@ module INFINITE-GAS-COMMON
 
     rule #gas(_) <Int Cmem(_, _)  => false [simplification]
     rule Cmem(_, _) <=Int #gas(_) => true  [simplification]
+
+    rule 0 <Int #allBut64th(G)        => true requires 0 <Int G        [simplification]
+    rule #allBut64th(G) <Int #gas(G') => true requires G <Int #gas(G') [simplification]
+
 endmodule

--- a/tests/specs/infinite-gas.k
+++ b/tests/specs/infinite-gas.k
@@ -128,4 +128,7 @@ module INFINITE-GAS-COMMON
     rule 0 <=Int #allBut64th(G)       => true                          [simplification]
     rule #allBut64th(G) <Int #gas(G') => true requires G <Int #gas(G') [simplification]
 
+    rule #gas(G1) +Int (G2 +Int G3) => (#gas(G1) +Int G2) +Int G3 [simplification]
+    rule #gas(G1) +Int (G2 -Int G3) => (#gas(G1) +Int G2) -Int G3 [simplification]
+
 endmodule

--- a/tests/specs/infinite-gas.k
+++ b/tests/specs/infinite-gas.k
@@ -17,62 +17,62 @@ endmodule
 module INFINITE-GAS-HASKELL [kore]
     imports INFINITE-GAS-COMMON
 
-    rule #gas(_)  <Int _I => false [concrete(_I), simplification]
-    rule #gas(_) <=Int _I => false [concrete(_I), simplification]
-    rule #gas(_) >=Int _I => true  [concrete(_I), simplification]
-    rule _I <=Int #gas(_) => true  [concrete(_I), simplification]
+    rule #gas(_)  <Int _C => false [concrete(_C), simplification]
+    rule #gas(_) <=Int _C => false [concrete(_C), simplification]
+    rule #gas(_) >=Int _C => true  [concrete(_C), simplification]
+    rule _C <=Int #gas(_) => true  [concrete(_C), simplification]
 
-    rule I1 +Int I2  <Int I3         => I1          <Int I3 -Int I2 [concrete(I2, I3), simplification]
-    rule I1          <Int I2 +Int I3 => I1 -Int I3  <Int I2         [concrete(I1, I3), simplification]
-    rule I1         <=Int I2 +Int I3 => I1 -Int I3 <=Int I2         [concrete(I1, I3), simplification]
+    rule I1 +Int C2  <Int C3         => I1          <Int C3 -Int C2 [concrete(C2, C3), simplification]
+    rule C1          <Int I2 +Int C3 => C1 -Int C3  <Int I2         [concrete(C1, C3), simplification]
+    rule C1         <=Int I2 +Int C3 => C1 -Int C3 <=Int I2         [concrete(C1, C3), simplification]
 
-    rule I1 +Int I2 => I2 +Int I1 [concrete(I1), symbolic(I2), simplification]
+    rule C1 +Int S2 => S2 +Int C1 [concrete(C1), symbolic(S2), simplification]
 
-    rule I1 +Int (I2 +Int I3) => (I1 +Int I2) +Int I3 [symbolic(I1, I2), simplification]
-    rule I1 +Int (I2 -Int I3) => (I1 +Int I2) -Int I3 [symbolic(I1, I2), simplification]
-    rule I1 -Int (I2 +Int I3) => (I1 -Int I2) -Int I3 [symbolic(I1, I2), simplification]
-    rule I1 -Int (I2 -Int I3) => (I1 -Int I2) +Int I3 [symbolic(I1, I2), simplification]
+    rule S1 +Int (S2 +Int I3) => (S1 +Int S2) +Int I3 [symbolic(S1, S2), simplification]
+    rule S1 +Int (S2 -Int I3) => (S1 +Int S2) -Int I3 [symbolic(S1, S2), simplification]
+    rule S1 -Int (S2 +Int I3) => (S1 -Int S2) -Int I3 [symbolic(S1, S2), simplification]
+    rule S1 -Int (S2 -Int I3) => (S1 -Int S2) +Int I3 [symbolic(S1, S2), simplification]
 
-    rule (I1 +Int I2) +Int I3 => (I1 +Int I3) +Int I2 [concrete(I2), symbolic(I3), simplification]
-    rule (I1 +Int I2) -Int I3 => (I1 -Int I3) +Int I2 [concrete(I2), symbolic(I3), simplification]
-    rule (I1 -Int I2) +Int I3 => (I1 +Int I3) -Int I2 [concrete(I2), symbolic(I3), simplification]
-    rule (I1 -Int I2) -Int I3 => (I1 -Int I3) -Int I2 [concrete(I2), symbolic(I3), simplification]
+    rule (I1 +Int C2) +Int S3 => (I1 +Int S3) +Int C2 [concrete(C2), symbolic(S3), simplification]
+    rule (I1 +Int C2) -Int S3 => (I1 -Int S3) +Int C2 [concrete(C2), symbolic(S3), simplification]
+    rule (I1 -Int C2) +Int S3 => (I1 +Int S3) -Int C2 [concrete(C2), symbolic(S3), simplification]
+    rule (I1 -Int C2) -Int S3 => (I1 -Int S3) -Int C2 [concrete(C2), symbolic(S3), simplification]
 
-    rule (I1 +Int I2) +Int I3 => I1 +Int (I2 +Int I3) [concrete(I2, I3), symbolic(I1), simplification]
-    rule (I1 +Int I2) -Int I3 => I1 +Int (I2 -Int I3) [concrete(I2, I3), symbolic(I1), simplification]
-    rule (I1 -Int I2) +Int I3 => I1 +Int (I3 -Int I2) [concrete(I2, I3), symbolic(I1), simplification]
-    rule (I1 -Int I2) -Int I3 => I1 -Int (I2 +Int I3) [concrete(I2, I3), symbolic(I1), simplification]
+    rule (S1 +Int C2) +Int C3 => S1 +Int (C2 +Int C3) [concrete(C2, C3), symbolic(S1), simplification]
+    rule (S1 +Int C2) -Int C3 => S1 +Int (C2 -Int C3) [concrete(C2, C3), symbolic(S1), simplification]
+    rule (S1 -Int C2) +Int C3 => S1 +Int (C3 -Int C2) [concrete(C2, C3), symbolic(S1), simplification]
+    rule (S1 -Int C2) -Int C3 => S1 -Int (C2 +Int C3) [concrete(C2, C3), symbolic(S1), simplification]
 endmodule
 
 module INFINITE-GAS-JAVA [kast]
     imports INFINITE-GAS-COMMON
     imports K-REFLECTION
 
-    rule #gas(_)  <Int I => false requires #isConcrete(I) [simplification]
-    rule #gas(_) <=Int I => false requires #isConcrete(I) [simplification]
-    rule #gas(_) >=Int I => true  requires #isConcrete(I) [simplification]
-    rule I <=Int #gas(_) => true  requires #isConcrete(I) [simplification]
+    rule #gas(_)  <Int C => false requires #isConcrete(C) [simplification]
+    rule #gas(_) <=Int C => false requires #isConcrete(C) [simplification]
+    rule #gas(_) >=Int C => true  requires #isConcrete(C) [simplification]
+    rule C <=Int #gas(_) => true  requires #isConcrete(C) [simplification]
 
-    rule I1 +Int I2  <Int I3         => I1          <Int I3 -Int I2 requires #isConcrete(I2) andBool #isConcrete(I3) [simplification]
-    rule I1          <Int I2 +Int I3 => I1 -Int I3  <Int I2         requires #isConcrete(I1) andBool #isConcrete(I3) [simplification]
-    rule I1         <=Int I2 +Int I3 => I1 -Int I3 <=Int I2         requires #isConcrete(I1) andBool #isConcrete(I3) [simplification]
+    rule I1 +Int C2  <Int C3         => I1          <Int C3 -Int C2 requires #isConcrete(C2) andBool #isConcrete(C3) [simplification]
+    rule C1          <Int I2 +Int C3 => C1 -Int C3  <Int I2         requires #isConcrete(C1) andBool #isConcrete(C3) [simplification]
+    rule C1         <=Int I2 +Int C3 => C1 -Int C3 <=Int I2         requires #isConcrete(C1) andBool #isConcrete(C3) [simplification]
 
-    rule I1 +Int I2 => I2 +Int I1 requires #isConcrete(I1) andBool notBool #isConcrete(I2) [simplification]
+    rule C1 +Int S2 => S2 +Int C1 requires #isConcrete(C1) andBool notBool #isConcrete(S2) [simplification]
 
-    rule I1 +Int (I2 +Int I3) => (I1 +Int I2) +Int I3 requires (notBool #isConcrete(I1)) andBool (notBool #isConcrete(I2)) [simplification]
-    rule I1 +Int (I2 -Int I3) => (I1 +Int I2) -Int I3 requires (notBool #isConcrete(I1)) andBool (notBool #isConcrete(I2)) [simplification]
-    rule I1 -Int (I2 +Int I3) => (I1 -Int I2) -Int I3 requires (notBool #isConcrete(I1)) andBool (notBool #isConcrete(I2)) [simplification]
-    rule I1 -Int (I2 -Int I3) => (I1 -Int I2) +Int I3 requires (notBool #isConcrete(I1)) andBool (notBool #isConcrete(I2)) [simplification]
+    rule S1 +Int (S2 +Int I3) => (S1 +Int S2) +Int I3 requires (notBool #isConcrete(S1)) andBool (notBool #isConcrete(S2)) [simplification]
+    rule S1 +Int (S2 -Int I3) => (S1 +Int S2) -Int I3 requires (notBool #isConcrete(S1)) andBool (notBool #isConcrete(S2)) [simplification]
+    rule S1 -Int (S2 +Int I3) => (S1 -Int S2) -Int I3 requires (notBool #isConcrete(S1)) andBool (notBool #isConcrete(S2)) [simplification]
+    rule S1 -Int (S2 -Int I3) => (S1 -Int S2) +Int I3 requires (notBool #isConcrete(S1)) andBool (notBool #isConcrete(S2)) [simplification]
 
-    rule (I1 +Int I2) +Int I3 => (I1 +Int I3) +Int I2 requires #isConcrete(I2) andBool notBool #isConcrete(I3) [simplification]
-    rule (I1 +Int I2) -Int I3 => (I1 -Int I3) +Int I2 requires #isConcrete(I2) andBool notBool #isConcrete(I3) [simplification]
-    rule (I1 -Int I2) +Int I3 => (I1 +Int I3) -Int I2 requires #isConcrete(I2) andBool notBool #isConcrete(I3) [simplification]
-    rule (I1 -Int I2) -Int I3 => (I1 -Int I3) -Int I2 requires #isConcrete(I2) andBool notBool #isConcrete(I3) [simplification]
+    rule (I1 +Int C2) +Int S3 => (I1 +Int S3) +Int C2 requires #isConcrete(C2) andBool notBool #isConcrete(S3) [simplification]
+    rule (I1 +Int C2) -Int S3 => (I1 -Int S3) +Int C2 requires #isConcrete(C2) andBool notBool #isConcrete(S3) [simplification]
+    rule (I1 -Int C2) +Int S3 => (I1 +Int S3) -Int C2 requires #isConcrete(C2) andBool notBool #isConcrete(S3) [simplification]
+    rule (I1 -Int C2) -Int S3 => (I1 -Int S3) -Int C2 requires #isConcrete(C2) andBool notBool #isConcrete(S3) [simplification]
 
-    rule (I1 +Int I2) +Int I3 => I1 +Int (I2 +Int I3) requires #isConcrete(I2) andBool #isConcrete(I3) andBool notBool #isConcrete(I1) [simplification]
-    rule (I1 +Int I2) -Int I3 => I1 +Int (I2 -Int I3) requires #isConcrete(I2) andBool #isConcrete(I3) andBool notBool #isConcrete(I1) [simplification]
-    rule (I1 -Int I2) +Int I3 => I1 +Int (I3 -Int I2) requires #isConcrete(I2) andBool #isConcrete(I3) andBool notBool #isConcrete(I1) [simplification]
-    rule (I1 -Int I2) -Int I3 => I1 -Int (I2 +Int I3) requires #isConcrete(I2) andBool #isConcrete(I3) andBool notBool #isConcrete(I1) [simplification]
+    rule (S1 +Int C2) +Int C3 => S1 +Int (C2 +Int C3) requires #isConcrete(C2) andBool #isConcrete(C3) andBool notBool #isConcrete(S1) [simplification]
+    rule (S1 +Int C2) -Int C3 => S1 +Int (C2 -Int C3) requires #isConcrete(C2) andBool #isConcrete(C3) andBool notBool #isConcrete(S1) [simplification]
+    rule (S1 -Int C2) +Int C3 => S1 +Int (C3 -Int C2) requires #isConcrete(C2) andBool #isConcrete(C3) andBool notBool #isConcrete(S1) [simplification]
+    rule (S1 -Int C2) -Int C3 => S1 -Int (C2 +Int C3) requires #isConcrete(C2) andBool #isConcrete(C3) andBool notBool #isConcrete(S1) [simplification]
 endmodule
 
 module INFINITE-GAS-COMMON

--- a/tests/specs/mcd/concrete-rules.txt
+++ b/tests/specs/mcd/concrete-rules.txt
@@ -1,5 +1,6 @@
 EDSL.#ceil32
 EDSL.keccakIntList
+EVM.allBut64th
 EVM.Cextra
 EVM.Cmem
 EVM.Cnew

--- a/tests/specs/mcd/concrete-rules.txt
+++ b/tests/specs/mcd/concrete-rules.txt
@@ -1,6 +1,6 @@
 EDSL.#ceil32
 EDSL.keccakIntList
-EVM.allBut64th
+EVM.allBut64th.pos
 EVM.Cextra
 EVM.Cmem
 EVM.Cnew


### PR DESCRIPTION
This PR does several things:

-   Makes sure that `#allBut64th` is always a positive number (for simplifying the infinite gas reasoning).
-   Leaves `#allBut64th` unevaluated to keep expressions small.
-   Loosens the bounds on the infinite gas simplifications (0 <Int G => 0 <=Int G in many cases).
-   Generalizes the lemmas for re-associating gas expressions so they apply in more places.

The added tests are inspired by several MKR proofs, but as they are not necessary for making them pass (just make the gas expressions generated significantly smaller which leads to up to 10% performance improvement), I decided not to add the MKR tests themselves.