### PR TITLE
MKR regression proofs

### DIFF
--- a/tests/failing-symbolic.haskell
+++ b/tests/failing-symbolic.haskell
@@ -65,6 +65,7 @@ tests/specs/mcd/dstoken-burn-self-fail-rough-spec.k
 tests/specs/mcd/dstoken-transferfrom-fail-rough-spec.k
 tests/specs/mcd/dsvalue-peek-pass-rough-spec.k
 tests/specs/mcd/dsvalue-read-pass-spec.k
+tests/specs/mcd/end-cash-pass-rough-spec.k
 tests/specs/mcd/end-pack-pass-rough-spec.k
 tests/specs/mcd/end-subuu-pass-spec.k
 tests/specs/mcd/flapper-yank-pass-rough-spec.k

--- a/tests/failing-symbolic.haskell
+++ b/tests/failing-symbolic.haskell
@@ -81,12 +81,13 @@ tests/specs/mcd/functional-spec.k
 tests/specs/mcd/pot-join-pass-rough-spec.k
 tests/specs/mcd/vat-addui-fail-rough-spec.k
 tests/specs/mcd/vat-deny-diff-fail-rough-spec.k
+tests/specs/mcd/vat-flux-diff-pass-rough-spec.k
 tests/specs/mcd/vat-move-diff-rough-spec.k
 tests/specs/mcd/vat-mului-pass-spec.k
 tests/specs/mcd/vat-slip-pass-rough-spec.k
 tests/specs/mcd/vat-subui-fail-rough-spec.k
 tests/specs/mcd/vat-subui-pass-rough-spec.k
 tests/specs/mcd/vat-subui-pass-spec.k
-tests/specs/mcd/vow-flog-fail-rough-spec.k
 tests/specs/mcd/vow-fess-fail-rough-spec.k
+tests/specs/mcd/vow-flog-fail-rough-spec.k
 tests/specs/opcodes/create-spec.k

--- a/tests/failing-symbolic.haskell
+++ b/tests/failing-symbolic.haskell
@@ -84,6 +84,7 @@ tests/specs/mcd/pot-join-pass-rough-spec.k
 tests/specs/mcd/vat-addui-fail-rough-spec.k
 tests/specs/mcd/vat-deny-diff-fail-rough-spec.k
 tests/specs/mcd/vat-flux-diff-pass-rough-spec.k
+tests/specs/mcd/vat-frob-diff-zero-dart-pass-rough-spec.k
 tests/specs/mcd/vat-move-diff-rough-spec.k
 tests/specs/mcd/vat-mului-pass-spec.k
 tests/specs/mcd/vat-slip-pass-rough-spec.k

--- a/tests/failing-symbolic.haskell
+++ b/tests/failing-symbolic.haskell
@@ -88,4 +88,5 @@ tests/specs/mcd/vat-subui-fail-rough-spec.k
 tests/specs/mcd/vat-subui-pass-rough-spec.k
 tests/specs/mcd/vat-subui-pass-spec.k
 tests/specs/mcd/vow-flog-fail-rough-spec.k
+tests/specs/mcd/vow-fess-fail-rough-spec.k
 tests/specs/opcodes/create-spec.k

--- a/tests/failing-symbolic.haskell
+++ b/tests/failing-symbolic.haskell
@@ -74,6 +74,7 @@ tests/specs/mcd/flipper-bids-pass-rough-spec.k
 tests/specs/mcd/flipper-tau-pass-spec.k
 tests/specs/mcd/flipper-ttl-pass-spec.k
 tests/specs/mcd/flopper-cage-pass-spec.k
+tests/specs/mcd/flopper-dent-guy-diff-tic-not-0-pass-rough-spec.k
 tests/specs/mcd/flopper-dent-guy-same-pass-rough-spec.k
 tests/specs/mcd/flopper-file-pass-rough-spec.k
 tests/specs/mcd/flopper-kick-pass-rough-spec.k

--- a/tests/failing-symbolic.haskell
+++ b/tests/failing-symbolic.haskell
@@ -90,6 +90,7 @@ tests/specs/mcd/vat-slip-pass-rough-spec.k
 tests/specs/mcd/vat-subui-fail-rough-spec.k
 tests/specs/mcd/vat-subui-pass-rough-spec.k
 tests/specs/mcd/vat-subui-pass-spec.k
+tests/specs/mcd/vow-cage-surplus-pass-rough-spec.k
 tests/specs/mcd/vow-fess-fail-rough-spec.k
 tests/specs/mcd/vow-flog-fail-rough-spec.k
 tests/specs/opcodes/create-spec.k

--- a/tests/specs/functional/lemmas-spec.k
+++ b/tests/specs/functional/lemmas-spec.k
@@ -21,6 +21,23 @@ module LEMMAS-SPEC
 
     claim <k> runLemma ( bool2Word((UINT8 ==K 0) ==K false) ) => doneLemma ( UINT8 ) ... </k> requires #rangeBool(UINT8)
 
+ // Arithmetic
+ // ----------
+
+    claim <k> runLemma((X +Int pow256) -Int chop(Y)) => doneLemma(X -Int Y) ... </k>
+      requires #rangeUInt(256, X)
+       andBool #rangeSInt(256, Y)
+       andBool Y <Int 0
+
+ // Arithmetic Comparisons
+ // ----------------------
+
+    claim <k> runLemma(#rangeUInt(256, #lookup(M, KX) -Int #lookup(M, KY))) => doneLemma(true) ... </k>
+      requires #rangeUInt(256, X) andBool X ==Int #lookup(M, KX)
+       andBool #rangeUInt(256, Y) andBool Y ==Int #lookup(M, KY)
+       andBool #rangeUInt(256, Z) andBool Z ==Int #lookup(M, KZ)
+       andBool #rangeUInt(256, (X -Int Y) -Int Z)
+
  // Buffer write simplifications
  // ----------------------------
 

--- a/tests/specs/functional/lemmas-spec.k
+++ b/tests/specs/functional/lemmas-spec.k
@@ -21,14 +21,6 @@ module LEMMAS-SPEC
 
     claim <k> runLemma ( bool2Word((UINT8 ==K 0) ==K false) ) => doneLemma ( UINT8 ) ... </k> requires #rangeBool(UINT8)
 
- // Arithmetic
- // ----------
-
-    claim <k> runLemma((X +Int pow256) -Int chop(Y)) => doneLemma(X -Int Y) ... </k>
-      requires #rangeUInt(256, X)
-       andBool #rangeSInt(256, Y)
-       andBool Y <Int 0
-
  // Arithmetic Comparisons
  // ----------------------
 

--- a/tests/specs/lemmas.k
+++ b/tests/specs/lemmas.k
@@ -11,12 +11,12 @@ module LEMMAS
     rule #lookup ( _M:Map [ K1 <- V1 ] , K2 ) => #lookup ( K1 |-> V1 , K1 ) requires K1 ==Int  K2 [simplification]
     rule #lookup (  M:Map [ K1 <- _  ] , K2 ) => #lookup ( M         , K2 ) requires K1 =/=Int K2 [simplification]
 
-    rule 0 <=Int #lookup( _M:Map , _ )             => true                                       [simplification]
-    rule         #lookup( _M:Map , _ ) <Int pow256 => true                                       [simplification, smt-lemma]
+    rule 0 <=Int #lookup( _M:Map , _ )             => true [simplification, smt-lemma]
+    rule         #lookup( _M:Map , _ ) <Int pow256 => true [simplification, smt-lemma]
 
     //Required for #Ceil(#buf)
-    rule 0 <=Int keccak( _ )             => true                                                 [simplification]
-    rule         keccak( _ ) <Int pow256 => true                                                 [simplification]
+    rule 0 <=Int keccak( _ )             => true [simplification]
+    rule         keccak( _ ) <Int pow256 => true [simplification]
 
     rule WS ++ .ByteArray => WS  [simplification]
     rule .ByteArray ++ WS => WS  [simplification]

--- a/tests/specs/mcd/end-cash-pass-rough-spec.k
+++ b/tests/specs/mcd/end-cash-pass-rough-spec.k
@@ -1,0 +1,829 @@
+requires "verification.k"
+
+module END-CASH-PASS-ROUGH-SPEC
+    imports VERIFICATION
+
+    // End_cash
+    claim [End.cash.pass.rough]:
+      <k> #execute ~> CONTINUATION => #halt ~> CONTINUATION </k>
+      <exit-code> 1 </exit-code>
+      <mode> NORMAL </mode>
+      <schedule> ISTANBUL </schedule>
+      <ethereum>
+        <evm>
+          <output> .ByteArray </output>
+          <statusCode> _ => EVMC_SUCCESS </statusCode>
+          <endPC> _ => ?_ </endPC>
+          <callStack> _VCallStack </callStack>
+          <interimStates> _ </interimStates>
+          <touchedAccounts> _ => ?_ </touchedAccounts>
+          <callState>
+            <program> End_bin_runtime </program>
+            <jumpDests> #computeValidJumpDests(End_bin_runtime) </jumpDests>
+            <id> ACCT_ID </id>
+            <caller> CALLER_ID </caller>
+            <callData> #abiCallData("cash", #bytes32(ABI_ilk), #uint256(ABI_wad)) ++ CD => ?_ </callData>
+            <callValue> VCallValue </callValue>
+            <wordStack> .WordStack => ?_ </wordStack>
+            <localMem> .Memory => ?_ </localMem>
+            <pc> 0 => ?_ </pc>
+            <gas> #gas(VGas) => ?_ </gas>
+            <memoryUsed> 0 => ?_ </memoryUsed>
+            <callGas> _ => ?_ </callGas>
+            <static> false </static>
+            <callDepth> VCallDepth </callDepth>
+          </callState>
+          <substate>
+            <selfDestruct> _VSelfDestruct </selfDestruct>
+            <log> _ => ?_ </log>
+            <refund> _Vrefund => ?_ </refund>
+          </substate>
+          <gasPrice> _ </gasPrice>
+          <origin> ORIGIN_ID </origin>
+          <blockhashes> _ </blockhashes>
+          <block>
+            <previousHash> _ </previousHash>
+            <ommersHash> _ </ommersHash>
+            <coinbase> _ </coinbase>
+            <stateRoot> _ </stateRoot>
+            <transactionsRoot> _ </transactionsRoot>
+            <receiptsRoot> _ </receiptsRoot>
+            <logsBloom> _ </logsBloom>
+            <difficulty> _ </difficulty>
+            <number> _BLOCK_NUMBER </number>
+            <gasLimit> _ </gasLimit>
+            <gasUsed> _ </gasUsed>
+            <timestamp> TIME </timestamp>
+            <extraData> _ </extraData>
+            <mixHash> _ </mixHash>
+            <blockNonce> _ </blockNonce>
+            <ommerBlockHeaders> _ </ommerBlockHeaders>
+          </block>
+        </evm>
+        <network>
+          <chainID> VChainId </chainID>
+          <activeAccounts> SetItem(ACCT_ID)
+          SetItem(Vat)
+          SetItem(1)
+          SetItem(2)
+          SetItem(3)
+          SetItem(4)
+          SetItem(5)
+          SetItem(6)
+          SetItem(7)
+          SetItem(8)
+          SetItem(9) _ </activeAccounts>
+          <accounts>
+            <account>
+              <acctID> ACCT_ID </acctID>
+              <balance> ACCT_ID_balance </balance>
+              <code> End_bin_runtime </code>
+              <storage> ACCT_ID_STORAGE => ACCT_ID_STORAGE [ #End.out[ABI_ilk][CALLER_ID] <- Out +Int ABI_wad ] </storage>
+              <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
+              <nonce> _Nonce_End => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> Vat </acctID>
+              <balance> Vat_balance </balance>
+              <code> Vat_bin_runtime </code>
+              <storage> Vat_STORAGE => Vat_STORAGE [ #Vat.gem[ABI_ilk][ACCT_ID] <- Gem_e -Int #rmul(ABI_wad, Fix) ] [ #Vat.gem[ABI_ilk][CALLER_ID] <- Gem_c +Int #rmul(ABI_wad, Fix) ] </storage>
+              <origStorage> Vat_ORIG_STORAGE </origStorage>
+              <nonce> _Nonce_Vat => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> 1 </acctID>
+              <balance> ECREC_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 2 </acctID>
+              <balance> SHA256_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 3 </acctID>
+              <balance> RIP160_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 4 </acctID>
+              <balance> ID_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 5 </acctID>
+              <balance> MODEXP_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 6 </acctID>
+              <balance> ECADD_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 7 </acctID>
+              <balance> ECMUL_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 8 </acctID>
+              <balance> ECPAIRING_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 9 </acctID>
+              <balance> BLAKE2_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+           ...
+          </accounts>
+          <txOrder> _ </txOrder>
+          <txPending> _ </txPending>
+          <messages> _ </messages>
+        </network>
+      </ethereum>
+      requires #rangeAddress(ACCT_ID)
+       andBool ACCT_ID =/=Int 0
+       andBool #notPrecompileAddress(ACCT_ID)
+       andBool #rangeAddress(CALLER_ID)
+       andBool #rangeAddress(ORIGIN_ID)
+       andBool #rangeUInt(256, TIME)
+       andBool #rangeUInt(256, ACCT_ID_balance)
+       andBool #rangeUInt(256, ECREC_BAL)
+       andBool #rangeUInt(256, SHA256_BAL)
+       andBool #rangeUInt(256, RIP160_BAL)
+       andBool #rangeUInt(256, ID_BAL)
+       andBool #rangeUInt(256, MODEXP_BAL)
+       andBool #rangeUInt(256, ECADD_BAL)
+       andBool #rangeUInt(256, ECMUL_BAL)
+       andBool #rangeUInt(256, ECPAIRING_BAL)
+       andBool #rangeUInt(256, BLAKE2_BAL)
+       andBool VCallDepth <=Int 1024
+       andBool #rangeUInt(256, VCallValue)
+       andBool #rangeUInt(256, VChainId)
+
+       andBool (#rangeBytes(32, ABI_ilk)
+       andBool (#rangeUInt(256, ABI_wad)
+       andBool (#rangeAddress(Vat)
+       andBool (#rangeUInt(256, Fix)
+       andBool (#rangeUInt(256, Bag)
+       andBool (#rangeUInt(256, Out)
+       andBool (#rangeUInt(256, Gem_e)
+       andBool (#rangeUInt(256, Gem_c)
+       andBool (#rangeUInt(256, Vat_balance)
+       andBool ((#sizeByteArray(CD) <=Int 1250000000)
+       andBool ((#notPrecompileAddress(Vat))
+       andBool ((ACCT_ID =/=Int Vat)
+       andBool ((ACCT_ID =/=Int CALLER_ID)
+       andBool ((Vat =/=Int 0)
+       andBool (#rangeUInt(256, Junk_0)
+       andBool (#rangeUInt(256, Junk_1)
+       andBool (#rangeUInt(256, Junk_2)
+       andBool (#rangeUInt(256, Junk_3)
+       andBool (#rangeUInt(256, Junk_4)
+       andBool (#rangeUInt(256, Junk_5)
+       andBool (#rangeUInt(256, Junk_6)
+       andBool (#rangeUInt(256, Junk_7)
+       andBool (((Fix =/=Int 0))
+       andBool (((Out +Int ABI_wad <=Int Bag))
+       andBool (((VCallValue ==Int 0))
+       andBool (((VCallDepth <Int 1024))
+       andBool ((#rangeUInt(256, ABI_wad *Int Fix))
+       andBool ((#rangeUInt(256, Gem_e -Int ((ABI_wad *Int Fix) /Int #Ray)))
+       andBool ((#rangeUInt(256, Gem_c +Int ((ABI_wad *Int Fix) /Int #Ray))))))))))))))))))))))))))))))))
+
+       andBool #lookup(ACCT_ID_STORAGE, #End.vat) ==Int Vat
+       andBool #lookup(ACCT_ID_STORAGE, #End.fix[ABI_ilk]) ==Int Fix
+       andBool #lookup(ACCT_ID_STORAGE, #End.bag[CALLER_ID]) ==Int Bag
+       andBool #lookup(ACCT_ID_STORAGE, #End.out[ABI_ilk][CALLER_ID]) ==Int Out
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #End.vat) ==Int Junk_0
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #End.fix[ABI_ilk]) ==Int Junk_1
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #End.bag[CALLER_ID]) ==Int Junk_2
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #End.out[ABI_ilk][CALLER_ID]) ==Int Junk_3
+       andBool #End.vat =/=Int #End.fix[ABI_ilk]
+       andBool #End.vat =/=Int #End.bag[CALLER_ID]
+       andBool #End.vat =/=Int #End.out[ABI_ilk][CALLER_ID]
+       andBool #End.fix[ABI_ilk] =/=Int #End.bag[CALLER_ID]
+       andBool #End.fix[ABI_ilk] =/=Int #End.out[ABI_ilk][CALLER_ID]
+       andBool #End.bag[CALLER_ID] =/=Int #End.out[ABI_ilk][CALLER_ID]
+       andBool #lookup(Vat_STORAGE, #Vat.can[ACCT_ID][ACCT_ID]) ==Int Junk_4
+       andBool #lookup(Vat_STORAGE, #Vat.gem[ABI_ilk][ACCT_ID]) ==Int Gem_e
+       andBool #lookup(Vat_STORAGE, #Vat.gem[ABI_ilk][CALLER_ID]) ==Int Gem_c
+       andBool #lookup(Vat_ORIG_STORAGE, #Vat.can[ACCT_ID][ACCT_ID]) ==Int Junk_5
+       andBool #lookup(Vat_ORIG_STORAGE, #Vat.gem[ABI_ilk][ACCT_ID]) ==Int Junk_6
+       andBool #lookup(Vat_ORIG_STORAGE, #Vat.gem[ABI_ilk][CALLER_ID]) ==Int Junk_7
+       andBool #Vat.can[ACCT_ID][ACCT_ID] =/=Int #Vat.gem[ABI_ilk][ACCT_ID]
+       andBool #Vat.can[ACCT_ID][ACCT_ID] =/=Int #Vat.gem[ABI_ilk][CALLER_ID]
+       andBool #Vat.gem[ABI_ilk][ACCT_ID] =/=Int #Vat.gem[ABI_ilk][CALLER_ID]
+
+    // End_adduu
+    claim [End.adduu.pass]:
+      <k> #execute ~> CONTINUATION => #execute ~> CONTINUATION </k>
+      <exit-code> 1 </exit-code>
+      <mode> NORMAL </mode>
+      <schedule> ISTANBUL </schedule>
+      <ethereum>
+        <evm>
+          <output> VOutput => VOutput </output>
+          <statusCode> _ => ?_ </statusCode>
+          <endPC> _ => ?_ </endPC>
+          <callStack> _VCallStack </callStack>
+          <interimStates> _ </interimStates>
+          <touchedAccounts> _ => ?_ </touchedAccounts>
+          <callState>
+            <program> End_bin_runtime </program>
+            <jumpDests> #computeValidJumpDests(End_bin_runtime) </jumpDests>
+            <id> ACCT_ID </id>
+            <caller> CALLER_ID </caller>
+            <callData> _ => ?_ </callData>
+            <callValue> VCallValue </callValue>
+            <wordStack> ABI_y : ABI_x : JMPTO : WS  =>  JMPTO : ABI_x +Int ABI_y : WS </wordStack>
+            <localMem> _ </localMem>
+            <pc> 14775 => 14800 </pc>
+            <gas> #gas(VGas) => #gas ( ( VGas +Int -54 ) ) </gas>
+            <memoryUsed> VMemoryUsed </memoryUsed>
+            <callGas> _ => ?_ </callGas>
+            <static> _ </static>
+            <callDepth> VCallDepth </callDepth>
+          </callState>
+          <substate>
+            <selfDestruct> _VSelfDestruct </selfDestruct>
+            <log> _ => ?_ </log>
+            <refund> _Vrefund => ?_ </refund>
+          </substate>
+          <gasPrice> _ </gasPrice>
+          <origin> ORIGIN_ID </origin>
+          <blockhashes> _ </blockhashes>
+          <block>
+            <previousHash> _ </previousHash>
+            <ommersHash> _ </ommersHash>
+            <coinbase> _ </coinbase>
+            <stateRoot> _ </stateRoot>
+            <transactionsRoot> _ </transactionsRoot>
+            <receiptsRoot> _ </receiptsRoot>
+            <logsBloom> _ </logsBloom>
+            <difficulty> _ </difficulty>
+            <number> _BLOCK_NUMBER </number>
+            <gasLimit> _ </gasLimit>
+            <gasUsed> _ </gasUsed>
+            <timestamp> TIME </timestamp>
+            <extraData> _ </extraData>
+            <mixHash> _ </mixHash>
+            <blockNonce> _ </blockNonce>
+            <ommerBlockHeaders> _ </ommerBlockHeaders>
+          </block>
+        </evm>
+        <network>
+          <chainID> VChainId </chainID>
+          <activeAccounts> SetItem(ACCT_ID)
+          SetItem(1)
+          SetItem(2)
+          SetItem(3)
+          SetItem(4)
+          SetItem(5)
+          SetItem(6)
+          SetItem(7)
+          SetItem(8)
+          SetItem(9) _ </activeAccounts>
+          <accounts>
+            <account>
+              <acctID> ACCT_ID </acctID>
+              <balance> ACCT_ID_balance </balance>
+              <code> End_bin_runtime </code>
+              <storage> ACCT_ID_STORAGE => ACCT_ID_STORAGE  </storage>
+              <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
+              <nonce> _Nonce_End => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> 1 </acctID>
+              <balance> ECREC_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 2 </acctID>
+              <balance> SHA256_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 3 </acctID>
+              <balance> RIP160_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 4 </acctID>
+              <balance> ID_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 5 </acctID>
+              <balance> MODEXP_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 6 </acctID>
+              <balance> ECADD_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 7 </acctID>
+              <balance> ECMUL_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 8 </acctID>
+              <balance> ECPAIRING_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 9 </acctID>
+              <balance> BLAKE2_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+           ...
+          </accounts>
+          <txOrder> _ </txOrder>
+          <txPending> _ </txPending>
+          <messages> _ </messages>
+        </network>
+      </ethereum>
+      requires #rangeAddress(ACCT_ID)
+       andBool ACCT_ID =/=Int 0
+       andBool #notPrecompileAddress(ACCT_ID)
+       andBool #rangeAddress(CALLER_ID)
+       andBool #rangeAddress(ORIGIN_ID)
+       andBool #rangeUInt(256, TIME)
+       andBool #rangeUInt(256, ACCT_ID_balance)
+       andBool #rangeUInt(256, ECREC_BAL)
+       andBool #rangeUInt(256, SHA256_BAL)
+       andBool #rangeUInt(256, RIP160_BAL)
+       andBool #rangeUInt(256, ID_BAL)
+       andBool #rangeUInt(256, MODEXP_BAL)
+       andBool #rangeUInt(256, ECADD_BAL)
+       andBool #rangeUInt(256, ECMUL_BAL)
+       andBool #rangeUInt(256, ECPAIRING_BAL)
+       andBool #rangeUInt(256, BLAKE2_BAL)
+       andBool VCallDepth <=Int 1024
+       andBool #rangeUInt(256, VCallValue)
+       andBool #rangeUInt(256, VChainId)
+
+       andBool (#rangeUInt(256, ABI_x)
+       andBool (#rangeUInt(256, ABI_y)
+       andBool ((#sizeWordStack(WS) <=Int 100)
+       andBool (#rangeUInt(256, VMemoryUsed)
+       andBool ((#rangeUInt(256, ABI_x +Int ABI_y)))))))
+
+
+    [trusted, matching(infGas)]
+
+
+    // End_rmul
+    claim [End.rmul.pass]:
+      <k> #execute ~> CONTINUATION => #execute ~> CONTINUATION </k>
+      <exit-code> 1 </exit-code>
+      <mode> NORMAL </mode>
+      <schedule> ISTANBUL </schedule>
+      <ethereum>
+        <evm>
+          <output> VOutput => VOutput </output>
+          <statusCode> _ => ?_ </statusCode>
+          <endPC> _ => ?_ </endPC>
+          <callStack> _VCallStack </callStack>
+          <interimStates> _ </interimStates>
+          <touchedAccounts> _ => ?_ </touchedAccounts>
+          <callState>
+            <program> End_bin_runtime </program>
+            <jumpDests> #computeValidJumpDests(End_bin_runtime) </jumpDests>
+            <id> ACCT_ID </id>
+            <caller> CALLER_ID </caller>
+            <callData> _ => ?_ </callData>
+            <callValue> VCallValue </callValue>
+            <wordStack> ABI_y : ABI_x : JMPTO : WS  =>  JMPTO : (ABI_x *Int ABI_y) /Int #Ray : WS </wordStack>
+            <localMem> _ </localMem>
+            <pc> 14623 => 14663 </pc>
+            <gas> #gas(VGas) => #if ABI_y ==Int 0
+              #then   #gas ( ( VGas +Int -127 ) )
+              #else   #gas ( ( VGas +Int -179 ) )
+            #fi </gas>
+            <memoryUsed> VMemoryUsed </memoryUsed>
+            <callGas> _ => ?_ </callGas>
+            <static> _ </static>
+            <callDepth> VCallDepth </callDepth>
+          </callState>
+          <substate>
+            <selfDestruct> _VSelfDestruct </selfDestruct>
+            <log> _ => ?_ </log>
+            <refund> _Vrefund => ?_ </refund>
+          </substate>
+          <gasPrice> _ </gasPrice>
+          <origin> ORIGIN_ID </origin>
+          <blockhashes> _ </blockhashes>
+          <block>
+            <previousHash> _ </previousHash>
+            <ommersHash> _ </ommersHash>
+            <coinbase> _ </coinbase>
+            <stateRoot> _ </stateRoot>
+            <transactionsRoot> _ </transactionsRoot>
+            <receiptsRoot> _ </receiptsRoot>
+            <logsBloom> _ </logsBloom>
+            <difficulty> _ </difficulty>
+            <number> _BLOCK_NUMBER </number>
+            <gasLimit> _ </gasLimit>
+            <gasUsed> _ </gasUsed>
+            <timestamp> TIME </timestamp>
+            <extraData> _ </extraData>
+            <mixHash> _ </mixHash>
+            <blockNonce> _ </blockNonce>
+            <ommerBlockHeaders> _ </ommerBlockHeaders>
+          </block>
+        </evm>
+        <network>
+          <chainID> VChainId </chainID>
+          <activeAccounts> SetItem(ACCT_ID)
+          SetItem(1)
+          SetItem(2)
+          SetItem(3)
+          SetItem(4)
+          SetItem(5)
+          SetItem(6)
+          SetItem(7)
+          SetItem(8)
+          SetItem(9) _ </activeAccounts>
+          <accounts>
+            <account>
+              <acctID> ACCT_ID </acctID>
+              <balance> ACCT_ID_balance </balance>
+              <code> End_bin_runtime </code>
+              <storage> ACCT_ID_STORAGE => ACCT_ID_STORAGE  </storage>
+              <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
+              <nonce> _Nonce_End => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> 1 </acctID>
+              <balance> ECREC_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 2 </acctID>
+              <balance> SHA256_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 3 </acctID>
+              <balance> RIP160_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 4 </acctID>
+              <balance> ID_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 5 </acctID>
+              <balance> MODEXP_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 6 </acctID>
+              <balance> ECADD_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 7 </acctID>
+              <balance> ECMUL_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 8 </acctID>
+              <balance> ECPAIRING_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 9 </acctID>
+              <balance> BLAKE2_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+           ...
+          </accounts>
+          <txOrder> _ </txOrder>
+          <txPending> _ </txPending>
+          <messages> _ </messages>
+        </network>
+      </ethereum>
+      requires #rangeAddress(ACCT_ID)
+       andBool ACCT_ID =/=Int 0
+       andBool #notPrecompileAddress(ACCT_ID)
+       andBool #rangeAddress(CALLER_ID)
+       andBool #rangeAddress(ORIGIN_ID)
+       andBool #rangeUInt(256, TIME)
+       andBool #rangeUInt(256, ACCT_ID_balance)
+       andBool #rangeUInt(256, ECREC_BAL)
+       andBool #rangeUInt(256, SHA256_BAL)
+       andBool #rangeUInt(256, RIP160_BAL)
+       andBool #rangeUInt(256, ID_BAL)
+       andBool #rangeUInt(256, MODEXP_BAL)
+       andBool #rangeUInt(256, ECADD_BAL)
+       andBool #rangeUInt(256, ECMUL_BAL)
+       andBool #rangeUInt(256, ECPAIRING_BAL)
+       andBool #rangeUInt(256, BLAKE2_BAL)
+       andBool VCallDepth <=Int 1024
+       andBool #rangeUInt(256, VCallValue)
+       andBool #rangeUInt(256, VChainId)
+
+       andBool (#rangeUInt(256, ABI_x)
+       andBool (#rangeUInt(256, ABI_y)
+       andBool ((#sizeWordStack(WS) <=Int 1000)
+       andBool (#rangeUInt(256, VMemoryUsed)
+       andBool ((#rangeUInt(256, ABI_x *Int ABI_y)))))))
+
+
+    [trusted, matching(infGas)]
+
+
+    // Vat_flux-diff
+    claim [Vat.flux-diff.pass]:
+      <k> #execute ~> CONTINUATION => #halt ~> CONTINUATION </k>
+      <exit-code> 1 </exit-code>
+      <mode> NORMAL </mode>
+      <schedule> ISTANBUL </schedule>
+      <ethereum>
+        <evm>
+          <output> .ByteArray </output>
+          <statusCode> _ => EVMC_SUCCESS </statusCode>
+          <endPC> _ => ?_ </endPC>
+          <callStack> _VCallStack </callStack>
+          <interimStates> _ </interimStates>
+          <touchedAccounts> _ => ?_ </touchedAccounts>
+          <callState>
+            <program> Vat_bin_runtime </program>
+            <jumpDests> #computeValidJumpDests(Vat_bin_runtime) </jumpDests>
+            <id> ACCT_ID </id>
+            <caller> CALLER_ID </caller>
+            <callData> #abiCallData("flux", #bytes32(ABI_ilk), #address(ABI_src), #address(ABI_dst), #uint256(ABI_wad)) ++ CD => ?_ </callData>
+            <callValue> VCallValue </callValue>
+            <wordStack> .WordStack => ?_ </wordStack>
+            <localMem> .Memory => ?_ </localMem>
+            <pc> 0 => ?_ </pc>
+            <gas> #gas(VGas) => #gas ( ( ( ( VGas -Int Csstore( ISTANBUL , ( Gem_src -Int ABI_wad ) , Gem_src , Junk_1 ) ) -Int Csstore( ISTANBUL , ( Gem_dst +Int ABI_wad ) , Gem_dst , Junk_2 ) ) +Int -8307 ) ) </gas>
+            <memoryUsed> 0 => ?_ </memoryUsed>
+            <callGas> _ => ?_ </callGas>
+            <static> false </static>
+            <callDepth> VCallDepth </callDepth>
+          </callState>
+          <substate>
+            <selfDestruct> _VSelfDestruct </selfDestruct>
+            <log> _ => ?_ </log>
+            <refund> _Vrefund => ?_ </refund>
+          </substate>
+          <gasPrice> _ </gasPrice>
+          <origin> ORIGIN_ID </origin>
+          <blockhashes> _ </blockhashes>
+          <block>
+            <previousHash> _ </previousHash>
+            <ommersHash> _ </ommersHash>
+            <coinbase> _ </coinbase>
+            <stateRoot> _ </stateRoot>
+            <transactionsRoot> _ </transactionsRoot>
+            <receiptsRoot> _ </receiptsRoot>
+            <logsBloom> _ </logsBloom>
+            <difficulty> _ </difficulty>
+            <number> _BLOCK_NUMBER </number>
+            <gasLimit> _ </gasLimit>
+            <gasUsed> _ </gasUsed>
+            <timestamp> TIME </timestamp>
+            <extraData> _ </extraData>
+            <mixHash> _ </mixHash>
+            <blockNonce> _ </blockNonce>
+            <ommerBlockHeaders> _ </ommerBlockHeaders>
+          </block>
+        </evm>
+        <network>
+          <chainID> VChainId </chainID>
+          <activeAccounts> SetItem(ACCT_ID)
+          SetItem(1)
+          SetItem(2)
+          SetItem(3)
+          SetItem(4)
+          SetItem(5)
+          SetItem(6)
+          SetItem(7)
+          SetItem(8)
+          SetItem(9) _ </activeAccounts>
+          <accounts>
+            <account>
+              <acctID> ACCT_ID </acctID>
+              <balance> ACCT_ID_balance </balance>
+              <code> Vat_bin_runtime </code>
+              <storage> ACCT_ID_STORAGE => ACCT_ID_STORAGE [ #Vat.gem[ABI_ilk][ABI_src] <- Gem_src -Int ABI_wad ] [ #Vat.gem[ABI_ilk][ABI_dst] <- Gem_dst +Int ABI_wad ] </storage>
+              <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
+              <nonce> _Nonce_Vat => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> 1 </acctID>
+              <balance> ECREC_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 2 </acctID>
+              <balance> SHA256_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 3 </acctID>
+              <balance> RIP160_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 4 </acctID>
+              <balance> ID_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 5 </acctID>
+              <balance> MODEXP_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 6 </acctID>
+              <balance> ECADD_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 7 </acctID>
+              <balance> ECMUL_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 8 </acctID>
+              <balance> ECPAIRING_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 9 </acctID>
+              <balance> BLAKE2_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+           ...
+          </accounts>
+          <txOrder> _ </txOrder>
+          <txPending> _ </txPending>
+          <messages> _ </messages>
+        </network>
+      </ethereum>
+      requires #rangeAddress(ACCT_ID)
+       andBool ACCT_ID =/=Int 0
+       andBool #notPrecompileAddress(ACCT_ID)
+       andBool #rangeAddress(CALLER_ID)
+       andBool #rangeAddress(ORIGIN_ID)
+       andBool #rangeUInt(256, TIME)
+       andBool #rangeUInt(256, ACCT_ID_balance)
+       andBool #rangeUInt(256, ECREC_BAL)
+       andBool #rangeUInt(256, SHA256_BAL)
+       andBool #rangeUInt(256, RIP160_BAL)
+       andBool #rangeUInt(256, ID_BAL)
+       andBool #rangeUInt(256, MODEXP_BAL)
+       andBool #rangeUInt(256, ECADD_BAL)
+       andBool #rangeUInt(256, ECMUL_BAL)
+       andBool #rangeUInt(256, ECPAIRING_BAL)
+       andBool #rangeUInt(256, BLAKE2_BAL)
+       andBool VCallDepth <=Int 1024
+       andBool #rangeUInt(256, VCallValue)
+       andBool #rangeUInt(256, VChainId)
+
+       andBool (#rangeBytes(32, ABI_ilk)
+       andBool (#rangeAddress(ABI_src)
+       andBool (#rangeAddress(ABI_dst)
+       andBool (#rangeUInt(256, ABI_wad)
+       andBool (#rangeUInt(256, May)
+       andBool (#rangeUInt(256, Gem_src)
+       andBool (#rangeUInt(256, Gem_dst)
+       andBool ((#sizeByteArray(CD) <=Int 1250000000)
+       andBool ((ABI_src =/=Int ABI_dst)
+       andBool (#rangeUInt(256, Junk_0)
+       andBool (#rangeUInt(256, Junk_1)
+       andBool (#rangeUInt(256, Junk_2)
+       andBool ((((May ==Int 1 orBool ABI_src ==Int CALLER_ID)))
+       andBool (((VCallValue ==Int 0))
+       andBool ((#rangeUInt(256, Gem_src -Int ABI_wad))
+       andBool ((#rangeUInt(256, Gem_dst +Int ABI_wad))))))))))))))))))
+
+       andBool #lookup(ACCT_ID_STORAGE, #Vat.can[ABI_src][CALLER_ID]) ==Int May
+       andBool #lookup(ACCT_ID_STORAGE, #Vat.gem[ABI_ilk][ABI_src]) ==Int Gem_src
+       andBool #lookup(ACCT_ID_STORAGE, #Vat.gem[ABI_ilk][ABI_dst]) ==Int Gem_dst
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Vat.can[ABI_src][CALLER_ID]) ==Int Junk_0
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Vat.gem[ABI_ilk][ABI_src]) ==Int Junk_1
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Vat.gem[ABI_ilk][ABI_dst]) ==Int Junk_2
+       andBool #Vat.can[ABI_src][CALLER_ID] =/=Int #Vat.gem[ABI_ilk][ABI_src]
+       andBool #Vat.can[ABI_src][CALLER_ID] =/=Int #Vat.gem[ABI_ilk][ABI_dst]
+       andBool #Vat.gem[ABI_ilk][ABI_src] =/=Int #Vat.gem[ABI_ilk][ABI_dst]
+    [trusted, matching(infGas)]
+
+
+endmodule

--- a/tests/specs/mcd/flopper-dent-guy-diff-tic-not-0-pass-rough-spec.k
+++ b/tests/specs/mcd/flopper-dent-guy-diff-tic-not-0-pass-rough-spec.k
@@ -1,0 +1,870 @@
+requires "verification.k"
+
+module FLOPPER-DENT-GUY-DIFF-TIC-NOT-0-PASS-ROUGH-SPEC
+    imports VERIFICATION
+
+    // Flopper_dent-guy-diff-tic-not-0
+    claim [Flopper.dent-guy-diff-tic-not-0.pass.rough]:
+      <k> #execute ~> CONTINUATION => #halt ~> CONTINUATION </k>
+      <exit-code> 1 </exit-code>
+      <mode> NORMAL </mode>
+      <schedule> ISTANBUL </schedule>
+      <ethereum>
+        <evm>
+          <output> .ByteArray </output>
+          <statusCode> _ => EVMC_SUCCESS </statusCode>
+          <endPC> _ => ?_ </endPC>
+          <callStack> _VCallStack </callStack>
+          <interimStates> _ </interimStates>
+          <touchedAccounts> _ => ?_ </touchedAccounts>
+          <callState>
+            <program> Flopper_bin_runtime </program>
+            <jumpDests> #computeValidJumpDests(Flopper_bin_runtime) </jumpDests>
+            <id> ACCT_ID </id>
+            <caller> CALLER_ID </caller>
+            <callData> #abiCallData("dent", #uint256(ABI_id), #uint256(ABI_lot), #uint256(ABI_bid)) ++ CD => ?_ </callData>
+            <callValue> VCallValue </callValue>
+            <wordStack> .WordStack => ?_ </wordStack>
+            <localMem> .Memory => ?_ </localMem>
+            <pc> 0 => ?_ </pc>
+            <gas> #gas(VGas) => ?_ </gas>
+            <memoryUsed> 0 => ?_ </memoryUsed>
+            <callGas> _ => ?_ </callGas>
+            <static> false </static>
+            <callDepth> VCallDepth </callDepth>
+          </callState>
+          <substate>
+            <selfDestruct> _VSelfDestruct </selfDestruct>
+            <log> _ => ?_ </log>
+            <refund> _Vrefund => ?_ </refund>
+          </substate>
+          <gasPrice> _ </gasPrice>
+          <origin> ORIGIN_ID </origin>
+          <blockhashes> _ </blockhashes>
+          <block>
+            <previousHash> _ </previousHash>
+            <ommersHash> _ </ommersHash>
+            <coinbase> _ </coinbase>
+            <stateRoot> _ </stateRoot>
+            <transactionsRoot> _ </transactionsRoot>
+            <receiptsRoot> _ </receiptsRoot>
+            <logsBloom> _ </logsBloom>
+            <difficulty> _ </difficulty>
+            <number> _BLOCK_NUMBER </number>
+            <gasLimit> _ </gasLimit>
+            <gasUsed> _ </gasUsed>
+            <timestamp> TIME </timestamp>
+            <extraData> _ </extraData>
+            <mixHash> _ </mixHash>
+            <blockNonce> _ </blockNonce>
+            <ommerBlockHeaders> _ </ommerBlockHeaders>
+          </block>
+        </evm>
+        <network>
+          <chainID> VChainId </chainID>
+          <activeAccounts> SetItem(ACCT_ID)
+          SetItem(Vat)
+          SetItem(1)
+          SetItem(2)
+          SetItem(3)
+          SetItem(4)
+          SetItem(5)
+          SetItem(6)
+          SetItem(7)
+          SetItem(8)
+          SetItem(9) _ </activeAccounts>
+          <accounts>
+            <account>
+              <acctID> ACCT_ID </acctID>
+              <balance> ACCT_ID_balance </balance>
+              <code> Flopper_bin_runtime </code>
+              <storage> ACCT_ID_STORAGE => ACCT_ID_STORAGE [ #Flopper.bids[ABI_id].lot <- ABI_lot ] [ #Flopper.bids[ABI_id].guy_tic_end <- #WordPackAddrUInt48UInt48(CALLER_ID, TIME +Int Ttl, End) ] </storage>
+              <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
+              <nonce> _Nonce_Flopper => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> Vat </acctID>
+              <balance> Vat_balance </balance>
+              <code> Vat_bin_runtime </code>
+              <storage> Vat_STORAGE => Vat_STORAGE [ #Vat.dai[CALLER_ID] <- Dai_a -Int ABI_bid ] [ #Vat.dai[Guy] <- Dai_g +Int ABI_bid ] </storage>
+              <origStorage> Vat_ORIG_STORAGE </origStorage>
+              <nonce> _Nonce_Vat => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> 1 </acctID>
+              <balance> ECREC_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 2 </acctID>
+              <balance> SHA256_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 3 </acctID>
+              <balance> RIP160_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 4 </acctID>
+              <balance> ID_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 5 </acctID>
+              <balance> MODEXP_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 6 </acctID>
+              <balance> ECADD_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 7 </acctID>
+              <balance> ECMUL_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 8 </acctID>
+              <balance> ECPAIRING_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 9 </acctID>
+              <balance> BLAKE2_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+           ...
+          </accounts>
+          <txOrder> _ </txOrder>
+          <txPending> _ </txPending>
+          <messages> _ </messages>
+        </network>
+      </ethereum>
+      requires #rangeAddress(ACCT_ID)
+       andBool ACCT_ID =/=Int 0
+       andBool #notPrecompileAddress(ACCT_ID)
+       andBool #rangeAddress(CALLER_ID)
+       andBool #rangeAddress(ORIGIN_ID)
+       andBool #rangeUInt(256, TIME)
+       andBool #rangeUInt(256, ACCT_ID_balance)
+       andBool #rangeUInt(256, ECREC_BAL)
+       andBool #rangeUInt(256, SHA256_BAL)
+       andBool #rangeUInt(256, RIP160_BAL)
+       andBool #rangeUInt(256, ID_BAL)
+       andBool #rangeUInt(256, MODEXP_BAL)
+       andBool #rangeUInt(256, ECADD_BAL)
+       andBool #rangeUInt(256, ECMUL_BAL)
+       andBool #rangeUInt(256, ECPAIRING_BAL)
+       andBool #rangeUInt(256, BLAKE2_BAL)
+       andBool VCallDepth <=Int 1024
+       andBool #rangeUInt(256, VCallValue)
+       andBool #rangeUInt(256, VChainId)
+
+       andBool (#rangeUInt(256, ABI_id)
+       andBool (#rangeUInt(256, ABI_lot)
+       andBool (#rangeUInt(256, ABI_bid)
+       andBool (#rangeUInt(256, Live)
+       andBool (#rangeAddress(Vat)
+       andBool (#rangeUInt(256, Beg)
+       andBool (#rangeUInt(48, Ttl)
+       andBool (#rangeUInt(48, Tau)
+       andBool (#rangeUInt(256, Bid)
+       andBool (#rangeUInt(256, Lot)
+       andBool (#rangeAddress(Guy)
+       andBool (#rangeUInt(48, Tic)
+       andBool (#rangeUInt(48, End)
+       andBool (#rangeUInt(256, CanMove)
+       andBool (#rangeUInt(256, Dai_a)
+       andBool (#rangeUInt(256, Dai_g)
+       andBool (#rangeUInt(256, Vat_balance)
+       andBool ((#sizeByteArray(CD) <=Int 1250000000)
+       andBool ((#notPrecompileAddress(Vat))
+       andBool ((#notPrecompileAddress(Guy))
+       andBool ((ACCT_ID =/=Int Vat)
+       andBool ((CALLER_ID =/=Int ACCT_ID)
+       andBool ((CALLER_ID =/=Int Guy)
+       andBool ((#rangeUInt(48, TIME))
+       andBool ((Tic =/=Int 0)
+       andBool ((Vat =/=Int 0)
+       andBool (#rangeUInt(256, Junk_0)
+       andBool (#rangeUInt(256, Junk_1)
+       andBool (#rangeUInt(256, Junk_2)
+       andBool (#rangeUInt(256, Junk_3)
+       andBool (#rangeUInt(256, Junk_4)
+       andBool (#rangeUInt(256, Junk_5)
+       andBool (#rangeUInt(256, Junk_6)
+       andBool (#rangeUInt(256, Junk_7)
+       andBool (#rangeUInt(256, Junk_8)
+       andBool (#rangeUInt(256, Junk_9)
+       andBool ((((Live ==Int 1)))
+       andBool ((((Guy =/=Int 0)))
+       andBool ((((Tic >Int TIME)))
+       andBool ((((End >Int TIME)))
+       andBool ((((ABI_bid ==Int Bid)))
+       andBool ((((ABI_lot <Int  Lot)))
+       andBool ((((Lot *Int #Wad <=Int maxUInt256)))
+       andBool ((((Beg *Int ABI_lot <=Int Lot *Int #Wad)))
+       andBool ((((CanMove ==Int 1)))
+       andBool ((((VCallValue ==Int 0)))
+       andBool ((((VCallDepth <Int 1024)))
+       andBool (((#rangeUInt(256, Dai_a -Int ABI_bid)))
+       andBool (((#rangeUInt(256, Dai_g +Int ABI_bid)))
+       andBool ((#rangeUInt(48, TIME +Int Ttl))))))))))))))))))))))))))))))))))))))))))))))))))))
+
+       andBool #lookup(ACCT_ID_STORAGE, #Flopper.live) ==Int Live
+       andBool #lookup(ACCT_ID_STORAGE, #Flopper.vat) ==Int Vat
+       andBool #lookup(ACCT_ID_STORAGE, #Flopper.beg) ==Int Beg
+       andBool #lookup(ACCT_ID_STORAGE, #Flopper.ttl_tau) ==Int #WordPackUInt48UInt48(Ttl, Tau)
+       andBool #lookup(ACCT_ID_STORAGE, #Flopper.bids[ABI_id].bid) ==Int Bid
+       andBool #lookup(ACCT_ID_STORAGE, #Flopper.bids[ABI_id].lot) ==Int Lot
+       andBool #lookup(ACCT_ID_STORAGE, #Flopper.bids[ABI_id].guy_tic_end) ==Int #WordPackAddrUInt48UInt48(Guy, Tic, End)
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Flopper.live) ==Int Junk_0
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Flopper.vat) ==Int Junk_1
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Flopper.beg) ==Int Junk_2
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Flopper.ttl_tau) ==Int Junk_3
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Flopper.bids[ABI_id].bid) ==Int Junk_4
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Flopper.bids[ABI_id].lot) ==Int Junk_5
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Flopper.bids[ABI_id].guy_tic_end) ==Int Junk_6
+       andBool #Flopper.live =/=Int #Flopper.vat
+       andBool #Flopper.live =/=Int #Flopper.beg
+       andBool #Flopper.live =/=Int #Flopper.ttl_tau
+       andBool #Flopper.live =/=Int #Flopper.bids[ABI_id].bid
+       andBool #Flopper.live =/=Int #Flopper.bids[ABI_id].lot
+       andBool #Flopper.live =/=Int #Flopper.bids[ABI_id].guy_tic_end
+       andBool #Flopper.vat =/=Int #Flopper.beg
+       andBool #Flopper.vat =/=Int #Flopper.ttl_tau
+       andBool #Flopper.vat =/=Int #Flopper.bids[ABI_id].bid
+       andBool #Flopper.vat =/=Int #Flopper.bids[ABI_id].lot
+       andBool #Flopper.vat =/=Int #Flopper.bids[ABI_id].guy_tic_end
+       andBool #Flopper.beg =/=Int #Flopper.ttl_tau
+       andBool #Flopper.beg =/=Int #Flopper.bids[ABI_id].bid
+       andBool #Flopper.beg =/=Int #Flopper.bids[ABI_id].lot
+       andBool #Flopper.beg =/=Int #Flopper.bids[ABI_id].guy_tic_end
+       andBool #Flopper.ttl_tau =/=Int #Flopper.bids[ABI_id].bid
+       andBool #Flopper.ttl_tau =/=Int #Flopper.bids[ABI_id].lot
+       andBool #Flopper.ttl_tau =/=Int #Flopper.bids[ABI_id].guy_tic_end
+       andBool #Flopper.bids[ABI_id].bid =/=Int #Flopper.bids[ABI_id].lot
+       andBool #Flopper.bids[ABI_id].bid =/=Int #Flopper.bids[ABI_id].guy_tic_end
+       andBool #Flopper.bids[ABI_id].lot =/=Int #Flopper.bids[ABI_id].guy_tic_end
+       andBool #lookup(Vat_STORAGE, #Vat.can[CALLER_ID][ACCT_ID]) ==Int CanMove
+       andBool #lookup(Vat_STORAGE, #Vat.dai[CALLER_ID]) ==Int Dai_a
+       andBool #lookup(Vat_STORAGE, #Vat.dai[Guy]) ==Int Dai_g
+       andBool #lookup(Vat_ORIG_STORAGE, #Vat.can[CALLER_ID][ACCT_ID]) ==Int Junk_7
+       andBool #lookup(Vat_ORIG_STORAGE, #Vat.dai[CALLER_ID]) ==Int Junk_8
+       andBool #lookup(Vat_ORIG_STORAGE, #Vat.dai[Guy]) ==Int Junk_9
+       andBool #Vat.can[CALLER_ID][ACCT_ID] =/=Int #Vat.dai[CALLER_ID]
+       andBool #Vat.can[CALLER_ID][ACCT_ID] =/=Int #Vat.dai[Guy]
+       andBool #Vat.dai[CALLER_ID] =/=Int #Vat.dai[Guy]
+
+    // Flopper_muluu
+    claim [Flopper.muluu.pass]:
+      <k> #execute ~> CONTINUATION => #execute ~> CONTINUATION </k>
+      <exit-code> 1 </exit-code>
+      <mode> NORMAL </mode>
+      <schedule> ISTANBUL </schedule>
+      <ethereum>
+        <evm>
+          <output> VOutput => VOutput </output>
+          <statusCode> _ => ?_ </statusCode>
+          <endPC> _ => ?_ </endPC>
+          <callStack> _VCallStack </callStack>
+          <interimStates> _ </interimStates>
+          <touchedAccounts> _ => ?_ </touchedAccounts>
+          <callState>
+            <program> Flopper_bin_runtime </program>
+            <jumpDests> #computeValidJumpDests(Flopper_bin_runtime) </jumpDests>
+            <id> ACCT_ID </id>
+            <caller> CALLER_ID </caller>
+            <callData> _ => ?_ </callData>
+            <callValue> VCallValue </callValue>
+            <wordStack> ABI_y : ABI_x : JMPTO : WS  =>  JMPTO : ABI_x *Int ABI_y : WS </wordStack>
+            <localMem> _ </localMem>
+            <pc> 8685 => 8728 </pc>
+            <gas> #gas(VGas) => #if ABI_y ==Int 0
+              #then   #gas ( ( VGas +Int -54 ) )
+              #else   #gas ( ( VGas +Int -106 ) )
+            #fi </gas>
+            <memoryUsed> VMemoryUsed </memoryUsed>
+            <callGas> _ => ?_ </callGas>
+            <static> _ </static>
+            <callDepth> VCallDepth </callDepth>
+          </callState>
+          <substate>
+            <selfDestruct> _VSelfDestruct </selfDestruct>
+            <log> _ => ?_ </log>
+            <refund> _Vrefund => ?_ </refund>
+          </substate>
+          <gasPrice> _ </gasPrice>
+          <origin> ORIGIN_ID </origin>
+          <blockhashes> _ </blockhashes>
+          <block>
+            <previousHash> _ </previousHash>
+            <ommersHash> _ </ommersHash>
+            <coinbase> _ </coinbase>
+            <stateRoot> _ </stateRoot>
+            <transactionsRoot> _ </transactionsRoot>
+            <receiptsRoot> _ </receiptsRoot>
+            <logsBloom> _ </logsBloom>
+            <difficulty> _ </difficulty>
+            <number> _BLOCK_NUMBER </number>
+            <gasLimit> _ </gasLimit>
+            <gasUsed> _ </gasUsed>
+            <timestamp> TIME </timestamp>
+            <extraData> _ </extraData>
+            <mixHash> _ </mixHash>
+            <blockNonce> _ </blockNonce>
+            <ommerBlockHeaders> _ </ommerBlockHeaders>
+          </block>
+        </evm>
+        <network>
+          <chainID> VChainId </chainID>
+          <activeAccounts> SetItem(ACCT_ID)
+          SetItem(1)
+          SetItem(2)
+          SetItem(3)
+          SetItem(4)
+          SetItem(5)
+          SetItem(6)
+          SetItem(7)
+          SetItem(8)
+          SetItem(9) _ </activeAccounts>
+          <accounts>
+            <account>
+              <acctID> ACCT_ID </acctID>
+              <balance> ACCT_ID_balance </balance>
+              <code> Flopper_bin_runtime </code>
+              <storage> ACCT_ID_STORAGE => ACCT_ID_STORAGE  </storage>
+              <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
+              <nonce> _Nonce_Flopper => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> 1 </acctID>
+              <balance> ECREC_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 2 </acctID>
+              <balance> SHA256_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 3 </acctID>
+              <balance> RIP160_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 4 </acctID>
+              <balance> ID_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 5 </acctID>
+              <balance> MODEXP_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 6 </acctID>
+              <balance> ECADD_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 7 </acctID>
+              <balance> ECMUL_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 8 </acctID>
+              <balance> ECPAIRING_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 9 </acctID>
+              <balance> BLAKE2_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+           ...
+          </accounts>
+          <txOrder> _ </txOrder>
+          <txPending> _ </txPending>
+          <messages> _ </messages>
+        </network>
+      </ethereum>
+      requires #rangeAddress(ACCT_ID)
+       andBool ACCT_ID =/=Int 0
+       andBool #notPrecompileAddress(ACCT_ID)
+       andBool #rangeAddress(CALLER_ID)
+       andBool #rangeAddress(ORIGIN_ID)
+       andBool #rangeUInt(256, TIME)
+       andBool #rangeUInt(256, ACCT_ID_balance)
+       andBool #rangeUInt(256, ECREC_BAL)
+       andBool #rangeUInt(256, SHA256_BAL)
+       andBool #rangeUInt(256, RIP160_BAL)
+       andBool #rangeUInt(256, ID_BAL)
+       andBool #rangeUInt(256, MODEXP_BAL)
+       andBool #rangeUInt(256, ECADD_BAL)
+       andBool #rangeUInt(256, ECMUL_BAL)
+       andBool #rangeUInt(256, ECPAIRING_BAL)
+       andBool #rangeUInt(256, BLAKE2_BAL)
+       andBool VCallDepth <=Int 1024
+       andBool #rangeUInt(256, VCallValue)
+       andBool #rangeUInt(256, VChainId)
+
+       andBool (#rangeUInt(256, ABI_x)
+       andBool (#rangeUInt(256, ABI_y)
+       andBool ((#sizeWordStack(WS) <=Int 1000)
+       andBool (#rangeUInt(256, VMemoryUsed)
+       andBool ((#rangeUInt(256, ABI_x *Int ABI_y)))))))
+
+
+    [trusted, matching(infGas)]
+
+
+    // Flopper_addu48u48
+    claim [Flopper.addu48u48.pass]:
+      <k> #execute ~> CONTINUATION => #execute ~> CONTINUATION </k>
+      <exit-code> 1 </exit-code>
+      <mode> NORMAL </mode>
+      <schedule> ISTANBUL </schedule>
+      <ethereum>
+        <evm>
+          <output> VOutput => VOutput </output>
+          <statusCode> _ => ?_ </statusCode>
+          <endPC> _ => ?_ </endPC>
+          <callStack> _VCallStack </callStack>
+          <interimStates> _ </interimStates>
+          <touchedAccounts> _ => ?_ </touchedAccounts>
+          <callState>
+            <program> Flopper_bin_runtime </program>
+            <jumpDests> #computeValidJumpDests(Flopper_bin_runtime) </jumpDests>
+            <id> ACCT_ID </id>
+            <caller> CALLER_ID </caller>
+            <callData> _ => ?_ </callData>
+            <callValue> VCallValue </callValue>
+            <wordStack> ABI_y : ABI_x : JMPTO : WS  =>  JMPTO : ABI_x +Int ABI_y : WS </wordStack>
+            <localMem> _ </localMem>
+            <pc> 8757 => 8798 </pc>
+            <gas> #gas(VGas) => #gas ( ( VGas +Int -66 ) ) </gas>
+            <memoryUsed> VMemoryUsed </memoryUsed>
+            <callGas> _ => ?_ </callGas>
+            <static> _ </static>
+            <callDepth> VCallDepth </callDepth>
+          </callState>
+          <substate>
+            <selfDestruct> _VSelfDestruct </selfDestruct>
+            <log> _ => ?_ </log>
+            <refund> _Vrefund => ?_ </refund>
+          </substate>
+          <gasPrice> _ </gasPrice>
+          <origin> ORIGIN_ID </origin>
+          <blockhashes> _ </blockhashes>
+          <block>
+            <previousHash> _ </previousHash>
+            <ommersHash> _ </ommersHash>
+            <coinbase> _ </coinbase>
+            <stateRoot> _ </stateRoot>
+            <transactionsRoot> _ </transactionsRoot>
+            <receiptsRoot> _ </receiptsRoot>
+            <logsBloom> _ </logsBloom>
+            <difficulty> _ </difficulty>
+            <number> _BLOCK_NUMBER </number>
+            <gasLimit> _ </gasLimit>
+            <gasUsed> _ </gasUsed>
+            <timestamp> TIME </timestamp>
+            <extraData> _ </extraData>
+            <mixHash> _ </mixHash>
+            <blockNonce> _ </blockNonce>
+            <ommerBlockHeaders> _ </ommerBlockHeaders>
+          </block>
+        </evm>
+        <network>
+          <chainID> VChainId </chainID>
+          <activeAccounts> SetItem(ACCT_ID)
+          SetItem(1)
+          SetItem(2)
+          SetItem(3)
+          SetItem(4)
+          SetItem(5)
+          SetItem(6)
+          SetItem(7)
+          SetItem(8)
+          SetItem(9) _ </activeAccounts>
+          <accounts>
+            <account>
+              <acctID> ACCT_ID </acctID>
+              <balance> ACCT_ID_balance </balance>
+              <code> Flopper_bin_runtime </code>
+              <storage> ACCT_ID_STORAGE => ACCT_ID_STORAGE  </storage>
+              <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
+              <nonce> _Nonce_Flopper => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> 1 </acctID>
+              <balance> ECREC_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 2 </acctID>
+              <balance> SHA256_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 3 </acctID>
+              <balance> RIP160_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 4 </acctID>
+              <balance> ID_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 5 </acctID>
+              <balance> MODEXP_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 6 </acctID>
+              <balance> ECADD_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 7 </acctID>
+              <balance> ECMUL_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 8 </acctID>
+              <balance> ECPAIRING_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 9 </acctID>
+              <balance> BLAKE2_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+           ...
+          </accounts>
+          <txOrder> _ </txOrder>
+          <txPending> _ </txPending>
+          <messages> _ </messages>
+        </network>
+      </ethereum>
+      requires #rangeAddress(ACCT_ID)
+       andBool ACCT_ID =/=Int 0
+       andBool #notPrecompileAddress(ACCT_ID)
+       andBool #rangeAddress(CALLER_ID)
+       andBool #rangeAddress(ORIGIN_ID)
+       andBool #rangeUInt(256, TIME)
+       andBool #rangeUInt(256, ACCT_ID_balance)
+       andBool #rangeUInt(256, ECREC_BAL)
+       andBool #rangeUInt(256, SHA256_BAL)
+       andBool #rangeUInt(256, RIP160_BAL)
+       andBool #rangeUInt(256, ID_BAL)
+       andBool #rangeUInt(256, MODEXP_BAL)
+       andBool #rangeUInt(256, ECADD_BAL)
+       andBool #rangeUInt(256, ECMUL_BAL)
+       andBool #rangeUInt(256, ECPAIRING_BAL)
+       andBool #rangeUInt(256, BLAKE2_BAL)
+       andBool VCallDepth <=Int 1024
+       andBool #rangeUInt(256, VCallValue)
+       andBool #rangeUInt(256, VChainId)
+
+       andBool (#rangeUInt(48, ABI_x)
+       andBool (#rangeUInt(48, ABI_y)
+       andBool ((#sizeWordStack(WS) <=Int 100)
+       andBool (#rangeUInt(256, VMemoryUsed)
+       andBool ((#rangeUInt(48, ABI_x +Int ABI_y)))))))
+
+
+    [trusted, matching(infGas)]
+
+
+    // Vat_move-diff
+    claim [Vat.move-diff.pass]:
+      <k> #execute ~> CONTINUATION => #halt ~> CONTINUATION </k>
+      <exit-code> 1 </exit-code>
+      <mode> NORMAL </mode>
+      <schedule> ISTANBUL </schedule>
+      <ethereum>
+        <evm>
+          <output> .ByteArray </output>
+          <statusCode> _ => EVMC_SUCCESS </statusCode>
+          <endPC> _ => ?_ </endPC>
+          <callStack> _VCallStack </callStack>
+          <interimStates> _ </interimStates>
+          <touchedAccounts> _ => ?_ </touchedAccounts>
+          <callState>
+            <program> Vat_bin_runtime </program>
+            <jumpDests> #computeValidJumpDests(Vat_bin_runtime) </jumpDests>
+            <id> ACCT_ID </id>
+            <caller> CALLER_ID </caller>
+            <callData> #abiCallData("move", #address(ABI_src), #address(ABI_dst), #uint256(ABI_rad)) ++ CD => ?_ </callData>
+            <callValue> VCallValue </callValue>
+            <wordStack> .WordStack => ?_ </wordStack>
+            <localMem> .Memory => ?_ </localMem>
+            <pc> 0 => ?_ </pc>
+            <gas> #gas(VGas) => #gas ( ( ( ( VGas -Int Csstore( ISTANBUL , ( Dai_src -Int ABI_rad ) , Dai_src , Junk_1 ) ) -Int Csstore( ISTANBUL , ( Dai_dst +Int ABI_rad ) , Dai_dst , Junk_2 ) ) +Int -7943 ) ) </gas>
+            <memoryUsed> 0 => ?_ </memoryUsed>
+            <callGas> _ => ?_ </callGas>
+            <static> false </static>
+            <callDepth> VCallDepth </callDepth>
+          </callState>
+          <substate>
+            <selfDestruct> _VSelfDestruct </selfDestruct>
+            <log> _ => ?_ </log>
+            <refund> _Vrefund => ?_ </refund>
+          </substate>
+          <gasPrice> _ </gasPrice>
+          <origin> ORIGIN_ID </origin>
+          <blockhashes> _ </blockhashes>
+          <block>
+            <previousHash> _ </previousHash>
+            <ommersHash> _ </ommersHash>
+            <coinbase> _ </coinbase>
+            <stateRoot> _ </stateRoot>
+            <transactionsRoot> _ </transactionsRoot>
+            <receiptsRoot> _ </receiptsRoot>
+            <logsBloom> _ </logsBloom>
+            <difficulty> _ </difficulty>
+            <number> _BLOCK_NUMBER </number>
+            <gasLimit> _ </gasLimit>
+            <gasUsed> _ </gasUsed>
+            <timestamp> TIME </timestamp>
+            <extraData> _ </extraData>
+            <mixHash> _ </mixHash>
+            <blockNonce> _ </blockNonce>
+            <ommerBlockHeaders> _ </ommerBlockHeaders>
+          </block>
+        </evm>
+        <network>
+          <chainID> VChainId </chainID>
+          <activeAccounts> SetItem(ACCT_ID)
+          SetItem(1)
+          SetItem(2)
+          SetItem(3)
+          SetItem(4)
+          SetItem(5)
+          SetItem(6)
+          SetItem(7)
+          SetItem(8)
+          SetItem(9) _ </activeAccounts>
+          <accounts>
+            <account>
+              <acctID> ACCT_ID </acctID>
+              <balance> ACCT_ID_balance </balance>
+              <code> Vat_bin_runtime </code>
+              <storage> ACCT_ID_STORAGE => ACCT_ID_STORAGE [ #Vat.dai[ABI_src] <- Dai_src -Int ABI_rad ] [ #Vat.dai[ABI_dst] <- Dai_dst +Int ABI_rad ] </storage>
+              <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
+              <nonce> _Nonce_Vat => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> 1 </acctID>
+              <balance> ECREC_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 2 </acctID>
+              <balance> SHA256_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 3 </acctID>
+              <balance> RIP160_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 4 </acctID>
+              <balance> ID_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 5 </acctID>
+              <balance> MODEXP_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 6 </acctID>
+              <balance> ECADD_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 7 </acctID>
+              <balance> ECMUL_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 8 </acctID>
+              <balance> ECPAIRING_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 9 </acctID>
+              <balance> BLAKE2_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+           ...
+          </accounts>
+          <txOrder> _ </txOrder>
+          <txPending> _ </txPending>
+          <messages> _ </messages>
+        </network>
+      </ethereum>
+      requires #rangeAddress(ACCT_ID)
+       andBool ACCT_ID =/=Int 0
+       andBool #notPrecompileAddress(ACCT_ID)
+       andBool #rangeAddress(CALLER_ID)
+       andBool #rangeAddress(ORIGIN_ID)
+       andBool #rangeUInt(256, TIME)
+       andBool #rangeUInt(256, ACCT_ID_balance)
+       andBool #rangeUInt(256, ECREC_BAL)
+       andBool #rangeUInt(256, SHA256_BAL)
+       andBool #rangeUInt(256, RIP160_BAL)
+       andBool #rangeUInt(256, ID_BAL)
+       andBool #rangeUInt(256, MODEXP_BAL)
+       andBool #rangeUInt(256, ECADD_BAL)
+       andBool #rangeUInt(256, ECMUL_BAL)
+       andBool #rangeUInt(256, ECPAIRING_BAL)
+       andBool #rangeUInt(256, BLAKE2_BAL)
+       andBool VCallDepth <=Int 1024
+       andBool #rangeUInt(256, VCallValue)
+       andBool #rangeUInt(256, VChainId)
+
+       andBool (#rangeAddress(ABI_src)
+       andBool (#rangeAddress(ABI_dst)
+       andBool (#rangeUInt(256, ABI_rad)
+       andBool (#rangeUInt(256, Dai_dst)
+       andBool (#rangeUInt(256, Dai_src)
+       andBool (#rangeUInt(256, May)
+       andBool ((#sizeByteArray(CD) <=Int 1250000000)
+       andBool ((ABI_src =/=Int ABI_dst)
+       andBool (#rangeUInt(256, Junk_0)
+       andBool (#rangeUInt(256, Junk_1)
+       andBool (#rangeUInt(256, Junk_2)
+       andBool ((((May ==Int 1 orBool ABI_src ==Int CALLER_ID)))
+       andBool (((VCallValue ==Int 0))
+       andBool ((#rangeUInt(256, Dai_src -Int ABI_rad))
+       andBool ((#rangeUInt(256, Dai_dst +Int ABI_rad)))))))))))))))))
+
+       andBool #lookup(ACCT_ID_STORAGE, #Vat.can[ABI_src][CALLER_ID]) ==Int May
+       andBool #lookup(ACCT_ID_STORAGE, #Vat.dai[ABI_src]) ==Int Dai_src
+       andBool #lookup(ACCT_ID_STORAGE, #Vat.dai[ABI_dst]) ==Int Dai_dst
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Vat.can[ABI_src][CALLER_ID]) ==Int Junk_0
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Vat.dai[ABI_src]) ==Int Junk_1
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Vat.dai[ABI_dst]) ==Int Junk_2
+       andBool #Vat.can[ABI_src][CALLER_ID] =/=Int #Vat.dai[ABI_src]
+       andBool #Vat.can[ABI_src][CALLER_ID] =/=Int #Vat.dai[ABI_dst]
+       andBool #Vat.dai[ABI_src] =/=Int #Vat.dai[ABI_dst]
+    [trusted, matching(infGas)]
+
+
+endmodule

--- a/tests/specs/mcd/functional-spec.k
+++ b/tests/specs/mcd/functional-spec.k
@@ -54,4 +54,29 @@ module FUNCTIONAL-SPEC
     claim <k> runLemma(M:Memory [ 128 := (B1 : B2 : B3 : B4 : _     : .ByteArray) ] [ 132 := BA':ByteArray ]) => doneLemma(M [ 128 := (B1 : B2 : B3 : B4 : .ByteArray) ] [ 132 := BA' ]) ... </k> requires #sizeByteArray(BA') ==Int 32
     claim <k> runLemma(M:Memory [ 128 := (B1 : B2 : B3 : B4 : _ : _ : .ByteArray) ] [ 132 := BA':ByteArray ]) => doneLemma(M [ 128 := (B1 : B2 : B3 : B4 : .ByteArray) ] [ 132 := BA' ]) ... </k> requires #sizeByteArray(BA') ==Int 32
 
+    claim <k> runLemma( M:Memory [ 132 := #buf(32, B11) ] [ 128 := (#buf(32, B21) ++ #buf(32, B22)) ] ) => doneLemma( M [ 128 := (#buf(32, B21) ++ #buf(32, B22)) ] ) ... </k>
+      requires #rangeUInt(256, B11) andBool #rangeUInt(256, B21) andBool #rangeUInt(256, B22)
+
+    claim <k> runLemma( M:Memory [ 128 := (#buf(32, B31) ++ #buf(32, B32)) ] [ 128 := #buf(32, B41) ] ) => doneLemma( M [ 128 := #buf(32, B41) ] [ 160 := #buf(32, B32) ] ) ... </k>
+      requires #rangeUInt(256, B31) andBool #rangeUInt(256, B32) andBool #rangeUInt(256, B41)
+
+    claim <k> runLemma(M:Memory [ 128 := (217 : 99 : 141 : 54 : .ByteArray) ]
+                                [ 132 := #buf(32, B11) ]
+                                [ 128 := (#buf(32, B21) ++ #buf(32, B22) ++ #buf(32, B23) ++ #buf(32, B24) ++ #buf(32, B25)) ]
+                                [ 128 := (217 : 99 : 141 : 54 : .ByteArray) ]
+                                [ 132 := #buf(32, B11) ]
+                                [ 128 := (#buf(32, B31) ++ #buf(32, B32)) ]
+                                [ 128 := #buf(32, B41) ]
+                      )
+           => doneLemma(M [ 128 := #buf(32, B41) ]
+                          [ 160 := #buf(32, B32) ]
+                          [ 192 := (#buf(32, B23) ++ #buf(32, B24) ++ #buf(32, B25)) ]
+                       )
+          ...
+          </k>
+     requires #rangeUInt(256, B11)
+      andBool #rangeUInt(256, B21) andBool #rangeUInt(256, B22) andBool #rangeUInt(256, B23) andBool #rangeUInt(256, B24) andBool #rangeUInt(256, B25)
+      andBool #rangeUInt(256, B31) andBool #rangeUInt(256, B32)
+      andBool #rangeUInt(256, B41)
+
 endmodule

--- a/tests/specs/mcd/functional-spec.k
+++ b/tests/specs/mcd/functional-spec.k
@@ -15,6 +15,13 @@ endmodule
 module FUNCTIONAL-SPEC
     imports FUNCTIONAL-SPEC-SYNTAX
 
+    // Arithmetic
+
+    claim <k> runLemma((X +Int pow256) -Int chop(Y)) => doneLemma(X -Int Y) ... </k>
+      requires #rangeUInt(256, X)
+       andBool #rangeSInt(256, Y)
+       andBool Y <Int 0
+
     // WordPack
 
     claim <k> runLemma((GAL |Int (maskWordPackAddrUInt48UInt48_1 &Int GUY_TIC_END)) modInt pow256) => doneLemma(GAL |Int (maskWordPackAddrUInt48UInt48_1 &Int GUY_TIC_END)) ... </k>

--- a/tests/specs/mcd/functional-spec.k
+++ b/tests/specs/mcd/functional-spec.k
@@ -44,6 +44,9 @@ module FUNCTIONAL-SPEC
        andBool GUY_TIC_END ==Int #WordPackAddrUInt48UInt48(GUY, TIC, END)
        andBool #rangeUInt(48, TIME +Int TTL)
 
+    claim <k> runLemma(maxUInt48 &Int ((CALLER_ID |Int (maskWordPackAddrUInt48UInt48_1 &Int #lookup(M, KX))) /Int pow208)) => doneLemma(maxUInt48 &Int (#lookup(M, KX) /Int pow208)) ... </k>
+      requires #rangeAddress(CALLER_ID)
+
     // Memory operations
 
     claim <k> runLemma(#range(M:Memory [ 0 := #buf(4, X) ] [ 0 <- 10 ] [ 1 <- 11 ] [ 2 <- 12 ] [ 3 <- 13 ], 0, 4)) => doneLemma(10 : 11 : 12 : 13 : .ByteArray) ... </k>

--- a/tests/specs/mcd/vat-flux-diff-pass-rough-spec.k
+++ b/tests/specs/mcd/vat-flux-diff-pass-rough-spec.k
@@ -1,0 +1,582 @@
+requires "verification.k"
+
+module VAT-FLUX-DIFF-PASS-ROUGH-SPEC
+    imports VERIFICATION
+
+    // Vat_flux-diff
+    claim [Vat.flux-diff.pass.rough]:
+      <k> #execute ~> CONTINUATION => #halt ~> CONTINUATION </k>
+      <exit-code> 1 </exit-code>
+      <mode> NORMAL </mode>
+      <schedule> ISTANBUL </schedule>
+      <ethereum>
+        <evm>
+          <output> .ByteArray </output>
+          <statusCode> _ => EVMC_SUCCESS </statusCode>
+          <endPC> _ => ?_ </endPC>
+          <callStack> _VCallStack </callStack>
+          <interimStates> _ </interimStates>
+          <touchedAccounts> _ => ?_ </touchedAccounts>
+          <callState>
+            <program> Vat_bin_runtime </program>
+            <jumpDests> #computeValidJumpDests(Vat_bin_runtime) </jumpDests>
+            <id> ACCT_ID </id>
+            <caller> CALLER_ID </caller>
+            <callData> #abiCallData("flux", #bytes32(ABI_ilk), #address(ABI_src), #address(ABI_dst), #uint256(ABI_wad)) ++ CD => ?_ </callData>
+            <callValue> VCallValue </callValue>
+            <wordStack> .WordStack => ?_ </wordStack>
+            <localMem> .Memory => ?_ </localMem>
+            <pc> 0 => ?_ </pc>
+            <gas> #gas(VGas) => ?_ </gas>
+            <memoryUsed> 0 => ?_ </memoryUsed>
+            <callGas> _ => ?_ </callGas>
+            <static> false </static>
+            <callDepth> VCallDepth </callDepth>
+          </callState>
+          <substate>
+            <selfDestruct> _VSelfDestruct </selfDestruct>
+            <log> _ => ?_ </log>
+            <refund> _Vrefund => ?_ </refund>
+          </substate>
+          <gasPrice> _ </gasPrice>
+          <origin> ORIGIN_ID </origin>
+          <blockhashes> _ </blockhashes>
+          <block>
+            <previousHash> _ </previousHash>
+            <ommersHash> _ </ommersHash>
+            <coinbase> _ </coinbase>
+            <stateRoot> _ </stateRoot>
+            <transactionsRoot> _ </transactionsRoot>
+            <receiptsRoot> _ </receiptsRoot>
+            <logsBloom> _ </logsBloom>
+            <difficulty> _ </difficulty>
+            <number> _BLOCK_NUMBER </number>
+            <gasLimit> _ </gasLimit>
+            <gasUsed> _ </gasUsed>
+            <timestamp> TIME </timestamp>
+            <extraData> _ </extraData>
+            <mixHash> _ </mixHash>
+            <blockNonce> _ </blockNonce>
+            <ommerBlockHeaders> _ </ommerBlockHeaders>
+          </block>
+        </evm>
+        <network>
+          <chainID> VChainId </chainID>
+          <activeAccounts> SetItem(ACCT_ID)
+          SetItem(1)
+          SetItem(2)
+          SetItem(3)
+          SetItem(4)
+          SetItem(5)
+          SetItem(6)
+          SetItem(7)
+          SetItem(8)
+          SetItem(9) _ </activeAccounts>
+          <accounts>
+            <account>
+              <acctID> ACCT_ID </acctID>
+              <balance> ACCT_ID_balance </balance>
+              <code> Vat_bin_runtime </code>
+              <storage> ACCT_ID_STORAGE => ACCT_ID_STORAGE [ #Vat.gem[ABI_ilk][ABI_src] <- Gem_src -Int ABI_wad ] [ #Vat.gem[ABI_ilk][ABI_dst] <- Gem_dst +Int ABI_wad ] </storage>
+              <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
+              <nonce> _Nonce_Vat => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> 1 </acctID>
+              <balance> ECREC_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 2 </acctID>
+              <balance> SHA256_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 3 </acctID>
+              <balance> RIP160_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 4 </acctID>
+              <balance> ID_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 5 </acctID>
+              <balance> MODEXP_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 6 </acctID>
+              <balance> ECADD_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 7 </acctID>
+              <balance> ECMUL_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 8 </acctID>
+              <balance> ECPAIRING_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 9 </acctID>
+              <balance> BLAKE2_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+           ...
+          </accounts>
+          <txOrder> _ </txOrder>
+          <txPending> _ </txPending>
+          <messages> _ </messages>
+        </network>
+      </ethereum>
+      requires #rangeAddress(ACCT_ID)
+       andBool ACCT_ID =/=Int 0
+       andBool #notPrecompileAddress(ACCT_ID)
+       andBool #rangeAddress(CALLER_ID)
+       andBool #rangeAddress(ORIGIN_ID)
+       andBool #rangeUInt(256, TIME)
+       andBool #rangeUInt(256, ACCT_ID_balance)
+       andBool #rangeUInt(256, ECREC_BAL)
+       andBool #rangeUInt(256, SHA256_BAL)
+       andBool #rangeUInt(256, RIP160_BAL)
+       andBool #rangeUInt(256, ID_BAL)
+       andBool #rangeUInt(256, MODEXP_BAL)
+       andBool #rangeUInt(256, ECADD_BAL)
+       andBool #rangeUInt(256, ECMUL_BAL)
+       andBool #rangeUInt(256, ECPAIRING_BAL)
+       andBool #rangeUInt(256, BLAKE2_BAL)
+       andBool VCallDepth <=Int 1024
+       andBool #rangeUInt(256, VCallValue)
+       andBool #rangeUInt(256, VChainId)
+
+       andBool (#rangeBytes(32, ABI_ilk)
+       andBool (#rangeAddress(ABI_src)
+       andBool (#rangeAddress(ABI_dst)
+       andBool (#rangeUInt(256, ABI_wad)
+       andBool (#rangeUInt(256, May)
+       andBool (#rangeUInt(256, Gem_src)
+       andBool (#rangeUInt(256, Gem_dst)
+       andBool ((#sizeByteArray(CD) <=Int 1250000000)
+       andBool ((ABI_src =/=Int ABI_dst)
+       andBool (#rangeUInt(256, Junk_0)
+       andBool (#rangeUInt(256, Junk_1)
+       andBool (#rangeUInt(256, Junk_2)
+       andBool ((((May ==Int 1 orBool ABI_src ==Int CALLER_ID)))
+       andBool (((VCallValue ==Int 0))
+       andBool ((#rangeUInt(256, Gem_src -Int ABI_wad))
+       andBool ((#rangeUInt(256, Gem_dst +Int ABI_wad))))))))))))))))))
+
+       andBool #lookup(ACCT_ID_STORAGE, #Vat.can[ABI_src][CALLER_ID]) ==Int May
+       andBool #lookup(ACCT_ID_STORAGE, #Vat.gem[ABI_ilk][ABI_src]) ==Int Gem_src
+       andBool #lookup(ACCT_ID_STORAGE, #Vat.gem[ABI_ilk][ABI_dst]) ==Int Gem_dst
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Vat.can[ABI_src][CALLER_ID]) ==Int Junk_0
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Vat.gem[ABI_ilk][ABI_src]) ==Int Junk_1
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Vat.gem[ABI_ilk][ABI_dst]) ==Int Junk_2
+       andBool #Vat.can[ABI_src][CALLER_ID] =/=Int #Vat.gem[ABI_ilk][ABI_src]
+       andBool #Vat.can[ABI_src][CALLER_ID] =/=Int #Vat.gem[ABI_ilk][ABI_dst]
+       andBool #Vat.gem[ABI_ilk][ABI_src] =/=Int #Vat.gem[ABI_ilk][ABI_dst]
+
+    // Vat_subuu
+    claim [Vat.subuu.pass]:
+      <k> #execute ~> CONTINUATION => #execute ~> CONTINUATION </k>
+      <exit-code> 1 </exit-code>
+      <mode> NORMAL </mode>
+      <schedule> ISTANBUL </schedule>
+      <ethereum>
+        <evm>
+          <output> VOutput => VOutput </output>
+          <statusCode> _ => ?_ </statusCode>
+          <endPC> _ => ?_ </endPC>
+          <callStack> _VCallStack </callStack>
+          <interimStates> _ </interimStates>
+          <touchedAccounts> _ => ?_ </touchedAccounts>
+          <callState>
+            <program> Vat_bin_runtime </program>
+            <jumpDests> #computeValidJumpDests(Vat_bin_runtime) </jumpDests>
+            <id> ACCT_ID </id>
+            <caller> CALLER_ID </caller>
+            <callData> _ => ?_ </callData>
+            <callValue> VCallValue </callValue>
+            <wordStack> ABI_y : ABI_x : JMPTO : WS  =>  JMPTO : ABI_x -Int ABI_y : WS </wordStack>
+            <localMem> _ </localMem>
+            <pc> 13060 => 13085 </pc>
+            <gas> #gas(VGas) => #gas ( ( VGas +Int 54 ) ) </gas>
+            <memoryUsed> VMemoryUsed </memoryUsed>
+            <callGas> _ => ?_ </callGas>
+            <static> _ </static>
+            <callDepth> VCallDepth </callDepth>
+          </callState>
+          <substate>
+            <selfDestruct> _VSelfDestruct </selfDestruct>
+            <log> _ => ?_ </log>
+            <refund> _Vrefund => ?_ </refund>
+          </substate>
+          <gasPrice> _ </gasPrice>
+          <origin> ORIGIN_ID </origin>
+          <blockhashes> _ </blockhashes>
+          <block>
+            <previousHash> _ </previousHash>
+            <ommersHash> _ </ommersHash>
+            <coinbase> _ </coinbase>
+            <stateRoot> _ </stateRoot>
+            <transactionsRoot> _ </transactionsRoot>
+            <receiptsRoot> _ </receiptsRoot>
+            <logsBloom> _ </logsBloom>
+            <difficulty> _ </difficulty>
+            <number> _BLOCK_NUMBER </number>
+            <gasLimit> _ </gasLimit>
+            <gasUsed> _ </gasUsed>
+            <timestamp> TIME </timestamp>
+            <extraData> _ </extraData>
+            <mixHash> _ </mixHash>
+            <blockNonce> _ </blockNonce>
+            <ommerBlockHeaders> _ </ommerBlockHeaders>
+          </block>
+        </evm>
+        <network>
+          <chainID> VChainId </chainID>
+          <activeAccounts> SetItem(ACCT_ID)
+          SetItem(1)
+          SetItem(2)
+          SetItem(3)
+          SetItem(4)
+          SetItem(5)
+          SetItem(6)
+          SetItem(7)
+          SetItem(8)
+          SetItem(9) _ </activeAccounts>
+          <accounts>
+            <account>
+              <acctID> ACCT_ID </acctID>
+              <balance> ACCT_ID_balance </balance>
+              <code> Vat_bin_runtime </code>
+              <storage> ACCT_ID_STORAGE => ACCT_ID_STORAGE  </storage>
+              <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
+              <nonce> _Nonce_Vat => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> 1 </acctID>
+              <balance> ECREC_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 2 </acctID>
+              <balance> SHA256_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 3 </acctID>
+              <balance> RIP160_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 4 </acctID>
+              <balance> ID_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 5 </acctID>
+              <balance> MODEXP_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 6 </acctID>
+              <balance> ECADD_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 7 </acctID>
+              <balance> ECMUL_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 8 </acctID>
+              <balance> ECPAIRING_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 9 </acctID>
+              <balance> BLAKE2_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+           ...
+          </accounts>
+          <txOrder> _ </txOrder>
+          <txPending> _ </txPending>
+          <messages> _ </messages>
+        </network>
+      </ethereum>
+      requires #rangeAddress(ACCT_ID)
+       andBool ACCT_ID =/=Int 0
+       andBool #notPrecompileAddress(ACCT_ID)
+       andBool #rangeAddress(CALLER_ID)
+       andBool #rangeAddress(ORIGIN_ID)
+       andBool #rangeUInt(256, TIME)
+       andBool #rangeUInt(256, ACCT_ID_balance)
+       andBool #rangeUInt(256, ECREC_BAL)
+       andBool #rangeUInt(256, SHA256_BAL)
+       andBool #rangeUInt(256, RIP160_BAL)
+       andBool #rangeUInt(256, ID_BAL)
+       andBool #rangeUInt(256, MODEXP_BAL)
+       andBool #rangeUInt(256, ECADD_BAL)
+       andBool #rangeUInt(256, ECMUL_BAL)
+       andBool #rangeUInt(256, ECPAIRING_BAL)
+       andBool #rangeUInt(256, BLAKE2_BAL)
+       andBool VCallDepth <=Int 1024
+       andBool #rangeUInt(256, VCallValue)
+       andBool #rangeUInt(256, VChainId)
+
+       andBool (#rangeUInt(256, ABI_x)
+       andBool (#rangeUInt(256, ABI_y)
+       andBool ((#sizeWordStack(WS) <=Int 100)
+       andBool (#rangeUInt(256, VMemoryUsed)
+       andBool ((#rangeUInt(256, ABI_x -Int ABI_y)))))))
+
+
+    [trusted, matching(infGas)]
+
+
+    // Vat_adduu
+    claim [Vat.adduu.pass]:
+      <k> #execute ~> CONTINUATION => #execute ~> CONTINUATION </k>
+      <exit-code> 1 </exit-code>
+      <mode> NORMAL </mode>
+      <schedule> ISTANBUL </schedule>
+      <ethereum>
+        <evm>
+          <output> VOutput => VOutput </output>
+          <statusCode> _ => ?_ </statusCode>
+          <endPC> _ => ?_ </endPC>
+          <callStack> _VCallStack </callStack>
+          <interimStates> _ </interimStates>
+          <touchedAccounts> _ => ?_ </touchedAccounts>
+          <callState>
+            <program> Vat_bin_runtime </program>
+            <jumpDests> #computeValidJumpDests(Vat_bin_runtime) </jumpDests>
+            <id> ACCT_ID </id>
+            <caller> CALLER_ID </caller>
+            <callData> _ => ?_ </callData>
+            <callValue> VCallValue </callValue>
+            <wordStack> ABI_y : ABI_x : JMPTO : WS  =>  JMPTO : ABI_x +Int ABI_y : WS </wordStack>
+            <localMem> _ </localMem>
+            <pc> 13086 => 13111 </pc>
+            <gas> #gas(VGas) => #gas ( ( VGas +Int 54 ) ) </gas>
+            <memoryUsed> VMemoryUsed </memoryUsed>
+            <callGas> _ => ?_ </callGas>
+            <static> _ </static>
+            <callDepth> VCallDepth </callDepth>
+          </callState>
+          <substate>
+            <selfDestruct> _VSelfDestruct </selfDestruct>
+            <log> _ => ?_ </log>
+            <refund> _Vrefund => ?_ </refund>
+          </substate>
+          <gasPrice> _ </gasPrice>
+          <origin> ORIGIN_ID </origin>
+          <blockhashes> _ </blockhashes>
+          <block>
+            <previousHash> _ </previousHash>
+            <ommersHash> _ </ommersHash>
+            <coinbase> _ </coinbase>
+            <stateRoot> _ </stateRoot>
+            <transactionsRoot> _ </transactionsRoot>
+            <receiptsRoot> _ </receiptsRoot>
+            <logsBloom> _ </logsBloom>
+            <difficulty> _ </difficulty>
+            <number> _BLOCK_NUMBER </number>
+            <gasLimit> _ </gasLimit>
+            <gasUsed> _ </gasUsed>
+            <timestamp> TIME </timestamp>
+            <extraData> _ </extraData>
+            <mixHash> _ </mixHash>
+            <blockNonce> _ </blockNonce>
+            <ommerBlockHeaders> _ </ommerBlockHeaders>
+          </block>
+        </evm>
+        <network>
+          <chainID> VChainId </chainID>
+          <activeAccounts> SetItem(ACCT_ID)
+          SetItem(1)
+          SetItem(2)
+          SetItem(3)
+          SetItem(4)
+          SetItem(5)
+          SetItem(6)
+          SetItem(7)
+          SetItem(8)
+          SetItem(9) _ </activeAccounts>
+          <accounts>
+            <account>
+              <acctID> ACCT_ID </acctID>
+              <balance> ACCT_ID_balance </balance>
+              <code> Vat_bin_runtime </code>
+              <storage> ACCT_ID_STORAGE => ACCT_ID_STORAGE  </storage>
+              <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
+              <nonce> _Nonce_Vat => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> 1 </acctID>
+              <balance> ECREC_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 2 </acctID>
+              <balance> SHA256_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 3 </acctID>
+              <balance> RIP160_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 4 </acctID>
+              <balance> ID_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 5 </acctID>
+              <balance> MODEXP_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 6 </acctID>
+              <balance> ECADD_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 7 </acctID>
+              <balance> ECMUL_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 8 </acctID>
+              <balance> ECPAIRING_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 9 </acctID>
+              <balance> BLAKE2_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+           ...
+          </accounts>
+          <txOrder> _ </txOrder>
+          <txPending> _ </txPending>
+          <messages> _ </messages>
+        </network>
+      </ethereum>
+      requires #rangeAddress(ACCT_ID)
+       andBool ACCT_ID =/=Int 0
+       andBool #notPrecompileAddress(ACCT_ID)
+       andBool #rangeAddress(CALLER_ID)
+       andBool #rangeAddress(ORIGIN_ID)
+       andBool #rangeUInt(256, TIME)
+       andBool #rangeUInt(256, ACCT_ID_balance)
+       andBool #rangeUInt(256, ECREC_BAL)
+       andBool #rangeUInt(256, SHA256_BAL)
+       andBool #rangeUInt(256, RIP160_BAL)
+       andBool #rangeUInt(256, ID_BAL)
+       andBool #rangeUInt(256, MODEXP_BAL)
+       andBool #rangeUInt(256, ECADD_BAL)
+       andBool #rangeUInt(256, ECMUL_BAL)
+       andBool #rangeUInt(256, ECPAIRING_BAL)
+       andBool #rangeUInt(256, BLAKE2_BAL)
+       andBool VCallDepth <=Int 1024
+       andBool #rangeUInt(256, VCallValue)
+       andBool #rangeUInt(256, VChainId)
+
+       andBool (#rangeUInt(256, ABI_x)
+       andBool (#rangeUInt(256, ABI_y)
+       andBool ((#sizeWordStack(WS) <=Int 100)
+       andBool (#rangeUInt(256, VMemoryUsed)
+       andBool ((#rangeUInt(256, ABI_x +Int ABI_y)))))))
+
+
+    [trusted, matching(infGas)]
+endmodule

--- a/tests/specs/mcd/vat-frob-diff-zero-dart-pass-rough-spec.k
+++ b/tests/specs/mcd/vat-frob-diff-zero-dart-pass-rough-spec.k
@@ -1,0 +1,565 @@
+requires "verification.k"
+
+module VAT-FROB-DIFF-ZERO-DART-PASS-ROUGH-SPEC
+    imports VERIFICATION
+
+    // Vat_frob-diff-zero-dart
+    claim [Vat.frob-diff-zero-dart.pass.rough]:
+      <k> #execute ~> CONTINUATION => #halt ~> CONTINUATION </k>
+      <exit-code> 1 </exit-code>
+      <mode> NORMAL </mode>
+      <schedule> ISTANBUL </schedule>
+      <ethereum>
+        <evm>
+          <output> .ByteArray </output>
+          <statusCode> _ => EVMC_SUCCESS </statusCode>
+          <endPC> _ => ?_ </endPC>
+          <callStack> _VCallStack </callStack>
+          <interimStates> _ </interimStates>
+          <touchedAccounts> _ => ?_ </touchedAccounts>
+          <callState>
+            <program> Vat_bin_runtime </program>
+            <jumpDests> #computeValidJumpDests(Vat_bin_runtime) </jumpDests>
+            <id> ACCT_ID </id>
+            <caller> CALLER_ID </caller>
+            <callData> #abiCallData("frob", #bytes32(ABI_i), #address(ABI_u), #address(ABI_v), #address(ABI_w), #int256(ABI_dink), #int256(ABI_dart)) ++ CD => ?_ </callData>
+            <callValue> VCallValue </callValue>
+            <wordStack> .WordStack => ?_ </wordStack>
+            <localMem> .Memory => ?_ </localMem>
+            <pc> 0 => ?_ </pc>
+            <gas> #gas(VGas) => ?_ </gas>
+            <memoryUsed> 0 => ?_ </memoryUsed>
+            <callGas> _ => ?_ </callGas>
+            <static> false </static>
+            <callDepth> VCallDepth </callDepth>
+          </callState>
+          <substate>
+            <selfDestruct> _VSelfDestruct </selfDestruct>
+            <log> _ => ?_ </log>
+            <refund> _Vrefund => ?_ </refund>
+          </substate>
+          <gasPrice> _ </gasPrice>
+          <origin> ORIGIN_ID </origin>
+          <blockhashes> _ </blockhashes>
+          <block>
+            <previousHash> _ </previousHash>
+            <ommersHash> _ </ommersHash>
+            <coinbase> _ </coinbase>
+            <stateRoot> _ </stateRoot>
+            <transactionsRoot> _ </transactionsRoot>
+            <receiptsRoot> _ </receiptsRoot>
+            <logsBloom> _ </logsBloom>
+            <difficulty> _ </difficulty>
+            <number> _BLOCK_NUMBER </number>
+            <gasLimit> _ </gasLimit>
+            <gasUsed> _ </gasUsed>
+            <timestamp> TIME </timestamp>
+            <extraData> _ </extraData>
+            <mixHash> _ </mixHash>
+            <blockNonce> _ </blockNonce>
+            <ommerBlockHeaders> _ </ommerBlockHeaders>
+          </block>
+        </evm>
+        <network>
+          <chainID> VChainId </chainID>
+          <activeAccounts> SetItem(ACCT_ID)
+          SetItem(1)
+          SetItem(2)
+          SetItem(3)
+          SetItem(4)
+          SetItem(5)
+          SetItem(6)
+          SetItem(7)
+          SetItem(8)
+          SetItem(9) _ </activeAccounts>
+          <accounts>
+            <account>
+              <acctID> ACCT_ID </acctID>
+              <balance> ACCT_ID_balance </balance>
+              <code> Vat_bin_runtime </code>
+              <storage> ACCT_ID_STORAGE => ACCT_ID_STORAGE [ #Vat.gem[ABI_i][ABI_v] <- Gem_iv  -Int ABI_dink ]  [ #Vat.urns[ABI_i][ABI_u].ink <- Urn_ink +Int ABI_dink ] </storage>
+              <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
+              <nonce> _Nonce_Vat => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> 1 </acctID>
+              <balance> ECREC_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 2 </acctID>
+              <balance> SHA256_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 3 </acctID>
+              <balance> RIP160_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 4 </acctID>
+              <balance> ID_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 5 </acctID>
+              <balance> MODEXP_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 6 </acctID>
+              <balance> ECADD_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 7 </acctID>
+              <balance> ECMUL_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 8 </acctID>
+              <balance> ECPAIRING_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 9 </acctID>
+              <balance> BLAKE2_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+           ...
+          </accounts>
+          <txOrder> _ </txOrder>
+          <txPending> _ </txPending>
+          <messages> _ </messages>
+        </network>
+      </ethereum>
+      requires #rangeAddress(ACCT_ID)
+       andBool ACCT_ID =/=Int 0
+       andBool #notPrecompileAddress(ACCT_ID)
+       andBool #rangeAddress(CALLER_ID)
+       andBool #rangeAddress(ORIGIN_ID)
+       andBool #rangeUInt(256, TIME)
+       andBool #rangeUInt(256, ACCT_ID_balance)
+       andBool #rangeUInt(256, ECREC_BAL)
+       andBool #rangeUInt(256, SHA256_BAL)
+       andBool #rangeUInt(256, RIP160_BAL)
+       andBool #rangeUInt(256, ID_BAL)
+       andBool #rangeUInt(256, MODEXP_BAL)
+       andBool #rangeUInt(256, ECADD_BAL)
+       andBool #rangeUInt(256, ECMUL_BAL)
+       andBool #rangeUInt(256, ECPAIRING_BAL)
+       andBool #rangeUInt(256, BLAKE2_BAL)
+       andBool VCallDepth <=Int 1024
+       andBool #rangeUInt(256, VCallValue)
+       andBool #rangeUInt(256, VChainId)
+
+       andBool (#rangeBytes(32, ABI_i)
+       andBool (#rangeAddress(ABI_u)
+       andBool (#rangeAddress(ABI_v)
+       andBool (#rangeAddress(ABI_w)
+       andBool (#rangeSInt(256, ABI_dink)
+       andBool (#rangeSInt(256, ABI_dart)
+       andBool (#rangeUInt(256, Ilk_rate)
+       andBool (#rangeUInt(256, Ilk_line)
+       andBool (#rangeUInt(256, Ilk_spot)
+       andBool (#rangeUInt(256, Ilk_dust)
+       andBool (#rangeUInt(256, Ilk_Art)
+       andBool (#rangeUInt(256, Urn_ink)
+       andBool (#rangeUInt(256, Urn_art)
+       andBool (#rangeUInt(256, Gem_iv)
+       andBool (#rangeUInt(256, Dai_w)
+       andBool (#rangeUInt(256, Debt)
+       andBool (#rangeUInt(256, Line)
+       andBool (#rangeUInt(256, Can_u)
+       andBool (#rangeUInt(256, Can_v)
+       andBool (#rangeUInt(256, Can_w)
+       andBool (#rangeUInt(256, Live)
+       andBool ((#sizeByteArray(CD) <=Int 1250000000)
+       andBool ((ABI_u =/=Int ABI_v)
+       andBool ((ABI_v =/=Int ABI_w)
+       andBool ((ABI_u =/=Int ABI_w)
+       andBool ((ABI_dink =/=Int 0)
+       andBool ((ABI_dart ==Int 0)
+       andBool (#rangeUInt(256, Junk_0)
+       andBool (#rangeUInt(256, Junk_1)
+       andBool (#rangeUInt(256, Junk_2)
+       andBool (#rangeUInt(256, Junk_3)
+       andBool (#rangeUInt(256, Junk_4)
+       andBool (#rangeUInt(256, Junk_5)
+       andBool (#rangeUInt(256, Junk_6)
+       andBool (#rangeUInt(256, Junk_7)
+       andBool (#rangeUInt(256, Junk_8)
+       andBool (#rangeUInt(256, Junk_9)
+       andBool (#rangeUInt(256, Junk_10)
+       andBool (#rangeUInt(256, Junk_11)
+       andBool (#rangeUInt(256, Junk_12)
+       andBool (#rangeUInt(256, Junk_13)
+       andBool (#rangeUInt(256, Junk_14)
+       andBool ((((#rangeUInt(256, Urn_ink +Int ABI_dink))))
+       andBool ((((#rangeUInt(256, Gem_iv  -Int ABI_dink))))
+       andBool ((((#rangeUInt(256, (Urn_ink +Int ABI_dink) *Int Ilk_spot))))
+       andBool ((((#rangeUInt(256, Urn_art *Int Ilk_rate))))
+       andBool ((((#rangeUInt(256, Ilk_Art *Int Ilk_rate))))
+       andBool (((#rangeSInt(256, Ilk_rate)))
+       andBool ((VCallValue ==Int 0)
+       andBool ((Live ==Int 1)
+       andBool ((Ilk_rate =/=Int 0)
+       andBool (((ABI_dink >=Int 0) orBool (((Urn_art *Int Ilk_rate) <=Int ((Urn_ink +Int ABI_dink) *Int Ilk_spot))))
+       andBool (((ABI_dink >=Int 0) orBool (ABI_u ==Int CALLER_ID orBool Can_u ==Int 1))
+       andBool (((ABI_dink <=Int 0) orBool (ABI_v ==Int CALLER_ID orBool Can_v ==Int 1))
+       andBool (((Urn_art ==Int 0) orBool ((Urn_art *Int Ilk_rate) >=Int Ilk_dust)))))))))))))))))))))))))))))))))))))))))))))))))))))))))
+
+       andBool #lookup(ACCT_ID_STORAGE, #Vat.ilks[ABI_i].rate) ==Int Ilk_rate
+       andBool #lookup(ACCT_ID_STORAGE, #Vat.ilks[ABI_i].line) ==Int Ilk_line
+       andBool #lookup(ACCT_ID_STORAGE, #Vat.ilks[ABI_i].spot) ==Int Ilk_spot
+       andBool #lookup(ACCT_ID_STORAGE, #Vat.ilks[ABI_i].dust) ==Int Ilk_dust
+       andBool #lookup(ACCT_ID_STORAGE, #Vat.Line) ==Int Line
+       andBool #lookup(ACCT_ID_STORAGE, #Vat.can[ABI_u][CALLER_ID]) ==Int Can_u
+       andBool #lookup(ACCT_ID_STORAGE, #Vat.can[ABI_v][CALLER_ID]) ==Int Can_v
+       andBool #lookup(ACCT_ID_STORAGE, #Vat.can[ABI_w][CALLER_ID]) ==Int Can_w
+       andBool #lookup(ACCT_ID_STORAGE, #Vat.debt) ==Int Debt
+       andBool #lookup(ACCT_ID_STORAGE, #Vat.gem[ABI_i][ABI_v]) ==Int Gem_iv
+       andBool #lookup(ACCT_ID_STORAGE, #Vat.dai[ABI_w]) ==Int Dai_w
+       andBool #lookup(ACCT_ID_STORAGE, #Vat.urns[ABI_i][ABI_u].ink) ==Int Urn_ink
+       andBool #lookup(ACCT_ID_STORAGE, #Vat.urns[ABI_i][ABI_u].art) ==Int Urn_art
+       andBool #lookup(ACCT_ID_STORAGE, #Vat.ilks[ABI_i].Art) ==Int Ilk_Art
+       andBool #lookup(ACCT_ID_STORAGE, #Vat.live) ==Int Live
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Vat.ilks[ABI_i].rate) ==Int Junk_0
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Vat.ilks[ABI_i].line) ==Int Junk_1
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Vat.ilks[ABI_i].spot) ==Int Junk_2
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Vat.ilks[ABI_i].dust) ==Int Junk_3
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Vat.Line) ==Int Junk_4
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Vat.can[ABI_u][CALLER_ID]) ==Int Junk_5
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Vat.can[ABI_v][CALLER_ID]) ==Int Junk_6
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Vat.can[ABI_w][CALLER_ID]) ==Int Junk_7
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Vat.debt) ==Int Junk_8
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Vat.gem[ABI_i][ABI_v]) ==Int Junk_9
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Vat.dai[ABI_w]) ==Int Junk_10
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Vat.urns[ABI_i][ABI_u].ink) ==Int Junk_11
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Vat.urns[ABI_i][ABI_u].art) ==Int Junk_12
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Vat.ilks[ABI_i].Art) ==Int Junk_13
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Vat.live) ==Int Junk_14
+       andBool #Vat.ilks[ABI_i].rate =/=Int #Vat.ilks[ABI_i].line
+       andBool #Vat.ilks[ABI_i].rate =/=Int #Vat.ilks[ABI_i].spot
+       andBool #Vat.ilks[ABI_i].rate =/=Int #Vat.ilks[ABI_i].dust
+       andBool #Vat.ilks[ABI_i].rate =/=Int #Vat.Line
+       andBool #Vat.ilks[ABI_i].rate =/=Int #Vat.can[ABI_u][CALLER_ID]
+       andBool #Vat.ilks[ABI_i].rate =/=Int #Vat.can[ABI_v][CALLER_ID]
+       andBool #Vat.ilks[ABI_i].rate =/=Int #Vat.can[ABI_w][CALLER_ID]
+       andBool #Vat.ilks[ABI_i].rate =/=Int #Vat.debt
+       andBool #Vat.ilks[ABI_i].rate =/=Int #Vat.gem[ABI_i][ABI_v]
+       andBool #Vat.ilks[ABI_i].rate =/=Int #Vat.dai[ABI_w]
+       andBool #Vat.ilks[ABI_i].rate =/=Int #Vat.urns[ABI_i][ABI_u].ink
+       andBool #Vat.ilks[ABI_i].rate =/=Int #Vat.urns[ABI_i][ABI_u].art
+       andBool #Vat.ilks[ABI_i].rate =/=Int #Vat.ilks[ABI_i].Art
+       andBool #Vat.ilks[ABI_i].rate =/=Int #Vat.live
+       andBool #Vat.ilks[ABI_i].line =/=Int #Vat.ilks[ABI_i].spot
+       andBool #Vat.ilks[ABI_i].line =/=Int #Vat.ilks[ABI_i].dust
+       andBool #Vat.ilks[ABI_i].line =/=Int #Vat.Line
+       andBool #Vat.ilks[ABI_i].line =/=Int #Vat.can[ABI_u][CALLER_ID]
+       andBool #Vat.ilks[ABI_i].line =/=Int #Vat.can[ABI_v][CALLER_ID]
+       andBool #Vat.ilks[ABI_i].line =/=Int #Vat.can[ABI_w][CALLER_ID]
+       andBool #Vat.ilks[ABI_i].line =/=Int #Vat.debt
+       andBool #Vat.ilks[ABI_i].line =/=Int #Vat.gem[ABI_i][ABI_v]
+       andBool #Vat.ilks[ABI_i].line =/=Int #Vat.dai[ABI_w]
+       andBool #Vat.ilks[ABI_i].line =/=Int #Vat.urns[ABI_i][ABI_u].ink
+       andBool #Vat.ilks[ABI_i].line =/=Int #Vat.urns[ABI_i][ABI_u].art
+       andBool #Vat.ilks[ABI_i].line =/=Int #Vat.ilks[ABI_i].Art
+       andBool #Vat.ilks[ABI_i].line =/=Int #Vat.live
+       andBool #Vat.ilks[ABI_i].spot =/=Int #Vat.ilks[ABI_i].dust
+       andBool #Vat.ilks[ABI_i].spot =/=Int #Vat.Line
+       andBool #Vat.ilks[ABI_i].spot =/=Int #Vat.can[ABI_u][CALLER_ID]
+       andBool #Vat.ilks[ABI_i].spot =/=Int #Vat.can[ABI_v][CALLER_ID]
+       andBool #Vat.ilks[ABI_i].spot =/=Int #Vat.can[ABI_w][CALLER_ID]
+       andBool #Vat.ilks[ABI_i].spot =/=Int #Vat.debt
+       andBool #Vat.ilks[ABI_i].spot =/=Int #Vat.gem[ABI_i][ABI_v]
+       andBool #Vat.ilks[ABI_i].spot =/=Int #Vat.dai[ABI_w]
+       andBool #Vat.ilks[ABI_i].spot =/=Int #Vat.urns[ABI_i][ABI_u].ink
+       andBool #Vat.ilks[ABI_i].spot =/=Int #Vat.urns[ABI_i][ABI_u].art
+       andBool #Vat.ilks[ABI_i].spot =/=Int #Vat.ilks[ABI_i].Art
+       andBool #Vat.ilks[ABI_i].spot =/=Int #Vat.live
+       andBool #Vat.ilks[ABI_i].dust =/=Int #Vat.Line
+       andBool #Vat.ilks[ABI_i].dust =/=Int #Vat.can[ABI_u][CALLER_ID]
+       andBool #Vat.ilks[ABI_i].dust =/=Int #Vat.can[ABI_v][CALLER_ID]
+       andBool #Vat.ilks[ABI_i].dust =/=Int #Vat.can[ABI_w][CALLER_ID]
+       andBool #Vat.ilks[ABI_i].dust =/=Int #Vat.debt
+       andBool #Vat.ilks[ABI_i].dust =/=Int #Vat.gem[ABI_i][ABI_v]
+       andBool #Vat.ilks[ABI_i].dust =/=Int #Vat.dai[ABI_w]
+       andBool #Vat.ilks[ABI_i].dust =/=Int #Vat.urns[ABI_i][ABI_u].ink
+       andBool #Vat.ilks[ABI_i].dust =/=Int #Vat.urns[ABI_i][ABI_u].art
+       andBool #Vat.ilks[ABI_i].dust =/=Int #Vat.ilks[ABI_i].Art
+       andBool #Vat.ilks[ABI_i].dust =/=Int #Vat.live
+       andBool #Vat.Line =/=Int #Vat.can[ABI_u][CALLER_ID]
+       andBool #Vat.Line =/=Int #Vat.can[ABI_v][CALLER_ID]
+       andBool #Vat.Line =/=Int #Vat.can[ABI_w][CALLER_ID]
+       andBool #Vat.Line =/=Int #Vat.debt
+       andBool #Vat.Line =/=Int #Vat.gem[ABI_i][ABI_v]
+       andBool #Vat.Line =/=Int #Vat.dai[ABI_w]
+       andBool #Vat.Line =/=Int #Vat.urns[ABI_i][ABI_u].ink
+       andBool #Vat.Line =/=Int #Vat.urns[ABI_i][ABI_u].art
+       andBool #Vat.Line =/=Int #Vat.ilks[ABI_i].Art
+       andBool #Vat.Line =/=Int #Vat.live
+       andBool #Vat.can[ABI_u][CALLER_ID] =/=Int #Vat.can[ABI_v][CALLER_ID]
+       andBool #Vat.can[ABI_u][CALLER_ID] =/=Int #Vat.can[ABI_w][CALLER_ID]
+       andBool #Vat.can[ABI_u][CALLER_ID] =/=Int #Vat.debt
+       andBool #Vat.can[ABI_u][CALLER_ID] =/=Int #Vat.gem[ABI_i][ABI_v]
+       andBool #Vat.can[ABI_u][CALLER_ID] =/=Int #Vat.dai[ABI_w]
+       andBool #Vat.can[ABI_u][CALLER_ID] =/=Int #Vat.urns[ABI_i][ABI_u].ink
+       andBool #Vat.can[ABI_u][CALLER_ID] =/=Int #Vat.urns[ABI_i][ABI_u].art
+       andBool #Vat.can[ABI_u][CALLER_ID] =/=Int #Vat.ilks[ABI_i].Art
+       andBool #Vat.can[ABI_u][CALLER_ID] =/=Int #Vat.live
+       andBool #Vat.can[ABI_v][CALLER_ID] =/=Int #Vat.can[ABI_w][CALLER_ID]
+       andBool #Vat.can[ABI_v][CALLER_ID] =/=Int #Vat.debt
+       andBool #Vat.can[ABI_v][CALLER_ID] =/=Int #Vat.gem[ABI_i][ABI_v]
+       andBool #Vat.can[ABI_v][CALLER_ID] =/=Int #Vat.dai[ABI_w]
+       andBool #Vat.can[ABI_v][CALLER_ID] =/=Int #Vat.urns[ABI_i][ABI_u].ink
+       andBool #Vat.can[ABI_v][CALLER_ID] =/=Int #Vat.urns[ABI_i][ABI_u].art
+       andBool #Vat.can[ABI_v][CALLER_ID] =/=Int #Vat.ilks[ABI_i].Art
+       andBool #Vat.can[ABI_v][CALLER_ID] =/=Int #Vat.live
+       andBool #Vat.can[ABI_w][CALLER_ID] =/=Int #Vat.debt
+       andBool #Vat.can[ABI_w][CALLER_ID] =/=Int #Vat.gem[ABI_i][ABI_v]
+       andBool #Vat.can[ABI_w][CALLER_ID] =/=Int #Vat.dai[ABI_w]
+       andBool #Vat.can[ABI_w][CALLER_ID] =/=Int #Vat.urns[ABI_i][ABI_u].ink
+       andBool #Vat.can[ABI_w][CALLER_ID] =/=Int #Vat.urns[ABI_i][ABI_u].art
+       andBool #Vat.can[ABI_w][CALLER_ID] =/=Int #Vat.ilks[ABI_i].Art
+       andBool #Vat.can[ABI_w][CALLER_ID] =/=Int #Vat.live
+       andBool #Vat.debt =/=Int #Vat.gem[ABI_i][ABI_v]
+       andBool #Vat.debt =/=Int #Vat.dai[ABI_w]
+       andBool #Vat.debt =/=Int #Vat.urns[ABI_i][ABI_u].ink
+       andBool #Vat.debt =/=Int #Vat.urns[ABI_i][ABI_u].art
+       andBool #Vat.debt =/=Int #Vat.ilks[ABI_i].Art
+       andBool #Vat.debt =/=Int #Vat.live
+       andBool #Vat.gem[ABI_i][ABI_v] =/=Int #Vat.dai[ABI_w]
+       andBool #Vat.gem[ABI_i][ABI_v] =/=Int #Vat.urns[ABI_i][ABI_u].ink
+       andBool #Vat.gem[ABI_i][ABI_v] =/=Int #Vat.urns[ABI_i][ABI_u].art
+       andBool #Vat.gem[ABI_i][ABI_v] =/=Int #Vat.ilks[ABI_i].Art
+       andBool #Vat.gem[ABI_i][ABI_v] =/=Int #Vat.live
+       andBool #Vat.dai[ABI_w] =/=Int #Vat.urns[ABI_i][ABI_u].ink
+       andBool #Vat.dai[ABI_w] =/=Int #Vat.urns[ABI_i][ABI_u].art
+       andBool #Vat.dai[ABI_w] =/=Int #Vat.ilks[ABI_i].Art
+       andBool #Vat.dai[ABI_w] =/=Int #Vat.live
+       andBool #Vat.urns[ABI_i][ABI_u].ink =/=Int #Vat.urns[ABI_i][ABI_u].art
+       andBool #Vat.urns[ABI_i][ABI_u].ink =/=Int #Vat.ilks[ABI_i].Art
+       andBool #Vat.urns[ABI_i][ABI_u].ink =/=Int #Vat.live
+       andBool #Vat.urns[ABI_i][ABI_u].art =/=Int #Vat.ilks[ABI_i].Art
+       andBool #Vat.urns[ABI_i][ABI_u].art =/=Int #Vat.live
+       andBool #Vat.ilks[ABI_i].Art =/=Int #Vat.live
+
+    // Vat_muluu
+    claim [Vat.muluu.pass]:
+      <k> #execute ~> CONTINUATION => #execute ~> CONTINUATION </k>
+      <exit-code> 1 </exit-code>
+      <mode> NORMAL </mode>
+      <schedule> ISTANBUL </schedule>
+      <ethereum>
+        <evm>
+          <output> VOutput => VOutput </output>
+          <statusCode> _ => ?_ </statusCode>
+          <endPC> _ => ?_ </endPC>
+          <callStack> _VCallStack </callStack>
+          <interimStates> _ </interimStates>
+          <touchedAccounts> _ => ?_ </touchedAccounts>
+          <callState>
+            <program> Vat_bin_runtime </program>
+            <jumpDests> #computeValidJumpDests(Vat_bin_runtime) </jumpDests>
+            <id> ACCT_ID </id>
+            <caller> CALLER_ID </caller>
+            <callData> _ => ?_ </callData>
+            <callValue> VCallValue </callValue>
+            <wordStack> ABI_y : ABI_x : JMPTO : WS  =>  JMPTO : ABI_x *Int ABI_y : WS </wordStack>
+            <localMem> _ </localMem>
+            <pc> 13234 => 13277 </pc>
+            <gas> #gas(VGas) => #if ABI_y ==Int 0
+              #then   #gas ( ( VGas +Int -54 ) )
+              #else   #gas ( ( VGas +Int -106 ) )
+            #fi </gas>
+            <memoryUsed> VMemoryUsed </memoryUsed>
+            <callGas> _ => ?_ </callGas>
+            <static> _ </static>
+            <callDepth> VCallDepth </callDepth>
+          </callState>
+          <substate>
+            <selfDestruct> _VSelfDestruct </selfDestruct>
+            <log> _ => ?_ </log>
+            <refund> _Vrefund => ?_ </refund>
+          </substate>
+          <gasPrice> _ </gasPrice>
+          <origin> ORIGIN_ID </origin>
+          <blockhashes> _ </blockhashes>
+          <block>
+            <previousHash> _ </previousHash>
+            <ommersHash> _ </ommersHash>
+            <coinbase> _ </coinbase>
+            <stateRoot> _ </stateRoot>
+            <transactionsRoot> _ </transactionsRoot>
+            <receiptsRoot> _ </receiptsRoot>
+            <logsBloom> _ </logsBloom>
+            <difficulty> _ </difficulty>
+            <number> _BLOCK_NUMBER </number>
+            <gasLimit> _ </gasLimit>
+            <gasUsed> _ </gasUsed>
+            <timestamp> TIME </timestamp>
+            <extraData> _ </extraData>
+            <mixHash> _ </mixHash>
+            <blockNonce> _ </blockNonce>
+            <ommerBlockHeaders> _ </ommerBlockHeaders>
+          </block>
+        </evm>
+        <network>
+          <chainID> VChainId </chainID>
+          <activeAccounts> SetItem(ACCT_ID)
+          SetItem(1)
+          SetItem(2)
+          SetItem(3)
+          SetItem(4)
+          SetItem(5)
+          SetItem(6)
+          SetItem(7)
+          SetItem(8)
+          SetItem(9) _ </activeAccounts>
+          <accounts>
+            <account>
+              <acctID> ACCT_ID </acctID>
+              <balance> ACCT_ID_balance </balance>
+              <code> Vat_bin_runtime </code>
+              <storage> ACCT_ID_STORAGE => ACCT_ID_STORAGE  </storage>
+              <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
+              <nonce> _Nonce_Vat => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> 1 </acctID>
+              <balance> ECREC_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 2 </acctID>
+              <balance> SHA256_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 3 </acctID>
+              <balance> RIP160_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 4 </acctID>
+              <balance> ID_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 5 </acctID>
+              <balance> MODEXP_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 6 </acctID>
+              <balance> ECADD_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 7 </acctID>
+              <balance> ECMUL_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 8 </acctID>
+              <balance> ECPAIRING_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 9 </acctID>
+              <balance> BLAKE2_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+           ...
+          </accounts>
+          <txOrder> _ </txOrder>
+          <txPending> _ </txPending>
+          <messages> _ </messages>
+        </network>
+      </ethereum>
+      requires #rangeAddress(ACCT_ID)
+       andBool ACCT_ID =/=Int 0
+       andBool #notPrecompileAddress(ACCT_ID)
+       andBool #rangeAddress(CALLER_ID)
+       andBool #rangeAddress(ORIGIN_ID)
+       andBool #rangeUInt(256, TIME)
+       andBool #rangeUInt(256, ACCT_ID_balance)
+       andBool #rangeUInt(256, ECREC_BAL)
+       andBool #rangeUInt(256, SHA256_BAL)
+       andBool #rangeUInt(256, RIP160_BAL)
+       andBool #rangeUInt(256, ID_BAL)
+       andBool #rangeUInt(256, MODEXP_BAL)
+       andBool #rangeUInt(256, ECADD_BAL)
+       andBool #rangeUInt(256, ECMUL_BAL)
+       andBool #rangeUInt(256, ECPAIRING_BAL)
+       andBool #rangeUInt(256, BLAKE2_BAL)
+       andBool VCallDepth <=Int 1024
+       andBool #rangeUInt(256, VCallValue)
+       andBool #rangeUInt(256, VChainId)
+
+       andBool (#rangeUInt(256, ABI_x)
+       andBool (#rangeUInt(256, ABI_y)
+       andBool ((#sizeWordStack(WS) <=Int 1000)
+       andBool (#rangeUInt(256, VMemoryUsed)
+       andBool ((#rangeUInt(256, ABI_x *Int ABI_y)))))))
+
+
+    [trusted, matching(infGas)]
+
+
+endmodule

--- a/tests/specs/mcd/verification.k
+++ b/tests/specs/mcd/verification.k
@@ -419,4 +419,8 @@ module VERIFICATION-COMMON
        andBool K1 +Int #sizeByteArray(BUF11) <=Int K2 +Int #sizeByteArray(BUF2)
       [simplification]
 
+    // ### vat-frob-diff-zero-dart-pass-rough
+
+    rule chop(X) => X +Int pow256 requires #rangeSInt(256, X) andBool X <Int 0 [simplification]
+
 endmodule

--- a/tests/specs/mcd/verification.k
+++ b/tests/specs/mcd/verification.k
@@ -394,4 +394,17 @@ module VERIFICATION-COMMON
     rule X <Int X -Int Y => false requires 0 <=Int Y [simplification]
     rule X +Int Y <Int X => false requires 0 <=Int Y [simplification]
 
+    // ### vow-cage-surplus-pass-rough
+
+    rule ADDR in (SetItem(I) REST) => true         requires ADDR  ==Int I [simplification]
+    rule ADDR in (SetItem(I) REST) => ADDR in REST requires ADDR =/=Int I [simplification]
+
+    rule <acctID> ACCTID </acctID>  ==K <acctID> ACCTID' </acctID> => ACCTID  ==Int ACCTID' [simplification]
+    rule <acctID> ACCTID </acctID> =/=K <acctID> ACCTID' </acctID> => ACCTID =/=Int ACCTID' [simplification]
+
+    rule ((K |-> V) REST) [ K' <- undef ] => REST                             requires K  ==K K' [simplification]
+    rule ((K |-> V) REST) [ K' <- undef ] => (K |-> V) (REST [ K' <- undef ]) requires K =/=K K' [simplification]
+
+    rule M:Map [ K1 <- V1 ] [ K2 <- V2 ] [ K1 <- V1' ] => M [ K1 <- V1' ] [ K2 <- V2 ] requires K1 =/=Int K2 [simplification]
+
 endmodule

--- a/tests/specs/mcd/verification.k
+++ b/tests/specs/mcd/verification.k
@@ -407,4 +407,16 @@ module VERIFICATION-COMMON
 
     rule M:Map [ K1 <- V1 ] [ K2 <- V2 ] [ K1 <- V1' ] => M [ K1 <- V1' ] [ K2 <- V2 ] requires K1 =/=Int K2 [simplification]
 
+    // end-cage-ilk-pass-rough
+
+    rule M:Memory [ K1 := BUF1 ] [ K2 := BUF2 ] => M [ K2 := BUF2 ]
+      requires K2 <=Int K1
+       andBool K1 +Int #sizeByteArray(BUF1) <=Int K2 +Int #sizeByteArray(BUF2)
+      [simplification]
+
+    rule M:Memory [ K1 := (BUF11 ++ BUF12) ] [ K2 := BUF2 ] => M [ K1 +Int #sizeByteArray(BUF11) := BUF12 ] [ K2 := BUF2 ]
+      requires K2 <=Int K1
+       andBool K1 +Int #sizeByteArray(BUF11) <=Int K2 +Int #sizeByteArray(BUF2)
+      [simplification]
+
 endmodule

--- a/tests/specs/mcd/verification.k
+++ b/tests/specs/mcd/verification.k
@@ -49,6 +49,10 @@ module VERIFICATION-SYNTAX
     rule nthbyteof(V, I, N) => nthbyteof(V /Int 256, I, N -Int 1) when N  >Int (I +Int 1) [concrete]
     rule nthbyteof(V, I, N) =>           V modInt 256             when N ==Int (I +Int 1) [concrete]
 
+    syntax Int ::= #rmul ( Int , Int ) [function, smtlib(smt_rmul)]
+ // ---------------------------------------------------------------
+    rule #rmul(X, Y) => (X *Int Y) /Int #Ray
+
 endmodule
 
 module VERIFICATION-HASKELL [symbolic, kore]

--- a/tests/specs/mcd/vow-cage-surplus-pass-rough-spec.k
+++ b/tests/specs/mcd/vow-cage-surplus-pass-rough-spec.k
@@ -1,0 +1,1567 @@
+requires "verification.k"
+
+module VOW-CAGE-SURPLUS-PASS-ROUGH-SPEC
+    imports VERIFICATION
+
+    // Vow_cage-surplus
+    claim [Vow.cage-surplus.pass.rough]:
+      <k> #execute ~> CONTINUATION => #halt ~> CONTINUATION </k>
+      <exit-code> 1 </exit-code>
+      <mode> NORMAL </mode>
+      <schedule> ISTANBUL </schedule>
+      <ethereum>
+        <evm>
+          <output> .ByteArray </output>
+          <statusCode> _ => EVMC_SUCCESS </statusCode>
+          <endPC> _ => ?_ </endPC>
+          <callStack> _VCallStack </callStack>
+          <interimStates> _ </interimStates>
+          <touchedAccounts> _ => ?_ </touchedAccounts>
+          <callState>
+            <program> Vow_bin_runtime </program>
+            <jumpDests> #computeValidJumpDests(Vow_bin_runtime) </jumpDests>
+            <id> ACCT_ID </id>
+            <caller> CALLER_ID </caller>
+            <callData> #abiCallData("cage", .TypedArgs) ++ CD => ?_ </callData>
+            <callValue> VCallValue </callValue>
+            <wordStack> .WordStack => ?_ </wordStack>
+            <localMem> .Memory => ?_ </localMem>
+            <pc> 0 => ?_ </pc>
+            <gas> #gas(VGas) => ?_ </gas>
+            <memoryUsed> 0 => ?_ </memoryUsed>
+            <callGas> _ => ?_ </callGas>
+            <static> false </static>
+            <callDepth> VCallDepth </callDepth>
+          </callState>
+          <substate>
+            <selfDestruct> _VSelfDestruct </selfDestruct>
+            <log> _ => ?_ </log>
+            <refund> _Vrefund => ?_ </refund>
+          </substate>
+          <gasPrice> _ </gasPrice>
+          <origin> ORIGIN_ID </origin>
+          <blockhashes> _ </blockhashes>
+          <block>
+            <previousHash> _ </previousHash>
+            <ommersHash> _ </ommersHash>
+            <coinbase> _ </coinbase>
+            <stateRoot> _ </stateRoot>
+            <transactionsRoot> _ </transactionsRoot>
+            <receiptsRoot> _ </receiptsRoot>
+            <logsBloom> _ </logsBloom>
+            <difficulty> _ </difficulty>
+            <number> _BLOCK_NUMBER </number>
+            <gasLimit> _ </gasLimit>
+            <gasUsed> _ </gasUsed>
+            <timestamp> TIME </timestamp>
+            <extraData> _ </extraData>
+            <mixHash> _ </mixHash>
+            <blockNonce> _ </blockNonce>
+            <ommerBlockHeaders> _ </ommerBlockHeaders>
+          </block>
+        </evm>
+        <network>
+          <chainID> VChainId </chainID>
+          <activeAccounts> SetItem(ACCT_ID)
+          SetItem(Vat)
+          SetItem(Flapper)
+          SetItem(Flopper)
+          SetItem(1)
+          SetItem(2)
+          SetItem(3)
+          SetItem(4)
+          SetItem(5)
+          SetItem(6)
+          SetItem(7)
+          SetItem(8)
+          SetItem(9) _ </activeAccounts>
+          <accounts>
+            <account>
+              <acctID> ACCT_ID </acctID>
+              <balance> ACCT_ID_balance </balance>
+              <code> Vow_bin_runtime </code>
+              <storage> ACCT_ID_STORAGE => ACCT_ID_STORAGE [ #Vow.live <- 0 ] [ #Vow.Sin <- 0 ] [ #Vow.Ash <- 0 ] </storage>
+              <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
+              <nonce> _Nonce_Vow => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> Vat </acctID>
+              <balance> Vat_balance </balance>
+              <code> Vat_bin_runtime </code>
+              <storage> Vat_STORAGE => Vat_STORAGE [ #Vat.dai[Flapper] <- 0 ] [ #Vat.dai[ACCT_ID] <- (Dai_v +Int Dai_f) -Int Sin_v ] [ #Vat.sin[ACCT_ID] <- 0 ] [ #Vat.vice <- Vice -Int Sin_v ] [ #Vat.debt <- Debt -Int Sin_v ] </storage>
+              <origStorage> Vat_ORIG_STORAGE </origStorage>
+              <nonce> _Nonce_Vat => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> Flapper </acctID>
+              <balance> Flapper_balance </balance>
+              <code> Flapper_bin_runtime </code>
+              <storage> Flapper_STORAGE => Flapper_STORAGE [ #Flapper.live <- 0 ] </storage>
+              <origStorage> Flapper_ORIG_STORAGE </origStorage>
+              <nonce> _Nonce_Flapper => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> Flopper </acctID>
+              <balance> Flopper_balance </balance>
+              <code> Flopper_bin_runtime </code>
+              <storage> Flopper_STORAGE => Flopper_STORAGE [ #Flopper.live <- 0 ] [ #Flopper.vow <- ACCT_ID ] </storage>
+              <origStorage> Flopper_ORIG_STORAGE </origStorage>
+              <nonce> _Nonce_Flopper => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> 1 </acctID>
+              <balance> ECREC_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 2 </acctID>
+              <balance> SHA256_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 3 </acctID>
+              <balance> RIP160_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 4 </acctID>
+              <balance> ID_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 5 </acctID>
+              <balance> MODEXP_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 6 </acctID>
+              <balance> ECADD_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 7 </acctID>
+              <balance> ECMUL_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 8 </acctID>
+              <balance> ECPAIRING_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 9 </acctID>
+              <balance> BLAKE2_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+           ...
+          </accounts>
+          <txOrder> _ </txOrder>
+          <txPending> _ </txPending>
+          <messages> _ </messages>
+        </network>
+      </ethereum>
+      requires #rangeAddress(ACCT_ID)
+       andBool ACCT_ID =/=Int 0
+       andBool #notPrecompileAddress(ACCT_ID)
+       andBool #rangeAddress(CALLER_ID)
+       andBool #rangeAddress(ORIGIN_ID)
+       andBool #rangeUInt(256, TIME)
+       andBool #rangeUInt(256, ACCT_ID_balance)
+       andBool #rangeUInt(256, ECREC_BAL)
+       andBool #rangeUInt(256, SHA256_BAL)
+       andBool #rangeUInt(256, RIP160_BAL)
+       andBool #rangeUInt(256, ID_BAL)
+       andBool #rangeUInt(256, MODEXP_BAL)
+       andBool #rangeUInt(256, ECADD_BAL)
+       andBool #rangeUInt(256, ECMUL_BAL)
+       andBool #rangeUInt(256, ECPAIRING_BAL)
+       andBool #rangeUInt(256, BLAKE2_BAL)
+       andBool VCallDepth <=Int 1024
+       andBool #rangeUInt(256, VCallValue)
+       andBool #rangeUInt(256, VChainId)
+
+       andBool (#rangeAddress(Vat)
+       andBool (#rangeAddress(Flapper)
+       andBool (#rangeAddress(Flopper)
+       andBool (#rangeAddress(FlapVat)
+       andBool (#rangeUInt(256, MayFlap)
+       andBool (#rangeUInt(256, MayFlop)
+       andBool (#rangeUInt(256, Dai_v)
+       andBool (#rangeUInt(256, Sin_v)
+       andBool (#rangeUInt(256, Dai_f)
+       andBool (#rangeUInt(256, Debt)
+       andBool (#rangeUInt(256, Vice)
+       andBool (#rangeUInt(256, Live)
+       andBool (#rangeUInt(256, Sin)
+       andBool (#rangeUInt(256, Ash)
+       andBool (#rangeUInt(256, FlapLive)
+       andBool (#rangeUInt(256, FlopLive)
+       andBool (#rangeAddress(FlopVow)
+       andBool (#rangeUInt(256, Vat_balance)
+       andBool (#rangeUInt(256, Flapper_balance)
+       andBool (#rangeUInt(256, Flopper_balance)
+       andBool ((#sizeByteArray(CD) <=Int 1250000000)
+       andBool ((#notPrecompileAddress(Vat))
+       andBool ((#notPrecompileAddress(Flapper))
+       andBool ((#notPrecompileAddress(Flopper))
+       andBool ((#notPrecompileAddress(FlapVat))
+       andBool ((#notPrecompileAddress(FlopVow))
+       andBool ((ACCT_ID =/=Int Vat)
+       andBool ((ACCT_ID =/=Int Flapper)
+       andBool ((ACCT_ID =/=Int Flopper)
+       andBool ((Dai_v +Int Dai_f >Int Sin_v)
+       andBool ((Flapper =/=Int ACCT_ID)
+       andBool ((Flapper =/=Int Vat)
+       andBool ((Flopper =/=Int ACCT_ID)
+       andBool ((Flopper =/=Int Vat)
+       andBool ((Flopper =/=Int Flapper)
+       andBool ((FlapVat ==Int  Vat)
+       andBool ((Vat =/=Int 0)
+       andBool ((Flapper =/=Int 0)
+       andBool ((Flopper =/=Int 0)
+       andBool (#rangeUInt(256, Junk_0)
+       andBool (#rangeUInt(256, Junk_1)
+       andBool (#rangeUInt(256, Junk_2)
+       andBool (#rangeUInt(256, Junk_3)
+       andBool (#rangeUInt(256, Junk_4)
+       andBool (#rangeUInt(256, Junk_5)
+       andBool (#rangeUInt(256, Junk_6)
+       andBool (#rangeUInt(256, Junk_7)
+       andBool (#rangeUInt(256, Junk_8)
+       andBool (#rangeUInt(256, Junk_9)
+       andBool (#rangeUInt(256, Junk_10)
+       andBool (#rangeUInt(256, Junk_11)
+       andBool (#rangeUInt(256, Junk_12)
+       andBool (#rangeUInt(256, Junk_13)
+       andBool (#rangeUInt(256, Junk_14)
+       andBool (#rangeUInt(256, Junk_15)
+       andBool (#rangeUInt(256, Junk_16)
+       andBool (#rangeUInt(256, Junk_17)
+       andBool (#rangeUInt(256, Junk_18)
+       andBool (#rangeUInt(256, Junk_19)
+       andBool (((VCallValue ==Int 0))
+       andBool (((VCallDepth <Int 1023))
+       andBool (((Live ==Int 1))
+       andBool (((Can ==Int 1))
+       andBool (((MayFlap ==Int 1))
+       andBool (((MayFlop ==Int 1))
+       andBool ((#rangeUInt(256, Dai_v +Int Dai_f))
+       andBool ((#rangeUInt(256, Debt -Int Sin_v))
+       andBool ((#rangeUInt(256, Vice -Int Sin_v))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))
+
+       andBool #lookup(ACCT_ID_STORAGE, #Vow.wards[CALLER_ID]) ==Int Can
+       andBool #lookup(ACCT_ID_STORAGE, #Vow.vat) ==Int Vat
+       andBool #lookup(ACCT_ID_STORAGE, #Vow.flopper) ==Int Flopper
+       andBool #lookup(ACCT_ID_STORAGE, #Vow.flapper) ==Int Flapper
+       andBool #lookup(ACCT_ID_STORAGE, #Vow.live) ==Int Live
+       andBool #lookup(ACCT_ID_STORAGE, #Vow.Sin) ==Int Sin
+       andBool #lookup(ACCT_ID_STORAGE, #Vow.Ash) ==Int Ash
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Vow.wards[CALLER_ID]) ==Int Junk_0
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Vow.vat) ==Int Junk_1
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Vow.flopper) ==Int Junk_2
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Vow.flapper) ==Int Junk_3
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Vow.live) ==Int Junk_4
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Vow.Sin) ==Int Junk_5
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Vow.Ash) ==Int Junk_6
+       andBool #Vow.wards[CALLER_ID] =/=Int #Vow.vat
+       andBool #Vow.wards[CALLER_ID] =/=Int #Vow.flopper
+       andBool #Vow.wards[CALLER_ID] =/=Int #Vow.flapper
+       andBool #Vow.wards[CALLER_ID] =/=Int #Vow.live
+       andBool #Vow.wards[CALLER_ID] =/=Int #Vow.Sin
+       andBool #Vow.wards[CALLER_ID] =/=Int #Vow.Ash
+       andBool #Vow.vat =/=Int #Vow.flopper
+       andBool #Vow.vat =/=Int #Vow.flapper
+       andBool #Vow.vat =/=Int #Vow.live
+       andBool #Vow.vat =/=Int #Vow.Sin
+       andBool #Vow.vat =/=Int #Vow.Ash
+       andBool #Vow.flopper =/=Int #Vow.flapper
+       andBool #Vow.flopper =/=Int #Vow.live
+       andBool #Vow.flopper =/=Int #Vow.Sin
+       andBool #Vow.flopper =/=Int #Vow.Ash
+       andBool #Vow.flapper =/=Int #Vow.live
+       andBool #Vow.flapper =/=Int #Vow.Sin
+       andBool #Vow.flapper =/=Int #Vow.Ash
+       andBool #Vow.live =/=Int #Vow.Sin
+       andBool #Vow.live =/=Int #Vow.Ash
+       andBool #Vow.Sin =/=Int #Vow.Ash
+       andBool #lookup(Vat_STORAGE, #Vat.can[Flapper][Flapper]) ==Int Junk_7
+       andBool #lookup(Vat_STORAGE, #Vat.dai[Flapper]) ==Int Dai_f
+       andBool #lookup(Vat_STORAGE, #Vat.dai[ACCT_ID]) ==Int Dai_v
+       andBool #lookup(Vat_STORAGE, #Vat.sin[ACCT_ID]) ==Int Sin_v
+       andBool #lookup(Vat_STORAGE, #Vat.debt) ==Int Debt
+       andBool #lookup(Vat_STORAGE, #Vat.vice) ==Int Vice
+       andBool #lookup(Vat_ORIG_STORAGE, #Vat.can[Flapper][Flapper]) ==Int Junk_8
+       andBool #lookup(Vat_ORIG_STORAGE, #Vat.dai[Flapper]) ==Int Junk_9
+       andBool #lookup(Vat_ORIG_STORAGE, #Vat.dai[ACCT_ID]) ==Int Junk_10
+       andBool #lookup(Vat_ORIG_STORAGE, #Vat.sin[ACCT_ID]) ==Int Junk_11
+       andBool #lookup(Vat_ORIG_STORAGE, #Vat.debt) ==Int Junk_12
+       andBool #lookup(Vat_ORIG_STORAGE, #Vat.vice) ==Int Junk_13
+       andBool #Vat.can[Flapper][Flapper] =/=Int #Vat.dai[Flapper]
+       andBool #Vat.can[Flapper][Flapper] =/=Int #Vat.dai[ACCT_ID]
+       andBool #Vat.can[Flapper][Flapper] =/=Int #Vat.sin[ACCT_ID]
+       andBool #Vat.can[Flapper][Flapper] =/=Int #Vat.debt
+       andBool #Vat.can[Flapper][Flapper] =/=Int #Vat.vice
+       andBool #Vat.dai[Flapper] =/=Int #Vat.dai[ACCT_ID]
+       andBool #Vat.dai[Flapper] =/=Int #Vat.sin[ACCT_ID]
+       andBool #Vat.dai[Flapper] =/=Int #Vat.debt
+       andBool #Vat.dai[Flapper] =/=Int #Vat.vice
+       andBool #Vat.dai[ACCT_ID] =/=Int #Vat.sin[ACCT_ID]
+       andBool #Vat.dai[ACCT_ID] =/=Int #Vat.debt
+       andBool #Vat.dai[ACCT_ID] =/=Int #Vat.vice
+       andBool #Vat.sin[ACCT_ID] =/=Int #Vat.debt
+       andBool #Vat.sin[ACCT_ID] =/=Int #Vat.vice
+       andBool #Vat.debt =/=Int #Vat.vice
+       andBool #lookup(Flapper_STORAGE, #Flapper.wards[ACCT_ID]) ==Int MayFlap
+       andBool #lookup(Flapper_STORAGE, #Flapper.vat) ==Int FlapVat
+       andBool #lookup(Flapper_STORAGE, #Flapper.live) ==Int FlapLive
+       andBool #lookup(Flapper_ORIG_STORAGE, #Flapper.wards[ACCT_ID]) ==Int Junk_14
+       andBool #lookup(Flapper_ORIG_STORAGE, #Flapper.vat) ==Int Junk_15
+       andBool #lookup(Flapper_ORIG_STORAGE, #Flapper.live) ==Int Junk_16
+       andBool #Flapper.wards[ACCT_ID] =/=Int #Flapper.vat
+       andBool #Flapper.wards[ACCT_ID] =/=Int #Flapper.live
+       andBool #Flapper.vat =/=Int #Flapper.live
+       andBool #lookup(Flopper_STORAGE, #Flopper.wards[ACCT_ID]) ==Int MayFlop
+       andBool #lookup(Flopper_STORAGE, #Flopper.live) ==Int FlopLive
+       andBool #lookup(Flopper_STORAGE, #Flopper.vow) ==Int FlopVow
+       andBool #lookup(Flopper_ORIG_STORAGE, #Flopper.wards[ACCT_ID]) ==Int Junk_17
+       andBool #lookup(Flopper_ORIG_STORAGE, #Flopper.live) ==Int Junk_18
+       andBool #lookup(Flopper_ORIG_STORAGE, #Flopper.vow) ==Int Junk_19
+       andBool #Flopper.wards[ACCT_ID] =/=Int #Flopper.live
+       andBool #Flopper.wards[ACCT_ID] =/=Int #Flopper.vow
+       andBool #Flopper.live =/=Int #Flopper.vow
+
+    // Vow_minuu
+    claim [Vow.minuu.pass]:
+      <k> #execute ~> CONTINUATION => #execute ~> CONTINUATION </k>
+      <exit-code> 1 </exit-code>
+      <mode> NORMAL </mode>
+      <schedule> ISTANBUL </schedule>
+      <ethereum>
+        <evm>
+          <output> VOutput => VOutput </output>
+          <statusCode> _ => ?_ </statusCode>
+          <endPC> _ => ?_ </endPC>
+          <callStack> _VCallStack </callStack>
+          <interimStates> _ </interimStates>
+          <touchedAccounts> _ => ?_ </touchedAccounts>
+          <callState>
+            <program> Vow_bin_runtime </program>
+            <jumpDests> #computeValidJumpDests(Vow_bin_runtime) </jumpDests>
+            <id> ACCT_ID </id>
+            <caller> CALLER_ID </caller>
+            <callData> _ => ?_ </callData>
+            <callValue> VCallValue </callValue>
+            <wordStack> ABI_y : ABI_x : JMPTO : WS  =>  JMPTO : #if ABI_x >Int ABI_y #then ABI_y #else ABI_x #fi : WS </wordStack>
+            <localMem> _ </localMem>
+            <pc> 9829 => 9854 </pc>
+            <gas> #gas(VGas) => #if ABI_x <=Int ABI_y
+              #then   #gas ( ( VGas +Int -49 ) )
+              #else   #gas ( ( VGas +Int -59 ) )
+            #fi </gas>
+            <memoryUsed> VMemoryUsed </memoryUsed>
+            <callGas> _ => ?_ </callGas>
+            <static> _ </static>
+            <callDepth> VCallDepth </callDepth>
+          </callState>
+          <substate>
+            <selfDestruct> _VSelfDestruct </selfDestruct>
+            <log> _ => ?_ </log>
+            <refund> _Vrefund => ?_ </refund>
+          </substate>
+          <gasPrice> _ </gasPrice>
+          <origin> ORIGIN_ID </origin>
+          <blockhashes> _ </blockhashes>
+          <block>
+            <previousHash> _ </previousHash>
+            <ommersHash> _ </ommersHash>
+            <coinbase> _ </coinbase>
+            <stateRoot> _ </stateRoot>
+            <transactionsRoot> _ </transactionsRoot>
+            <receiptsRoot> _ </receiptsRoot>
+            <logsBloom> _ </logsBloom>
+            <difficulty> _ </difficulty>
+            <number> _BLOCK_NUMBER </number>
+            <gasLimit> _ </gasLimit>
+            <gasUsed> _ </gasUsed>
+            <timestamp> TIME </timestamp>
+            <extraData> _ </extraData>
+            <mixHash> _ </mixHash>
+            <blockNonce> _ </blockNonce>
+            <ommerBlockHeaders> _ </ommerBlockHeaders>
+          </block>
+        </evm>
+        <network>
+          <chainID> VChainId </chainID>
+          <activeAccounts> SetItem(ACCT_ID)
+          SetItem(1)
+          SetItem(2)
+          SetItem(3)
+          SetItem(4)
+          SetItem(5)
+          SetItem(6)
+          SetItem(7)
+          SetItem(8)
+          SetItem(9) _ </activeAccounts>
+          <accounts>
+            <account>
+              <acctID> ACCT_ID </acctID>
+              <balance> ACCT_ID_balance </balance>
+              <code> Vow_bin_runtime </code>
+              <storage> ACCT_ID_STORAGE => ACCT_ID_STORAGE  </storage>
+              <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
+              <nonce> _Nonce_Vow => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> 1 </acctID>
+              <balance> ECREC_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 2 </acctID>
+              <balance> SHA256_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 3 </acctID>
+              <balance> RIP160_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 4 </acctID>
+              <balance> ID_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 5 </acctID>
+              <balance> MODEXP_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 6 </acctID>
+              <balance> ECADD_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 7 </acctID>
+              <balance> ECMUL_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 8 </acctID>
+              <balance> ECPAIRING_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 9 </acctID>
+              <balance> BLAKE2_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+           ...
+          </accounts>
+          <txOrder> _ </txOrder>
+          <txPending> _ </txPending>
+          <messages> _ </messages>
+        </network>
+      </ethereum>
+      requires #rangeAddress(ACCT_ID)
+       andBool ACCT_ID =/=Int 0
+       andBool #notPrecompileAddress(ACCT_ID)
+       andBool #rangeAddress(CALLER_ID)
+       andBool #rangeAddress(ORIGIN_ID)
+       andBool #rangeUInt(256, TIME)
+       andBool #rangeUInt(256, ACCT_ID_balance)
+       andBool #rangeUInt(256, ECREC_BAL)
+       andBool #rangeUInt(256, SHA256_BAL)
+       andBool #rangeUInt(256, RIP160_BAL)
+       andBool #rangeUInt(256, ID_BAL)
+       andBool #rangeUInt(256, MODEXP_BAL)
+       andBool #rangeUInt(256, ECADD_BAL)
+       andBool #rangeUInt(256, ECMUL_BAL)
+       andBool #rangeUInt(256, ECPAIRING_BAL)
+       andBool #rangeUInt(256, BLAKE2_BAL)
+       andBool VCallDepth <=Int 1024
+       andBool #rangeUInt(256, VCallValue)
+       andBool #rangeUInt(256, VChainId)
+
+       andBool (#rangeUInt(256, ABI_x)
+       andBool (#rangeUInt(256, ABI_y)
+       andBool ((#sizeWordStack(WS) <=Int 1000)
+       andBool (#rangeUInt(256, VMemoryUsed)))))
+
+
+    [trusted, matching(infGas)]
+
+
+    // Vat_dai
+    claim [Vat.dai.pass]:
+      <k> #execute ~> CONTINUATION => #halt ~> CONTINUATION </k>
+      <exit-code> 1 </exit-code>
+      <mode> NORMAL </mode>
+      <schedule> ISTANBUL </schedule>
+      <ethereum>
+        <evm>
+          <output> _ => #buf(32, Rad) </output>
+          <statusCode> _ => EVMC_SUCCESS </statusCode>
+          <endPC> _ => ?_ </endPC>
+          <callStack> _VCallStack </callStack>
+          <interimStates> _ </interimStates>
+          <touchedAccounts> _ => ?_ </touchedAccounts>
+          <callState>
+            <program> Vat_bin_runtime </program>
+            <jumpDests> #computeValidJumpDests(Vat_bin_runtime) </jumpDests>
+            <id> ACCT_ID </id>
+            <caller> CALLER_ID </caller>
+            <callData> #abiCallData("dai", #address(ABI_usr)) ++ CD => ?_ </callData>
+            <callValue> VCallValue </callValue>
+            <wordStack> .WordStack => ?_ </wordStack>
+            <localMem> .Memory => ?_ </localMem>
+            <pc> 0 => ?_ </pc>
+            <gas> #gas(VGas) => #gas ( ( VGas +Int -1236 ) ) </gas>
+            <memoryUsed> 0 => ?_ </memoryUsed>
+            <callGas> _ => ?_ </callGas>
+            <static> _ </static>
+            <callDepth> VCallDepth </callDepth>
+          </callState>
+          <substate>
+            <selfDestruct> _VSelfDestruct </selfDestruct>
+            <log> _ => ?_ </log>
+            <refund> _Vrefund => ?_ </refund>
+          </substate>
+          <gasPrice> _ </gasPrice>
+          <origin> ORIGIN_ID </origin>
+          <blockhashes> _ </blockhashes>
+          <block>
+            <previousHash> _ </previousHash>
+            <ommersHash> _ </ommersHash>
+            <coinbase> _ </coinbase>
+            <stateRoot> _ </stateRoot>
+            <transactionsRoot> _ </transactionsRoot>
+            <receiptsRoot> _ </receiptsRoot>
+            <logsBloom> _ </logsBloom>
+            <difficulty> _ </difficulty>
+            <number> _BLOCK_NUMBER </number>
+            <gasLimit> _ </gasLimit>
+            <gasUsed> _ </gasUsed>
+            <timestamp> TIME </timestamp>
+            <extraData> _ </extraData>
+            <mixHash> _ </mixHash>
+            <blockNonce> _ </blockNonce>
+            <ommerBlockHeaders> _ </ommerBlockHeaders>
+          </block>
+        </evm>
+        <network>
+          <chainID> VChainId </chainID>
+          <activeAccounts> SetItem(ACCT_ID)
+          SetItem(1)
+          SetItem(2)
+          SetItem(3)
+          SetItem(4)
+          SetItem(5)
+          SetItem(6)
+          SetItem(7)
+          SetItem(8)
+          SetItem(9) _ </activeAccounts>
+          <accounts>
+            <account>
+              <acctID> ACCT_ID </acctID>
+              <balance> ACCT_ID_balance </balance>
+              <code> Vat_bin_runtime </code>
+              <storage> ACCT_ID_STORAGE => ACCT_ID_STORAGE  </storage>
+              <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
+              <nonce> _Nonce_Vat => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> 1 </acctID>
+              <balance> ECREC_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 2 </acctID>
+              <balance> SHA256_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 3 </acctID>
+              <balance> RIP160_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 4 </acctID>
+              <balance> ID_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 5 </acctID>
+              <balance> MODEXP_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 6 </acctID>
+              <balance> ECADD_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 7 </acctID>
+              <balance> ECMUL_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 8 </acctID>
+              <balance> ECPAIRING_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 9 </acctID>
+              <balance> BLAKE2_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+           ...
+          </accounts>
+          <txOrder> _ </txOrder>
+          <txPending> _ </txPending>
+          <messages> _ </messages>
+        </network>
+      </ethereum>
+      requires #rangeAddress(ACCT_ID)
+       andBool ACCT_ID =/=Int 0
+       andBool #notPrecompileAddress(ACCT_ID)
+       andBool #rangeAddress(CALLER_ID)
+       andBool #rangeAddress(ORIGIN_ID)
+       andBool #rangeUInt(256, TIME)
+       andBool #rangeUInt(256, ACCT_ID_balance)
+       andBool #rangeUInt(256, ECREC_BAL)
+       andBool #rangeUInt(256, SHA256_BAL)
+       andBool #rangeUInt(256, RIP160_BAL)
+       andBool #rangeUInt(256, ID_BAL)
+       andBool #rangeUInt(256, MODEXP_BAL)
+       andBool #rangeUInt(256, ECADD_BAL)
+       andBool #rangeUInt(256, ECMUL_BAL)
+       andBool #rangeUInt(256, ECPAIRING_BAL)
+       andBool #rangeUInt(256, BLAKE2_BAL)
+       andBool VCallDepth <=Int 1024
+       andBool #rangeUInt(256, VCallValue)
+       andBool #rangeUInt(256, VChainId)
+
+       andBool (#rangeAddress(ABI_usr)
+       andBool (#rangeUInt(256, Rad)
+       andBool (#sizeByteArray(CD) <=Int 1250000000
+       andBool (#rangeUInt(256, Junk_0)
+       andBool ((VCallValue ==Int 0))))))
+
+       andBool #lookup(ACCT_ID_STORAGE, #Vat.dai[ABI_usr]) ==Int Rad
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Vat.dai[ABI_usr]) ==Int Junk_0
+    [trusted, matching(infGas)]
+
+
+    // Vat_sin
+    claim [Vat.sin.pass]:
+      <k> #execute ~> CONTINUATION => #halt ~> CONTINUATION </k>
+      <exit-code> 1 </exit-code>
+      <mode> NORMAL </mode>
+      <schedule> ISTANBUL </schedule>
+      <ethereum>
+        <evm>
+          <output> _ => #buf(32, Rad) </output>
+          <statusCode> _ => EVMC_SUCCESS </statusCode>
+          <endPC> _ => ?_ </endPC>
+          <callStack> _VCallStack </callStack>
+          <interimStates> _ </interimStates>
+          <touchedAccounts> _ => ?_ </touchedAccounts>
+          <callState>
+            <program> Vat_bin_runtime </program>
+            <jumpDests> #computeValidJumpDests(Vat_bin_runtime) </jumpDests>
+            <id> ACCT_ID </id>
+            <caller> CALLER_ID </caller>
+            <callData> #abiCallData("sin", #address(ABI_usr)) ++ CD => ?_ </callData>
+            <callValue> VCallValue </callValue>
+            <wordStack> .WordStack => ?_ </wordStack>
+            <localMem> .Memory => ?_ </localMem>
+            <pc> 0 => ?_ </pc>
+            <gas> #gas(VGas) => #gas ( ( VGas +Int -1235 ) ) </gas>
+            <memoryUsed> 0 => ?_ </memoryUsed>
+            <callGas> _ => ?_ </callGas>
+            <static> _ </static>
+            <callDepth> VCallDepth </callDepth>
+          </callState>
+          <substate>
+            <selfDestruct> _VSelfDestruct </selfDestruct>
+            <log> _ => ?_ </log>
+            <refund> _Vrefund => ?_ </refund>
+          </substate>
+          <gasPrice> _ </gasPrice>
+          <origin> ORIGIN_ID </origin>
+          <blockhashes> _ </blockhashes>
+          <block>
+            <previousHash> _ </previousHash>
+            <ommersHash> _ </ommersHash>
+            <coinbase> _ </coinbase>
+            <stateRoot> _ </stateRoot>
+            <transactionsRoot> _ </transactionsRoot>
+            <receiptsRoot> _ </receiptsRoot>
+            <logsBloom> _ </logsBloom>
+            <difficulty> _ </difficulty>
+            <number> _BLOCK_NUMBER </number>
+            <gasLimit> _ </gasLimit>
+            <gasUsed> _ </gasUsed>
+            <timestamp> TIME </timestamp>
+            <extraData> _ </extraData>
+            <mixHash> _ </mixHash>
+            <blockNonce> _ </blockNonce>
+            <ommerBlockHeaders> _ </ommerBlockHeaders>
+          </block>
+        </evm>
+        <network>
+          <chainID> VChainId </chainID>
+          <activeAccounts> SetItem(ACCT_ID)
+          SetItem(1)
+          SetItem(2)
+          SetItem(3)
+          SetItem(4)
+          SetItem(5)
+          SetItem(6)
+          SetItem(7)
+          SetItem(8)
+          SetItem(9) _ </activeAccounts>
+          <accounts>
+            <account>
+              <acctID> ACCT_ID </acctID>
+              <balance> ACCT_ID_balance </balance>
+              <code> Vat_bin_runtime </code>
+              <storage> ACCT_ID_STORAGE => ACCT_ID_STORAGE  </storage>
+              <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
+              <nonce> _Nonce_Vat => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> 1 </acctID>
+              <balance> ECREC_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 2 </acctID>
+              <balance> SHA256_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 3 </acctID>
+              <balance> RIP160_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 4 </acctID>
+              <balance> ID_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 5 </acctID>
+              <balance> MODEXP_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 6 </acctID>
+              <balance> ECADD_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 7 </acctID>
+              <balance> ECMUL_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 8 </acctID>
+              <balance> ECPAIRING_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 9 </acctID>
+              <balance> BLAKE2_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+           ...
+          </accounts>
+          <txOrder> _ </txOrder>
+          <txPending> _ </txPending>
+          <messages> _ </messages>
+        </network>
+      </ethereum>
+      requires #rangeAddress(ACCT_ID)
+       andBool ACCT_ID =/=Int 0
+       andBool #notPrecompileAddress(ACCT_ID)
+       andBool #rangeAddress(CALLER_ID)
+       andBool #rangeAddress(ORIGIN_ID)
+       andBool #rangeUInt(256, TIME)
+       andBool #rangeUInt(256, ACCT_ID_balance)
+       andBool #rangeUInt(256, ECREC_BAL)
+       andBool #rangeUInt(256, SHA256_BAL)
+       andBool #rangeUInt(256, RIP160_BAL)
+       andBool #rangeUInt(256, ID_BAL)
+       andBool #rangeUInt(256, MODEXP_BAL)
+       andBool #rangeUInt(256, ECADD_BAL)
+       andBool #rangeUInt(256, ECMUL_BAL)
+       andBool #rangeUInt(256, ECPAIRING_BAL)
+       andBool #rangeUInt(256, BLAKE2_BAL)
+       andBool VCallDepth <=Int 1024
+       andBool #rangeUInt(256, VCallValue)
+       andBool #rangeUInt(256, VChainId)
+
+       andBool (#rangeAddress(ABI_usr)
+       andBool (#rangeUInt(256, Rad)
+       andBool (#sizeByteArray(CD) <=Int 1250000000
+       andBool (#rangeUInt(256, Junk_0)
+       andBool ((VCallValue ==Int 0))))))
+
+       andBool #lookup(ACCT_ID_STORAGE, #Vat.sin[ABI_usr]) ==Int Rad
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Vat.sin[ABI_usr]) ==Int Junk_0
+    [trusted, matching(infGas)]
+
+
+    // Vat_heal
+    claim [Vat.heal.pass]:
+      <k> #execute ~> CONTINUATION => #halt ~> CONTINUATION </k>
+      <exit-code> 1 </exit-code>
+      <mode> NORMAL </mode>
+      <schedule> ISTANBUL </schedule>
+      <ethereum>
+        <evm>
+          <output> .ByteArray </output>
+          <statusCode> _ => EVMC_SUCCESS </statusCode>
+          <endPC> _ => ?_ </endPC>
+          <callStack> _VCallStack </callStack>
+          <interimStates> _ </interimStates>
+          <touchedAccounts> _ => ?_ </touchedAccounts>
+          <callState>
+            <program> Vat_bin_runtime </program>
+            <jumpDests> #computeValidJumpDests(Vat_bin_runtime) </jumpDests>
+            <id> ACCT_ID </id>
+            <caller> CALLER_ID </caller>
+            <callData> #abiCallData("heal", #uint256(ABI_rad)) ++ CD => ?_ </callData>
+            <callValue> VCallValue </callValue>
+            <wordStack> .WordStack => ?_ </wordStack>
+            <localMem> .Memory => ?_ </localMem>
+            <pc> 0 => ?_ </pc>
+            <gas> #gas(VGas) => #gas ( ( ( ( ( ( VGas -Int Csstore( ISTANBUL , ( Sin -Int ABI_rad ) , Sin , Junk_0 ) ) -Int Csstore( ISTANBUL , ( Dai -Int ABI_rad ) , Dai , Junk_1 ) ) -Int Csstore( ISTANBUL , ( Vice -Int ABI_rad ) , Vice , Junk_3 ) ) -Int Csstore( ISTANBUL , ( Debt -Int ABI_rad ) , Debt , Junk_2 ) ) +Int -8616 ) ) </gas>
+            <memoryUsed> 0 => ?_ </memoryUsed>
+            <callGas> _ => ?_ </callGas>
+            <static> false </static>
+            <callDepth> VCallDepth </callDepth>
+          </callState>
+          <substate>
+            <selfDestruct> _VSelfDestruct </selfDestruct>
+            <log> _ => ?_ </log>
+            <refund> _Vrefund => ?_ </refund>
+          </substate>
+          <gasPrice> _ </gasPrice>
+          <origin> ORIGIN_ID </origin>
+          <blockhashes> _ </blockhashes>
+          <block>
+            <previousHash> _ </previousHash>
+            <ommersHash> _ </ommersHash>
+            <coinbase> _ </coinbase>
+            <stateRoot> _ </stateRoot>
+            <transactionsRoot> _ </transactionsRoot>
+            <receiptsRoot> _ </receiptsRoot>
+            <logsBloom> _ </logsBloom>
+            <difficulty> _ </difficulty>
+            <number> _BLOCK_NUMBER </number>
+            <gasLimit> _ </gasLimit>
+            <gasUsed> _ </gasUsed>
+            <timestamp> TIME </timestamp>
+            <extraData> _ </extraData>
+            <mixHash> _ </mixHash>
+            <blockNonce> _ </blockNonce>
+            <ommerBlockHeaders> _ </ommerBlockHeaders>
+          </block>
+        </evm>
+        <network>
+          <chainID> VChainId </chainID>
+          <activeAccounts> SetItem(ACCT_ID)
+          SetItem(1)
+          SetItem(2)
+          SetItem(3)
+          SetItem(4)
+          SetItem(5)
+          SetItem(6)
+          SetItem(7)
+          SetItem(8)
+          SetItem(9) _ </activeAccounts>
+          <accounts>
+            <account>
+              <acctID> ACCT_ID </acctID>
+              <balance> ACCT_ID_balance </balance>
+              <code> Vat_bin_runtime </code>
+              <storage> ACCT_ID_STORAGE => ACCT_ID_STORAGE [ #Vat.sin[CALLER_ID] <- Sin -Int ABI_rad ] [ #Vat.dai[CALLER_ID] <- Dai -Int ABI_rad ] [ #Vat.debt <- Debt  -Int ABI_rad ] [ #Vat.vice <- Vice  -Int ABI_rad ] </storage>
+              <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
+              <nonce> _Nonce_Vat => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> 1 </acctID>
+              <balance> ECREC_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 2 </acctID>
+              <balance> SHA256_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 3 </acctID>
+              <balance> RIP160_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 4 </acctID>
+              <balance> ID_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 5 </acctID>
+              <balance> MODEXP_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 6 </acctID>
+              <balance> ECADD_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 7 </acctID>
+              <balance> ECMUL_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 8 </acctID>
+              <balance> ECPAIRING_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 9 </acctID>
+              <balance> BLAKE2_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+           ...
+          </accounts>
+          <txOrder> _ </txOrder>
+          <txPending> _ </txPending>
+          <messages> _ </messages>
+        </network>
+      </ethereum>
+      requires #rangeAddress(ACCT_ID)
+       andBool ACCT_ID =/=Int 0
+       andBool #notPrecompileAddress(ACCT_ID)
+       andBool #rangeAddress(CALLER_ID)
+       andBool #rangeAddress(ORIGIN_ID)
+       andBool #rangeUInt(256, TIME)
+       andBool #rangeUInt(256, ACCT_ID_balance)
+       andBool #rangeUInt(256, ECREC_BAL)
+       andBool #rangeUInt(256, SHA256_BAL)
+       andBool #rangeUInt(256, RIP160_BAL)
+       andBool #rangeUInt(256, ID_BAL)
+       andBool #rangeUInt(256, MODEXP_BAL)
+       andBool #rangeUInt(256, ECADD_BAL)
+       andBool #rangeUInt(256, ECMUL_BAL)
+       andBool #rangeUInt(256, ECPAIRING_BAL)
+       andBool #rangeUInt(256, BLAKE2_BAL)
+       andBool VCallDepth <=Int 1024
+       andBool #rangeUInt(256, VCallValue)
+       andBool #rangeUInt(256, VChainId)
+
+       andBool (#rangeUInt(256, ABI_rad)
+       andBool (#rangeUInt(256, Dai)
+       andBool (#rangeUInt(256, Sin)
+       andBool (#rangeUInt(256, Debt)
+       andBool (#rangeUInt(256, Vice)
+       andBool (#sizeByteArray(CD) <=Int 1250000000
+       andBool (#rangeUInt(256, Junk_0)
+       andBool (#rangeUInt(256, Junk_1)
+       andBool (#rangeUInt(256, Junk_2)
+       andBool (#rangeUInt(256, Junk_3)
+       andBool (((VCallValue ==Int 0))
+       andBool ((#rangeUInt(256, Dai -Int ABI_rad))
+       andBool ((#rangeUInt(256, Sin -Int ABI_rad))
+       andBool ((#rangeUInt(256, Debt  -Int ABI_rad))
+       andBool ((#rangeUInt(256, Vice  -Int ABI_rad)))))))))))))))))
+
+       andBool #lookup(ACCT_ID_STORAGE, #Vat.sin[CALLER_ID]) ==Int Sin
+       andBool #lookup(ACCT_ID_STORAGE, #Vat.dai[CALLER_ID]) ==Int Dai
+       andBool #lookup(ACCT_ID_STORAGE, #Vat.debt) ==Int Debt
+       andBool #lookup(ACCT_ID_STORAGE, #Vat.vice) ==Int Vice
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Vat.sin[CALLER_ID]) ==Int Junk_0
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Vat.dai[CALLER_ID]) ==Int Junk_1
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Vat.debt) ==Int Junk_2
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Vat.vice) ==Int Junk_3
+       andBool #Vat.sin[CALLER_ID] =/=Int #Vat.dai[CALLER_ID]
+       andBool #Vat.sin[CALLER_ID] =/=Int #Vat.debt
+       andBool #Vat.sin[CALLER_ID] =/=Int #Vat.vice
+       andBool #Vat.dai[CALLER_ID] =/=Int #Vat.debt
+       andBool #Vat.dai[CALLER_ID] =/=Int #Vat.vice
+       andBool #Vat.debt =/=Int #Vat.vice
+    [trusted, matching(infGas)]
+
+
+    // Flapper_cage
+    claim [Flapper.cage.pass]:
+      <k> #execute ~> CONTINUATION => #halt ~> CONTINUATION </k>
+      <exit-code> 1 </exit-code>
+      <mode> NORMAL </mode>
+      <schedule> ISTANBUL </schedule>
+      <ethereum>
+        <evm>
+          <output> .ByteArray </output>
+          <statusCode> _ => EVMC_SUCCESS </statusCode>
+          <endPC> _ => ?_ </endPC>
+          <callStack> _VCallStack </callStack>
+          <interimStates> _ </interimStates>
+          <touchedAccounts> _ => ?_ </touchedAccounts>
+          <callState>
+            <program> Flapper_bin_runtime </program>
+            <jumpDests> #computeValidJumpDests(Flapper_bin_runtime) </jumpDests>
+            <id> ACCT_ID </id>
+            <caller> CALLER_ID </caller>
+            <callData> #abiCallData("cage", #uint256(ABI_rad)) ++ CD => ?_ </callData>
+            <callValue> VCallValue </callValue>
+            <wordStack> .WordStack => ?_ </wordStack>
+            <localMem> .Memory => ?_ </localMem>
+            <pc> 0 => ?_ </pc>
+            <gas> #gas(VGas) => #gas ( ( ( ( ( ( ( ( VGas -Int Csstore( ISTANBUL , 0 , Live , Junk_2 ) ) -Int #allBut64th( ( ( VGas -Int Csstore( ISTANBUL , 0 , Live , Junk_2 ) ) +Int -3653 ) ) ) +Int -3653 ) +Int #allBut64th( ( ( VGas -Int Csstore( ISTANBUL , 0 , Live , Junk_2 ) ) +Int -3653 ) ) ) -Int Csstore( ISTANBUL , ( Dai_a -Int ABI_rad ) , Dai_a , Junk_5 ) ) -Int Csstore( ISTANBUL , ( Dai_u +Int ABI_rad ) , Dai_u , Junk_6 ) ) +Int -12311 ) ) </gas>
+            <memoryUsed> 0 => ?_ </memoryUsed>
+            <callGas> _ => ?_ </callGas>
+            <static> false </static>
+            <callDepth> VCallDepth </callDepth>
+          </callState>
+          <substate>
+            <selfDestruct> _VSelfDestruct </selfDestruct>
+            <log> _ => ?_ </log>
+            <refund> _Vrefund => ?_ </refund>
+          </substate>
+          <gasPrice> _ </gasPrice>
+          <origin> ORIGIN_ID </origin>
+          <blockhashes> _ </blockhashes>
+          <block>
+            <previousHash> _ </previousHash>
+            <ommersHash> _ </ommersHash>
+            <coinbase> _ </coinbase>
+            <stateRoot> _ </stateRoot>
+            <transactionsRoot> _ </transactionsRoot>
+            <receiptsRoot> _ </receiptsRoot>
+            <logsBloom> _ </logsBloom>
+            <difficulty> _ </difficulty>
+            <number> _BLOCK_NUMBER </number>
+            <gasLimit> _ </gasLimit>
+            <gasUsed> _ </gasUsed>
+            <timestamp> TIME </timestamp>
+            <extraData> _ </extraData>
+            <mixHash> _ </mixHash>
+            <blockNonce> _ </blockNonce>
+            <ommerBlockHeaders> _ </ommerBlockHeaders>
+          </block>
+        </evm>
+        <network>
+          <chainID> VChainId </chainID>
+          <activeAccounts> SetItem(ACCT_ID)
+          SetItem(Vat)
+          SetItem(1)
+          SetItem(2)
+          SetItem(3)
+          SetItem(4)
+          SetItem(5)
+          SetItem(6)
+          SetItem(7)
+          SetItem(8)
+          SetItem(9) _ </activeAccounts>
+          <accounts>
+            <account>
+              <acctID> ACCT_ID </acctID>
+              <balance> ACCT_ID_balance </balance>
+              <code> Flapper_bin_runtime </code>
+              <storage> ACCT_ID_STORAGE => ACCT_ID_STORAGE [ #Flapper.live <- 0 ] </storage>
+              <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
+              <nonce> _Nonce_Flapper => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> Vat </acctID>
+              <balance> Vat_balance </balance>
+              <code> Vat_bin_runtime </code>
+              <storage> Vat_STORAGE => Vat_STORAGE [ #Vat.dai[ACCT_ID] <- Dai_a -Int ABI_rad ] [ #Vat.dai[CALLER_ID] <- Dai_u +Int ABI_rad ] </storage>
+              <origStorage> Vat_ORIG_STORAGE </origStorage>
+              <nonce> _Nonce_Vat => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> 1 </acctID>
+              <balance> ECREC_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 2 </acctID>
+              <balance> SHA256_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 3 </acctID>
+              <balance> RIP160_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 4 </acctID>
+              <balance> ID_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 5 </acctID>
+              <balance> MODEXP_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 6 </acctID>
+              <balance> ECADD_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 7 </acctID>
+              <balance> ECMUL_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 8 </acctID>
+              <balance> ECPAIRING_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 9 </acctID>
+              <balance> BLAKE2_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+           ...
+          </accounts>
+          <txOrder> _ </txOrder>
+          <txPending> _ </txPending>
+          <messages> _ </messages>
+        </network>
+      </ethereum>
+      requires #rangeAddress(ACCT_ID)
+       andBool ACCT_ID =/=Int 0
+       andBool #notPrecompileAddress(ACCT_ID)
+       andBool #rangeAddress(CALLER_ID)
+       andBool #rangeAddress(ORIGIN_ID)
+       andBool #rangeUInt(256, TIME)
+       andBool #rangeUInt(256, ACCT_ID_balance)
+       andBool #rangeUInt(256, ECREC_BAL)
+       andBool #rangeUInt(256, SHA256_BAL)
+       andBool #rangeUInt(256, RIP160_BAL)
+       andBool #rangeUInt(256, ID_BAL)
+       andBool #rangeUInt(256, MODEXP_BAL)
+       andBool #rangeUInt(256, ECADD_BAL)
+       andBool #rangeUInt(256, ECMUL_BAL)
+       andBool #rangeUInt(256, ECPAIRING_BAL)
+       andBool #rangeUInt(256, BLAKE2_BAL)
+       andBool VCallDepth <=Int 1024
+       andBool #rangeUInt(256, VCallValue)
+       andBool #rangeUInt(256, VChainId)
+
+       andBool (#rangeUInt(256, ABI_rad)
+       andBool (#rangeAddress(Vat)
+       andBool (#rangeUInt(256, Ward)
+       andBool (#rangeUInt(256, Live)
+       andBool (#rangeUInt(256, Dai_a)
+       andBool (#rangeUInt(256, Dai_u)
+       andBool (#rangeUInt(256, Vat_balance)
+       andBool ((#sizeByteArray(CD) <=Int 1250000000)
+       andBool ((#notPrecompileAddress(Vat))
+       andBool ((CALLER_ID =/=Int ACCT_ID)
+       andBool (ACCT_ID =/=Int Vat
+       andBool ((Vat =/=Int 0)
+       andBool (#rangeUInt(256, Junk_0)
+       andBool (#rangeUInt(256, Junk_1)
+       andBool (#rangeUInt(256, Junk_2)
+       andBool (#rangeUInt(256, Junk_3)
+       andBool (#rangeUInt(256, Junk_4)
+       andBool (#rangeUInt(256, Junk_5)
+       andBool (#rangeUInt(256, Junk_6)
+       andBool (((Ward ==Int 1))
+       andBool (((VCallDepth <Int 1024))
+       andBool (((VCallValue ==Int 0))
+       andBool ((#rangeUInt(256, Dai_a -Int ABI_rad))
+       andBool ((#rangeUInt(256, Dai_u +Int ABI_rad))))))))))))))))))))))))))
+
+       andBool #lookup(ACCT_ID_STORAGE, #Flapper.wards[CALLER_ID]) ==Int Ward
+       andBool #lookup(ACCT_ID_STORAGE, #Flapper.vat) ==Int Vat
+       andBool #lookup(ACCT_ID_STORAGE, #Flapper.live) ==Int Live
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Flapper.wards[CALLER_ID]) ==Int Junk_0
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Flapper.vat) ==Int Junk_1
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Flapper.live) ==Int Junk_2
+       andBool #Flapper.wards[CALLER_ID] =/=Int #Flapper.vat
+       andBool #Flapper.wards[CALLER_ID] =/=Int #Flapper.live
+       andBool #Flapper.vat =/=Int #Flapper.live
+       andBool #lookup(Vat_STORAGE, #Vat.can[ACCT_ID][ACCT_ID]) ==Int Junk_3
+       andBool #lookup(Vat_STORAGE, #Vat.dai[ACCT_ID]) ==Int Dai_a
+       andBool #lookup(Vat_STORAGE, #Vat.dai[CALLER_ID]) ==Int Dai_u
+       andBool #lookup(Vat_ORIG_STORAGE, #Vat.can[ACCT_ID][ACCT_ID]) ==Int Junk_4
+       andBool #lookup(Vat_ORIG_STORAGE, #Vat.dai[ACCT_ID]) ==Int Junk_5
+       andBool #lookup(Vat_ORIG_STORAGE, #Vat.dai[CALLER_ID]) ==Int Junk_6
+       andBool #Vat.can[ACCT_ID][ACCT_ID] =/=Int #Vat.dai[ACCT_ID]
+       andBool #Vat.can[ACCT_ID][ACCT_ID] =/=Int #Vat.dai[CALLER_ID]
+       andBool #Vat.dai[ACCT_ID] =/=Int #Vat.dai[CALLER_ID]
+    [trusted, matching(infGas)]
+
+
+    // Flopper_cage
+    claim [Flopper.cage.pass]:
+      <k> #execute ~> CONTINUATION => #halt ~> CONTINUATION </k>
+      <exit-code> 1 </exit-code>
+      <mode> NORMAL </mode>
+      <schedule> ISTANBUL </schedule>
+      <ethereum>
+        <evm>
+          <output> .ByteArray </output>
+          <statusCode> _ => EVMC_SUCCESS </statusCode>
+          <endPC> _ => ?_ </endPC>
+          <callStack> _VCallStack </callStack>
+          <interimStates> _ </interimStates>
+          <touchedAccounts> _ => ?_ </touchedAccounts>
+          <callState>
+            <program> Flopper_bin_runtime </program>
+            <jumpDests> #computeValidJumpDests(Flopper_bin_runtime) </jumpDests>
+            <id> ACCT_ID </id>
+            <caller> CALLER_ID </caller>
+            <callData> #abiCallData("cage", .TypedArgs) ++ CD => ?_ </callData>
+            <callValue> VCallValue </callValue>
+            <wordStack> .WordStack => ?_ </wordStack>
+            <localMem> .Memory => ?_ </localMem>
+            <pc> 0 => ?_ </pc>
+            <gas> #gas(VGas) => #gas ( ( ( ( VGas -Int Csstore( ISTANBUL , 0 , Live , Junk_1 ) ) -Int Csstore( ISTANBUL , CALLER_ID , Vow , Junk_2 ) ) +Int -6351 ) ) </gas>
+            <memoryUsed> 0 => ?_ </memoryUsed>
+            <callGas> _ => ?_ </callGas>
+            <static> false </static>
+            <callDepth> VCallDepth </callDepth>
+          </callState>
+          <substate>
+            <selfDestruct> _VSelfDestruct </selfDestruct>
+            <log> _ => ?_ </log>
+            <refund> _Vrefund => ?_ </refund>
+          </substate>
+          <gasPrice> _ </gasPrice>
+          <origin> ORIGIN_ID </origin>
+          <blockhashes> _ </blockhashes>
+          <block>
+            <previousHash> _ </previousHash>
+            <ommersHash> _ </ommersHash>
+            <coinbase> _ </coinbase>
+            <stateRoot> _ </stateRoot>
+            <transactionsRoot> _ </transactionsRoot>
+            <receiptsRoot> _ </receiptsRoot>
+            <logsBloom> _ </logsBloom>
+            <difficulty> _ </difficulty>
+            <number> _BLOCK_NUMBER </number>
+            <gasLimit> _ </gasLimit>
+            <gasUsed> _ </gasUsed>
+            <timestamp> TIME </timestamp>
+            <extraData> _ </extraData>
+            <mixHash> _ </mixHash>
+            <blockNonce> _ </blockNonce>
+            <ommerBlockHeaders> _ </ommerBlockHeaders>
+          </block>
+        </evm>
+        <network>
+          <chainID> VChainId </chainID>
+          <activeAccounts> SetItem(ACCT_ID)
+          SetItem(1)
+          SetItem(2)
+          SetItem(3)
+          SetItem(4)
+          SetItem(5)
+          SetItem(6)
+          SetItem(7)
+          SetItem(8)
+          SetItem(9) _ </activeAccounts>
+          <accounts>
+            <account>
+              <acctID> ACCT_ID </acctID>
+              <balance> ACCT_ID_balance </balance>
+              <code> Flopper_bin_runtime </code>
+              <storage> ACCT_ID_STORAGE => ACCT_ID_STORAGE [ #Flopper.live <- 0 ] [ #Flopper.vow <- CALLER_ID ] </storage>
+              <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
+              <nonce> _Nonce_Flopper => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> 1 </acctID>
+              <balance> ECREC_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 2 </acctID>
+              <balance> SHA256_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 3 </acctID>
+              <balance> RIP160_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 4 </acctID>
+              <balance> ID_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 5 </acctID>
+              <balance> MODEXP_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 6 </acctID>
+              <balance> ECADD_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 7 </acctID>
+              <balance> ECMUL_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 8 </acctID>
+              <balance> ECPAIRING_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 9 </acctID>
+              <balance> BLAKE2_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+           ...
+          </accounts>
+          <txOrder> _ </txOrder>
+          <txPending> _ </txPending>
+          <messages> _ </messages>
+        </network>
+      </ethereum>
+      requires #rangeAddress(ACCT_ID)
+       andBool ACCT_ID =/=Int 0
+       andBool #notPrecompileAddress(ACCT_ID)
+       andBool #rangeAddress(CALLER_ID)
+       andBool #rangeAddress(ORIGIN_ID)
+       andBool #rangeUInt(256, TIME)
+       andBool #rangeUInt(256, ACCT_ID_balance)
+       andBool #rangeUInt(256, ECREC_BAL)
+       andBool #rangeUInt(256, SHA256_BAL)
+       andBool #rangeUInt(256, RIP160_BAL)
+       andBool #rangeUInt(256, ID_BAL)
+       andBool #rangeUInt(256, MODEXP_BAL)
+       andBool #rangeUInt(256, ECADD_BAL)
+       andBool #rangeUInt(256, ECMUL_BAL)
+       andBool #rangeUInt(256, ECPAIRING_BAL)
+       andBool #rangeUInt(256, BLAKE2_BAL)
+       andBool VCallDepth <=Int 1024
+       andBool #rangeUInt(256, VCallValue)
+       andBool #rangeUInt(256, VChainId)
+
+       andBool (#rangeUInt(256, Ward)
+       andBool (#rangeUInt(256, Live)
+       andBool (#rangeAddress(Vow)
+       andBool (#sizeByteArray(CD) <=Int 1250000000
+       andBool (#notPrecompileAddress(Vow)
+       andBool (#rangeUInt(256, Junk_0)
+       andBool (#rangeUInt(256, Junk_1)
+       andBool (#rangeUInt(256, Junk_2)
+       andBool ((Ward ==Int 1)
+       andBool ((VCallValue ==Int 0)))))))))))
+
+       andBool #lookup(ACCT_ID_STORAGE, #Flopper.wards[CALLER_ID]) ==Int Ward
+       andBool #lookup(ACCT_ID_STORAGE, #Flopper.live) ==Int Live
+       andBool #lookup(ACCT_ID_STORAGE, #Flopper.vow) ==Int Vow
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Flopper.wards[CALLER_ID]) ==Int Junk_0
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Flopper.live) ==Int Junk_1
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Flopper.vow) ==Int Junk_2
+       andBool #Flopper.wards[CALLER_ID] =/=Int #Flopper.live
+       andBool #Flopper.wards[CALLER_ID] =/=Int #Flopper.vow
+       andBool #Flopper.live =/=Int #Flopper.vow
+    [trusted, matching(infGas)]
+
+
+endmodule

--- a/tests/specs/mcd/vow-fess-fail-rough-spec.k
+++ b/tests/specs/mcd/vow-fess-fail-rough-spec.k
@@ -1,0 +1,396 @@
+requires "verification.k"
+
+module VOW-FESS-FAIL-ROUGH-SPEC
+    imports VERIFICATION
+
+    // Vow_fess
+    claim [Vow.fess.fail.rough]:
+      <k> #execute ~> CONTINUATION => #halt ~> CONTINUATION </k>
+      <exit-code> 1 </exit-code>
+      <mode> NORMAL </mode>
+      <schedule> ISTANBUL </schedule>
+      <ethereum>
+        <evm>
+          <output> _ => ?_ </output>
+          <statusCode> _ => ?FAILURE:EndStatusCode </statusCode>
+          <endPC> _ => ?_ </endPC>
+          <callStack> _VCallStack </callStack>
+          <interimStates> _ </interimStates>
+          <touchedAccounts> _ => ?_ </touchedAccounts>
+          <callState>
+            <program> Vow_bin_runtime </program>
+            <jumpDests> #computeValidJumpDests(Vow_bin_runtime) </jumpDests>
+            <id> ACCT_ID </id>
+            <caller> CALLER_ID </caller>
+            <callData> #abiCallData("fess", #uint256(ABI_tab)) ++ CD => ?_ </callData>
+            <callValue> VCallValue </callValue>
+            <wordStack> .WordStack => ?_ </wordStack>
+            <localMem> .Memory => ?_ </localMem>
+            <pc> 0 => ?_ </pc>
+            <gas> VGas => ?_ </gas>
+            <memoryUsed> 0 => ?_ </memoryUsed>
+            <callGas> _ => ?_ </callGas>
+            <static> false </static>
+            <callDepth> VCallDepth => ?_ </callDepth>
+          </callState>
+          <substate>
+            <selfDestruct> _VSelfDestruct </selfDestruct>
+            <log> _ => ?_ </log>
+            <refund> _Vrefund => ?_ </refund>
+          </substate>
+          <gasPrice> _ </gasPrice>
+          <origin> ORIGIN_ID </origin>
+          <blockhashes> _ </blockhashes>
+          <block>
+            <previousHash> _ </previousHash>
+            <ommersHash> _ </ommersHash>
+            <coinbase> _ </coinbase>
+            <stateRoot> _ </stateRoot>
+            <transactionsRoot> _ </transactionsRoot>
+            <receiptsRoot> _ </receiptsRoot>
+            <logsBloom> _ </logsBloom>
+            <difficulty> _ </difficulty>
+            <number> _BLOCK_NUMBER </number>
+            <gasLimit> _ </gasLimit>
+            <gasUsed> _ </gasUsed>
+            <timestamp> TIME </timestamp>
+            <extraData> _ </extraData>
+            <mixHash> _ </mixHash>
+            <blockNonce> _ </blockNonce>
+            <ommerBlockHeaders> _ </ommerBlockHeaders>
+          </block>
+        </evm>
+        <network>
+          <chainID> VChainId </chainID>
+          <activeAccounts> SetItem(ACCT_ID)
+          SetItem(1)
+          SetItem(2)
+          SetItem(3)
+          SetItem(4)
+          SetItem(5)
+          SetItem(6)
+          SetItem(7)
+          SetItem(8)
+          SetItem(9) _ </activeAccounts>
+          <accounts>
+            <account>
+              <acctID> ACCT_ID </acctID>
+              <balance> ACCT_ID_balance </balance>
+              <code> Vow_bin_runtime </code>
+              <storage> ACCT_ID_STORAGE => ?_ACCT_ID_STORAGE </storage>
+              <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
+              <nonce> _Nonce_Vow => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> 1 </acctID>
+              <balance> ECREC_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 2 </acctID>
+              <balance> SHA256_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 3 </acctID>
+              <balance> RIP160_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 4 </acctID>
+              <balance> ID_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 5 </acctID>
+              <balance> MODEXP_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 6 </acctID>
+              <balance> ECADD_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 7 </acctID>
+              <balance> ECMUL_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 8 </acctID>
+              <balance> ECPAIRING_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 9 </acctID>
+              <balance> BLAKE2_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+           ...
+          </accounts>
+          <txOrder> _ </txOrder>
+          <txPending> _ </txPending>
+          <messages> _ </messages>
+        </network>
+      </ethereum>
+    requires #rangeAddress(ACCT_ID)
+     andBool ACCT_ID =/=Int 0
+     andBool #notPrecompileAddress(ACCT_ID)
+     andBool #rangeAddress(CALLER_ID)
+     andBool #rangeAddress(ORIGIN_ID)
+     andBool #rangeUInt(256, TIME)
+     andBool #rangeUInt(256, ACCT_ID_balance)
+     andBool #rangeUInt(256, ECREC_BAL)
+     andBool #rangeUInt(256, SHA256_BAL)
+     andBool #rangeUInt(256, RIP160_BAL)
+     andBool #rangeUInt(256, ID_BAL)
+     andBool #rangeUInt(256, MODEXP_BAL)
+     andBool #rangeUInt(256, ECADD_BAL)
+     andBool #rangeUInt(256, ECMUL_BAL)
+     andBool #rangeUInt(256, ECPAIRING_BAL)
+     andBool #rangeUInt(256, BLAKE2_BAL)
+     andBool VCallDepth <=Int 1024
+     andBool #rangeUInt(256, VCallValue)
+     andBool #rangeUInt(256, VChainId)
+
+     andBool (#rangeUInt(256, ABI_tab)
+     andBool (#rangeUInt(256, May)
+     andBool (#rangeUInt(256, Sin_era)
+     andBool (#rangeUInt(256, Sin)
+     andBool (#sizeByteArray(CD) <=Int 1250000000
+     andBool (VGas >=Int 3000000
+     andBool (#rangeUInt(256, Junk_0)
+     andBool (#rangeUInt(256, Junk_1)
+     andBool (#rangeUInt(256, Junk_2))))))))))
+
+     andBool #lookup(ACCT_ID_STORAGE, #Vow.wards[CALLER_ID]) ==Int May
+     andBool #lookup(ACCT_ID_STORAGE, #Vow.sin[TIME]) ==Int Sin_era
+     andBool #lookup(ACCT_ID_STORAGE, #Vow.Sin) ==Int Sin
+     andBool #lookup(ACCT_ID_ORIG_STORAGE, #Vow.wards[CALLER_ID]) ==Int Junk_0
+     andBool #lookup(ACCT_ID_ORIG_STORAGE, #Vow.sin[TIME]) ==Int Junk_1
+     andBool #lookup(ACCT_ID_ORIG_STORAGE, #Vow.Sin) ==Int Junk_2
+     andBool #Vow.wards[CALLER_ID] =/=Int #Vow.sin[TIME]
+     andBool #Vow.wards[CALLER_ID] =/=Int #Vow.Sin
+     andBool #Vow.sin[TIME] =/=Int #Vow.Sin
+     andBool notBool ( (((May:Int ==Int 1))
+               andBool (((VCallValue:Int ==Int 0))
+               andBool ((#rangeUInt(256, Sin_era:Int +Int ABI_tab:Int))
+               andBool ((#rangeUInt(256, Sin:Int     +Int ABI_tab:Int))))))
+                     )
+
+     ensures ?FAILURE =/=K EVMC_SUCCESS
+
+    // Vow_adduu
+    claim [Vow.adduu.pass]:
+      <k> #execute ~> CONTINUATION => #execute ~> CONTINUATION </k>
+      <exit-code> 1 </exit-code>
+      <mode> NORMAL </mode>
+      <schedule> ISTANBUL </schedule>
+      <ethereum>
+        <evm>
+          <output> VOutput => VOutput </output>
+          <statusCode> _ => ?_ </statusCode>
+          <endPC> _ => ?_ </endPC>
+          <callStack> _VCallStack </callStack>
+          <interimStates> _ </interimStates>
+          <touchedAccounts> _ => ?_ </touchedAccounts>
+          <callState>
+            <program> Vow_bin_runtime </program>
+            <jumpDests> #computeValidJumpDests(Vow_bin_runtime) </jumpDests>
+            <id> ACCT_ID </id>
+            <caller> CALLER_ID </caller>
+            <callData> _ => ?_ </callData>
+            <callValue> VCallValue </callValue>
+            <wordStack> ABI_y : ABI_x : JMPTO : WS  =>  JMPTO : ABI_x +Int ABI_y : WS </wordStack>
+            <localMem> _ </localMem>
+            <pc> 9777 => 9802 </pc>
+            <gas> VGas => ( VGas +Int -54 ) </gas>
+            <memoryUsed> VMemoryUsed </memoryUsed>
+            <callGas> _ => ?_ </callGas>
+            <static> _ </static>
+            <callDepth> VCallDepth </callDepth>
+          </callState>
+          <substate>
+            <selfDestruct> _VSelfDestruct </selfDestruct>
+            <log> _ => ?_ </log>
+            <refund> _Vrefund => ?_ </refund>
+          </substate>
+          <gasPrice> _ </gasPrice>
+          <origin> ORIGIN_ID </origin>
+          <blockhashes> _ </blockhashes>
+          <block>
+            <previousHash> _ </previousHash>
+            <ommersHash> _ </ommersHash>
+            <coinbase> _ </coinbase>
+            <stateRoot> _ </stateRoot>
+            <transactionsRoot> _ </transactionsRoot>
+            <receiptsRoot> _ </receiptsRoot>
+            <logsBloom> _ </logsBloom>
+            <difficulty> _ </difficulty>
+            <number> _BLOCK_NUMBER </number>
+            <gasLimit> _ </gasLimit>
+            <gasUsed> _ </gasUsed>
+            <timestamp> TIME </timestamp>
+            <extraData> _ </extraData>
+            <mixHash> _ </mixHash>
+            <blockNonce> _ </blockNonce>
+            <ommerBlockHeaders> _ </ommerBlockHeaders>
+          </block>
+        </evm>
+        <network>
+          <chainID> VChainId </chainID>
+          <activeAccounts> SetItem(ACCT_ID)
+          SetItem(1)
+          SetItem(2)
+          SetItem(3)
+          SetItem(4)
+          SetItem(5)
+          SetItem(6)
+          SetItem(7)
+          SetItem(8)
+          SetItem(9) _ </activeAccounts>
+          <accounts>
+            <account>
+              <acctID> ACCT_ID </acctID>
+              <balance> ACCT_ID_balance </balance>
+              <code> Vow_bin_runtime </code>
+              <storage> ACCT_ID_STORAGE => ACCT_ID_STORAGE  </storage>
+              <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
+              <nonce> _Nonce_Vow => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> 1 </acctID>
+              <balance> ECREC_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 2 </acctID>
+              <balance> SHA256_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 3 </acctID>
+              <balance> RIP160_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 4 </acctID>
+              <balance> ID_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 5 </acctID>
+              <balance> MODEXP_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 6 </acctID>
+              <balance> ECADD_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 7 </acctID>
+              <balance> ECMUL_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 8 </acctID>
+              <balance> ECPAIRING_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 9 </acctID>
+              <balance> BLAKE2_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+           ...
+          </accounts>
+          <txOrder> _ </txOrder>
+          <txPending> _ </txPending>
+          <messages> _ </messages>
+        </network>
+      </ethereum>
+    requires #rangeAddress(ACCT_ID)
+     andBool ACCT_ID =/=Int 0
+     andBool #notPrecompileAddress(ACCT_ID)
+     andBool #rangeAddress(CALLER_ID)
+     andBool #rangeAddress(ORIGIN_ID)
+     andBool #rangeUInt(256, TIME)
+     andBool #rangeUInt(256, ACCT_ID_balance)
+     andBool #rangeUInt(256, ECREC_BAL)
+     andBool #rangeUInt(256, SHA256_BAL)
+     andBool #rangeUInt(256, RIP160_BAL)
+     andBool #rangeUInt(256, ID_BAL)
+     andBool #rangeUInt(256, MODEXP_BAL)
+     andBool #rangeUInt(256, ECADD_BAL)
+     andBool #rangeUInt(256, ECMUL_BAL)
+     andBool #rangeUInt(256, ECPAIRING_BAL)
+     andBool #rangeUInt(256, BLAKE2_BAL)
+     andBool VCallDepth <=Int 1024
+     andBool #rangeUInt(256, VCallValue)
+     andBool #rangeUInt(256, VChainId)
+
+     andBool (#rangeUInt(256, ABI_x)
+     andBool (#rangeUInt(256, ABI_y)
+     andBool ((#sizeWordStack(WS) <=Int 100)
+     andBool (#rangeUInt(256, VMemoryUsed)
+     andBool (2300 <Int ( VGas +Int -54 )
+     andBool ((#rangeUInt(256, ABI_x +Int ABI_y))))))))
+    [trusted]
+
+
+endmodule

--- a/tests/specs/mcd/word-pack.k
+++ b/tests/specs/mcd/word-pack.k
@@ -65,6 +65,7 @@ module WORD-PACK
     rule maskWordPackAddrUInt48UInt48_3 => 411376139330301510538742295639337626245683966408394965837152255                [macro]
 
     rule (ADDR |Int (maskWordPackAddrUInt48UInt48_1 &Int ADDR_UINT48_UINT48)) /Int pow160 => ADDR_UINT48_UINT48 /Int pow160 requires #rangeUInt(256, ADDR_UINT48_UINT48) andBool #rangeAddress(ADDR) [simplification]
+    rule (ADDR |Int (maskWordPackAddrUInt48UInt48_1 &Int ADDR_UINT48_UINT48)) /Int pow208 => ADDR_UINT48_UINT48 /Int pow208 requires #rangeUInt(256, ADDR_UINT48_UINT48) andBool #rangeAddress(ADDR) [simplification]
 
     rule (UINT48_2 *Int pow208) |Int (maskWordPackAddrUInt48UInt48_3 &Int ADDR_UINT48_UINT48) => #WordPackAddrUInt48UInt48(maxUInt160 &Int ADDR_UINT48_UINT48, maxUInt48 &Int (ADDR_UINT48_UINT48 /Int pow160), UINT48_2) requires #rangeUInt(256, ADDR_UINT48_UINT48) andBool #rangeUInt(48, UINT48_2) [simplification]
     rule (UINT48_1 *Int pow160) |Int (maskWordPackAddrUInt48UInt48_2 &Int ADDR_UINT48_UINT48) => #WordPackAddrUInt48UInt48(maxUInt160 &Int ADDR_UINT48_UINT48, UINT48_1, maxUInt48 &Int (ADDR_UINT48_UINT48 /Int pow208)) requires #rangeUInt(256, ADDR_UINT48_UINT48) andBool #rangeUInt(48, UINT48_1) [simplification]


### PR DESCRIPTION
This adds several MKR regression proofs to the test-suite, and the lemmas needed to make them pass.

-   Proofs added are: end-cash-pass-rough, flopper-dent-guy-diff-tic-not-0-pass-rough, vat-flux-diff-pass-rough, vat-frob-diff-zero-dart-pass-rough, vow-cage-surplus-pass-rough, and vow-fess-fail-rough
-   Adds another work-pack simplification lemma.
-   Sends both bounds (upper and lower) for `#lookup(...)` to smt.
-   Adds the `#rmul` abstraction which is used in several MKR proofs.
-   Lemmas for simplifying account-map lookups by providing instructions on how to compare `<acctID> ACCTID </acctID> ==K <acctID> ACCTID' </acctID>`
-   Lemmas to simplify multiple writes to the same storage location.
-   Lemmas for simplifying ranged writes to locations in localMemory.
-   Simple lemma about `chop(X)` when `X` is an `SInt(256)`.