### PR TITLE
More MKR regression proofs with simplification lemmas

### DIFF
--- a/evm-types.md
+++ b/evm-types.md
@@ -224,8 +224,7 @@ Warning: operands are assumed to be within the range of a 256 bit EVM word. Unbo
                  | Int "%Word" Int [function, functional]
  // -----------------------------------------------------
     rule W0 +Word W1 => chop( W0 +Int W1 )
-    rule W0 -Word W1 => W0 -Int W1 requires W0 >=Int W1
-    rule W0 -Word W1 => chop( (W0 +Int pow256) -Int W1 ) requires W0 <Int W1
+    rule W0 -Word W1 => chop( W0 -Int W1 )
     rule W0 *Word W1 => chop( W0 *Int W1 )
     rule  _ /Word W1 => 0            requires W1  ==Int 0
     rule W0 /Word W1 => W0 /Int W1   requires W1 =/=Int 0
@@ -253,14 +252,10 @@ The helper `powmod` is a totalization of the operator `_^%Int__` (which comes wi
     syntax Int ::= Int "/sWord" Int [function]
                  | Int "%sWord" Int [function]
  // ------------------------------------------
-    rule [divSWord]: W0 /sWord W1 => #sgnInterp(sgn(W0) *Int sgn(W1) , abs(W0) /Word abs(W1))
-    rule [modSWord]: W0 %sWord W1 => #sgnInterp(sgn(W0)              , abs(W0) %Word abs(W1))
-
-    syntax Int ::= #sgnInterp ( Int , Int ) [function, functional]
- // --------------------------------------------------------------
-    rule #sgnInterp( W0 ,  _ ) => 0          requires W0 ==Int 0
-    rule #sgnInterp( W0 , W1 ) => W1         requires W0 >Int 0
-    rule #sgnInterp( W0 , W1 ) => 0 -Word W1 requires W0 <Int 0
+    rule [divSWord.same]: W0 /sWord W1 =>          abs(W0) /Word abs(W1)  requires sgn(W0) *Int sgn(W1) ==Int  1
+    rule [divSWord.diff]: W0 /sWord W1 => 0 -Word (abs(W0) /Word abs(W1)) requires sgn(W0) *Int sgn(W1) ==Int -1
+    rule [modSWord.pos]:  W0 %sWord W1 =>          abs(W0) %Word abs(W1)  requires sgn(W0) ==Int  1
+    rule [modSWord.neg]:  W0 %sWord W1 => 0 -Word (abs(W0) %Word abs(W1)) requires sgn(W0) ==Int -1
 ```
 
 ### Word Comparison

--- a/tests/failing-symbolic.haskell
+++ b/tests/failing-symbolic.haskell
@@ -68,6 +68,7 @@ tests/specs/mcd/dsvalue-read-pass-spec.k
 tests/specs/mcd/end-cash-pass-rough-spec.k
 tests/specs/mcd/end-pack-pass-rough-spec.k
 tests/specs/mcd/end-subuu-pass-spec.k
+tests/specs/mcd/flapper-tend-guy-diff-pass-rough-spec.k
 tests/specs/mcd/flapper-yank-pass-rough-spec.k
 tests/specs/mcd/flipper-addu48u48-fail-rough-spec.k
 tests/specs/mcd/flipper-bids-pass-rough-spec.k

--- a/tests/failing-symbolic.haskell
+++ b/tests/failing-symbolic.haskell
@@ -86,6 +86,8 @@ tests/specs/mcd/pot-join-pass-rough-spec.k
 tests/specs/mcd/vat-addui-fail-rough-spec.k
 tests/specs/mcd/vat-deny-diff-fail-rough-spec.k
 tests/specs/mcd/vat-flux-diff-pass-rough-spec.k
+tests/specs/mcd/vat-fold-pass-rough-spec.k
+tests/specs/mcd/vat-fork-diff-pass-rough-spec.k
 tests/specs/mcd/vat-frob-diff-zero-dart-pass-rough-spec.k
 tests/specs/mcd/vat-move-diff-rough-spec.k
 tests/specs/mcd/vat-mului-pass-spec.k

--- a/tests/failing-symbolic.haskell
+++ b/tests/failing-symbolic.haskell
@@ -81,6 +81,7 @@ tests/specs/mcd/flopper-file-pass-rough-spec.k
 tests/specs/mcd/flopper-kick-pass-rough-spec.k
 tests/specs/mcd/flopper-tick-pass-rough-spec.k
 tests/specs/mcd/functional-spec.k
+tests/specs/mcd/gemjoin-exit-pass-rough-spec.k
 tests/specs/mcd/pot-join-pass-rough-spec.k
 tests/specs/mcd/vat-addui-fail-rough-spec.k
 tests/specs/mcd/vat-deny-diff-fail-rough-spec.k

--- a/tests/failing-symbolic.haskell
+++ b/tests/failing-symbolic.haskell
@@ -91,6 +91,7 @@ tests/specs/mcd/vat-slip-pass-rough-spec.k
 tests/specs/mcd/vat-subui-fail-rough-spec.k
 tests/specs/mcd/vat-subui-pass-rough-spec.k
 tests/specs/mcd/vat-subui-pass-spec.k
+tests/specs/mcd/vow-cage-deficit-pass-rough-spec.k
 tests/specs/mcd/vow-cage-surplus-pass-rough-spec.k
 tests/specs/mcd/vow-fess-fail-rough-spec.k
 tests/specs/mcd/vow-flog-fail-rough-spec.k

--- a/tests/specs/functional/infinite-gas-spec.k
+++ b/tests/specs/functional/infinite-gas-spec.k
@@ -31,6 +31,8 @@ module INFINITE-GAS-SPEC
 
     claim <k> runLemma(((VGas -Int (#allBut64th(VGas +Int -2655) +Int 700)) +Int #allBut64th(VGas +Int -2655)) +Int -7244) => doneLemma(VGas +Int -7944) ... </k>
 
+    claim <k> runLemma(X +Int (0 -Int ABI_wad)) => doneLemma(X -Int ABI_wad) ... </k>
+
  // Infinite Gas simplifications
  // ----------------------------
 

--- a/tests/specs/infinite-gas.k
+++ b/tests/specs/infinite-gas.k
@@ -33,6 +33,9 @@ module INFINITE-GAS-HASKELL [kore]
     rule S1 -Int (S2 +Int I3) => (S1 -Int S2) -Int I3 [symbolic(S1, S2), simplification]
     rule S1 -Int (S2 -Int I3) => (S1 -Int S2) +Int I3 [symbolic(S1, S2), simplification]
 
+    rule S1 +Int (C2 -Int S3) => (S1 -Int S3) +Int C2 [symbolic(S1, S3), concrete(C2), simplification]
+    rule S1 -Int (C2 -Int S3) => (S1 +Int S3) -Int C2 [symbolic(S1, S3), concrete(C2), simplification]
+
     rule (I1 +Int C2) +Int S3 => (I1 +Int S3) +Int C2 [concrete(C2), symbolic(S3), simplification]
     rule (I1 +Int C2) -Int S3 => (I1 -Int S3) +Int C2 [concrete(C2), symbolic(S3), simplification]
     rule (I1 -Int C2) +Int S3 => (I1 +Int S3) -Int C2 [concrete(C2), symbolic(S3), simplification]
@@ -63,6 +66,9 @@ module INFINITE-GAS-JAVA [kast]
     rule S1 +Int (S2 -Int I3) => (S1 +Int S2) -Int I3 requires (notBool #isConcrete(S1)) andBool (notBool #isConcrete(S2)) [simplification]
     rule S1 -Int (S2 +Int I3) => (S1 -Int S2) -Int I3 requires (notBool #isConcrete(S1)) andBool (notBool #isConcrete(S2)) [simplification]
     rule S1 -Int (S2 -Int I3) => (S1 -Int S2) +Int I3 requires (notBool #isConcrete(S1)) andBool (notBool #isConcrete(S2)) [simplification]
+
+    rule S1 +Int (C2 -Int S3) => (S1 -Int S3) +Int C2 requires #isConcrete(C2) andBool (notBool #isConcrete(S1)) andBool (notBool #isConcrete(S3)) [simplification]
+    rule S1 -Int (C2 -Int S3) => (S1 +Int S3) -Int C2 requires #isConcrete(C2) andBool (notBool #isConcrete(S1)) andBool (notBool #isConcrete(S3)) [simplification]
 
     rule (I1 +Int C2) +Int S3 => (I1 +Int S3) +Int C2 requires #isConcrete(C2) andBool notBool #isConcrete(S3) [simplification]
     rule (I1 +Int C2) -Int S3 => (I1 -Int S3) +Int C2 requires #isConcrete(C2) andBool notBool #isConcrete(S3) [simplification]

--- a/tests/specs/mcd/concrete-rules.txt
+++ b/tests/specs/mcd/concrete-rules.txt
@@ -15,7 +15,6 @@ EVM-TYPES.#asByteStack
 EVM-TYPES.#asByteStackAux.recursive
 EVM-TYPES.#asWord.recursive
 EVM-TYPES.ByteArray.range
-EVM-TYPES.divSWord
 EVM-TYPES.mapWriteBytes.recursive
 EVM-TYPES.#padToWidth
 EVM-TYPES.powmod.nonzero

--- a/tests/specs/mcd/flapper-tend-guy-diff-pass-rough-spec.k
+++ b/tests/specs/mcd/flapper-tend-guy-diff-pass-rough-spec.k
@@ -1,0 +1,903 @@
+requires "verification.k"
+
+module FLAPPER-TEND-GUY-DIFF-PASS-ROUGH-SPEC
+    imports VERIFICATION
+
+    // Flapper_tend-guy-diff
+    claim [Flapper.tend-guy-diff.pass.rough]:
+      <k> #execute ~> CONTINUATION => #halt ~> CONTINUATION </k>
+      <exit-code> 1 </exit-code>
+      <mode> NORMAL </mode>
+      <schedule> ISTANBUL </schedule>
+      <ethereum>
+        <evm>
+          <output> .ByteArray </output>
+          <statusCode> _ => EVMC_SUCCESS </statusCode>
+          <endPC> _ => ?_ </endPC>
+          <callStack> _VCallStack </callStack>
+          <interimStates> _ </interimStates>
+          <touchedAccounts> _ => ?_ </touchedAccounts>
+          <callState>
+            <program> Flapper_bin_runtime </program>
+            <jumpDests> #computeValidJumpDests(Flapper_bin_runtime) </jumpDests>
+            <id> ACCT_ID </id>
+            <caller> CALLER_ID </caller>
+            <callData> #abiCallData("tend", #uint256(ABI_id), #uint256(ABI_lot), #uint256(ABI_bid)) ++ CD => ?_ </callData>
+            <callValue> VCallValue </callValue>
+            <wordStack> .WordStack => ?_ </wordStack>
+            <localMem> .Memory => ?_ </localMem>
+            <pc> 0 => ?_ </pc>
+            <gas> #gas(VGas) => ?_ </gas>
+            <memoryUsed> 0 => ?_ </memoryUsed>
+            <callGas> _ => ?_ </callGas>
+            <static> false </static>
+            <callDepth> VCallDepth </callDepth>
+          </callState>
+          <substate>
+            <selfDestruct> _VSelfDestruct </selfDestruct>
+            <log> _ => ?_ </log>
+            <refund> _Vrefund => ?_ </refund>
+          </substate>
+          <gasPrice> _ </gasPrice>
+          <origin> ORIGIN_ID </origin>
+          <blockhashes> _ </blockhashes>
+          <block>
+            <previousHash> _ </previousHash>
+            <ommersHash> _ </ommersHash>
+            <coinbase> _ </coinbase>
+            <stateRoot> _ </stateRoot>
+            <transactionsRoot> _ </transactionsRoot>
+            <receiptsRoot> _ </receiptsRoot>
+            <logsBloom> _ </logsBloom>
+            <difficulty> _ </difficulty>
+            <number> _BLOCK_NUMBER </number>
+            <gasLimit> _ </gasLimit>
+            <gasUsed> _ </gasUsed>
+            <timestamp> TIME </timestamp>
+            <extraData> _ </extraData>
+            <mixHash> _ </mixHash>
+            <blockNonce> _ </blockNonce>
+            <ommerBlockHeaders> _ </ommerBlockHeaders>
+          </block>
+        </evm>
+        <network>
+          <chainID> VChainId </chainID>
+          <activeAccounts> SetItem(ACCT_ID)
+          SetItem(DSToken)
+          SetItem(1)
+          SetItem(2)
+          SetItem(3)
+          SetItem(4)
+          SetItem(5)
+          SetItem(6)
+          SetItem(7)
+          SetItem(8)
+          SetItem(9) _ </activeAccounts>
+          <accounts>
+            <account>
+              <acctID> ACCT_ID </acctID>
+              <balance> ACCT_ID_balance </balance>
+              <code> Flapper_bin_runtime </code>
+              <storage> ACCT_ID_STORAGE => ACCT_ID_STORAGE [ #Flapper.bids[ABI_id].bid <- ABI_bid ]  [ #Flapper.bids[ABI_id].guy_tic_end <- #WordPackAddrUInt48UInt48(CALLER_ID, TIME +Int Ttl, End) ] </storage>
+              <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
+              <nonce> _Nonce_Flapper => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> DSToken </acctID>
+              <balance> DSToken_balance </balance>
+              <code> DSToken_bin_runtime </code>
+              <storage> DSToken_STORAGE => DSToken_STORAGE [ #DSToken.allowance[CALLER_ID][ACCT_ID] <- #if (Allowed ==Int maxUInt256) #then Allowed #else Allowed -Int ABI_bid #fi ] [ #DSToken.balances[CALLER_ID] <- Gem_u -Int ABI_bid ] [ #DSToken.balances[Guy] <- Gem_g +Int Bid ] [ #DSToken.balances[ACCT_ID] <- Gem_a +Int (ABI_bid -Int Bid) ] </storage>
+              <origStorage> DSToken_ORIG_STORAGE </origStorage>
+              <nonce> _Nonce_DSToken => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> 1 </acctID>
+              <balance> ECREC_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 2 </acctID>
+              <balance> SHA256_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 3 </acctID>
+              <balance> RIP160_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 4 </acctID>
+              <balance> ID_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 5 </acctID>
+              <balance> MODEXP_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 6 </acctID>
+              <balance> ECADD_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 7 </acctID>
+              <balance> ECMUL_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 8 </acctID>
+              <balance> ECPAIRING_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 9 </acctID>
+              <balance> BLAKE2_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+           ...
+          </accounts>
+          <txOrder> _ </txOrder>
+          <txPending> _ </txPending>
+          <messages> _ </messages>
+        </network>
+      </ethereum>
+      requires #rangeAddress(ACCT_ID)
+       andBool ACCT_ID =/=Int 0
+       andBool #notPrecompileAddress(ACCT_ID)
+       andBool #rangeAddress(CALLER_ID)
+       andBool #rangeAddress(ORIGIN_ID)
+       andBool #rangeUInt(256, TIME)
+       andBool #rangeUInt(256, ACCT_ID_balance)
+       andBool #rangeUInt(256, ECREC_BAL)
+       andBool #rangeUInt(256, SHA256_BAL)
+       andBool #rangeUInt(256, RIP160_BAL)
+       andBool #rangeUInt(256, ID_BAL)
+       andBool #rangeUInt(256, MODEXP_BAL)
+       andBool #rangeUInt(256, ECADD_BAL)
+       andBool #rangeUInt(256, ECMUL_BAL)
+       andBool #rangeUInt(256, ECPAIRING_BAL)
+       andBool #rangeUInt(256, BLAKE2_BAL)
+       andBool VCallDepth <=Int 1024
+       andBool #rangeUInt(256, VCallValue)
+       andBool #rangeUInt(256, VChainId)
+
+       andBool (#rangeUInt(256, ABI_id)
+       andBool (#rangeUInt(256, ABI_lot)
+       andBool (#rangeUInt(256, ABI_bid)
+       andBool (#rangeAddress(DSToken)
+       andBool (#rangeUInt(256, Live)
+       andBool (#rangeUInt(48, Ttl)
+       andBool (#rangeUInt(48, Tau)
+       andBool (#rangeUInt(256, Beg)
+       andBool (#rangeUInt(256, Bid)
+       andBool (#rangeUInt(256, Lot)
+       andBool (#rangeAddress(Guy)
+       andBool (#rangeUInt(48, Tic)
+       andBool (#rangeUInt(48, End)
+       andBool (#rangeUInt(256, Allowed)
+       andBool (#rangeUInt(256, Gem_g)
+       andBool (#rangeUInt(256, Gem_a)
+       andBool (#rangeUInt(256, Gem_u)
+       andBool (#rangeAddress(Owner)
+       andBool (#rangeBool(Stopped)
+       andBool (#rangeUInt(256, DSToken_balance)
+       andBool ((#sizeByteArray(CD) <=Int 1250000000)
+       andBool ((#notPrecompileAddress(DSToken))
+       andBool ((#notPrecompileAddress(Guy))
+       andBool ((#notPrecompileAddress(Owner))
+       andBool ((ACCT_ID =/=Int DSToken)
+       andBool ((#rangeUInt(48, TIME))
+       andBool ((CALLER_ID =/=Int ACCT_ID)
+       andBool ((CALLER_ID =/=Int Guy)
+       andBool ((ACCT_ID   =/=Int Guy)
+       andBool ((DSToken =/=Int 0)
+       andBool (#rangeUInt(256, Junk_0)
+       andBool (#rangeUInt(256, Junk_1)
+       andBool (#rangeUInt(256, Junk_2)
+       andBool (#rangeUInt(256, Junk_3)
+       andBool (#rangeUInt(256, Junk_4)
+       andBool (#rangeUInt(256, Junk_5)
+       andBool (#rangeUInt(256, Junk_6)
+       andBool (#rangeUInt(256, Junk_7)
+       andBool (#rangeUInt(256, Junk_8)
+       andBool (#rangeUInt(256, Junk_9)
+       andBool (#rangeUInt(256, Junk_10)
+       andBool (#rangeUInt(256, Junk_11)
+       andBool (((VCallValue ==Int 0))
+       andBool (((VCallDepth <Int 1024))
+       andBool (((Guy =/=Int 0))
+       andBool (((Stopped ==Int 0))
+       andBool ((((Allowed ==Int maxUInt256) orBool (ABI_bid <=Int Allowed)))
+       andBool (((Live ==Int 1))
+       andBool (((Tic >Int TIME orBool Tic ==Int 0))
+       andBool (((End >Int TIME))
+       andBool (((TIME +Int Ttl <=Int maxUInt48))
+       andBool (((ABI_lot ==Int Lot))
+       andBool (((ABI_bid >Int Bid))
+       andBool (((ABI_bid *Int #Wad <=Int maxUInt256))
+       andBool (((ABI_bid *Int #Wad >=Int Beg *Int Bid))
+       andBool ((#rangeUInt(256, Gem_u -Int ABI_bid))
+       andBool ((#rangeUInt(256, Gem_g +Int Bid))
+       andBool ((#rangeUInt(256, Gem_a +Int (ABI_bid -Int Bid)))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))
+
+       andBool #lookup(ACCT_ID_STORAGE, #Flapper.gem) ==Int DSToken
+       andBool #lookup(ACCT_ID_STORAGE, #Flapper.live) ==Int Live
+       andBool #lookup(ACCT_ID_STORAGE, #Flapper.ttl_tau) ==Int #WordPackUInt48UInt48(Ttl, Tau)
+       andBool #lookup(ACCT_ID_STORAGE, #Flapper.beg) ==Int Beg
+       andBool #lookup(ACCT_ID_STORAGE, #Flapper.bids[ABI_id].bid) ==Int Bid
+       andBool #lookup(ACCT_ID_STORAGE, #Flapper.bids[ABI_id].lot) ==Int Lot
+       andBool #lookup(ACCT_ID_STORAGE, #Flapper.bids[ABI_id].guy_tic_end) ==Int #WordPackAddrUInt48UInt48(Guy, Tic, End)
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Flapper.gem) ==Int Junk_0
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Flapper.live) ==Int Junk_1
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Flapper.ttl_tau) ==Int Junk_2
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Flapper.beg) ==Int Junk_3
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Flapper.bids[ABI_id].bid) ==Int Junk_4
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Flapper.bids[ABI_id].lot) ==Int Junk_5
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Flapper.bids[ABI_id].guy_tic_end) ==Int Junk_6
+       andBool #Flapper.gem =/=Int #Flapper.live
+       andBool #Flapper.gem =/=Int #Flapper.ttl_tau
+       andBool #Flapper.gem =/=Int #Flapper.beg
+       andBool #Flapper.gem =/=Int #Flapper.bids[ABI_id].bid
+       andBool #Flapper.gem =/=Int #Flapper.bids[ABI_id].lot
+       andBool #Flapper.gem =/=Int #Flapper.bids[ABI_id].guy_tic_end
+       andBool #Flapper.live =/=Int #Flapper.ttl_tau
+       andBool #Flapper.live =/=Int #Flapper.beg
+       andBool #Flapper.live =/=Int #Flapper.bids[ABI_id].bid
+       andBool #Flapper.live =/=Int #Flapper.bids[ABI_id].lot
+       andBool #Flapper.live =/=Int #Flapper.bids[ABI_id].guy_tic_end
+       andBool #Flapper.ttl_tau =/=Int #Flapper.beg
+       andBool #Flapper.ttl_tau =/=Int #Flapper.bids[ABI_id].bid
+       andBool #Flapper.ttl_tau =/=Int #Flapper.bids[ABI_id].lot
+       andBool #Flapper.ttl_tau =/=Int #Flapper.bids[ABI_id].guy_tic_end
+       andBool #Flapper.beg =/=Int #Flapper.bids[ABI_id].bid
+       andBool #Flapper.beg =/=Int #Flapper.bids[ABI_id].lot
+       andBool #Flapper.beg =/=Int #Flapper.bids[ABI_id].guy_tic_end
+       andBool #Flapper.bids[ABI_id].bid =/=Int #Flapper.bids[ABI_id].lot
+       andBool #Flapper.bids[ABI_id].bid =/=Int #Flapper.bids[ABI_id].guy_tic_end
+       andBool #Flapper.bids[ABI_id].lot =/=Int #Flapper.bids[ABI_id].guy_tic_end
+       andBool #lookup(DSToken_STORAGE, #DSToken.allowance[CALLER_ID][ACCT_ID]) ==Int Allowed
+       andBool #lookup(DSToken_STORAGE, #DSToken.balances[CALLER_ID]) ==Int Gem_u
+       andBool #lookup(DSToken_STORAGE, #DSToken.balances[Guy]) ==Int Gem_g
+       andBool #lookup(DSToken_STORAGE, #DSToken.balances[ACCT_ID]) ==Int Gem_a
+       andBool #lookup(DSToken_STORAGE, #DSToken.owner_stopped) ==Int #WordPackAddrUInt8(Owner, Stopped)
+       andBool #lookup(DSToken_ORIG_STORAGE, #DSToken.allowance[CALLER_ID][ACCT_ID]) ==Int Junk_7
+       andBool #lookup(DSToken_ORIG_STORAGE, #DSToken.balances[CALLER_ID]) ==Int Junk_8
+       andBool #lookup(DSToken_ORIG_STORAGE, #DSToken.balances[Guy]) ==Int Junk_9
+       andBool #lookup(DSToken_ORIG_STORAGE, #DSToken.balances[ACCT_ID]) ==Int Junk_10
+       andBool #lookup(DSToken_ORIG_STORAGE, #DSToken.owner_stopped) ==Int Junk_11
+       andBool #DSToken.allowance[CALLER_ID][ACCT_ID] =/=Int #DSToken.balances[CALLER_ID]
+       andBool #DSToken.allowance[CALLER_ID][ACCT_ID] =/=Int #DSToken.balances[Guy]
+       andBool #DSToken.allowance[CALLER_ID][ACCT_ID] =/=Int #DSToken.balances[ACCT_ID]
+       andBool #DSToken.allowance[CALLER_ID][ACCT_ID] =/=Int #DSToken.owner_stopped
+       andBool #DSToken.balances[CALLER_ID] =/=Int #DSToken.balances[Guy]
+       andBool #DSToken.balances[CALLER_ID] =/=Int #DSToken.balances[ACCT_ID]
+       andBool #DSToken.balances[CALLER_ID] =/=Int #DSToken.owner_stopped
+       andBool #DSToken.balances[Guy] =/=Int #DSToken.balances[ACCT_ID]
+       andBool #DSToken.balances[Guy] =/=Int #DSToken.owner_stopped
+       andBool #DSToken.balances[ACCT_ID] =/=Int #DSToken.owner_stopped
+
+    // Flapper_addu48u48
+    claim [Flapper.addu48u48.pass]:
+      <k> #execute ~> CONTINUATION => #execute ~> CONTINUATION </k>
+      <exit-code> 1 </exit-code>
+      <mode> NORMAL </mode>
+      <schedule> ISTANBUL </schedule>
+      <ethereum>
+        <evm>
+          <output> VOutput => VOutput </output>
+          <statusCode> _ => ?_ </statusCode>
+          <endPC> _ => ?_ </endPC>
+          <callStack> _VCallStack </callStack>
+          <interimStates> _ </interimStates>
+          <touchedAccounts> _ => ?_ </touchedAccounts>
+          <callState>
+            <program> Flapper_bin_runtime </program>
+            <jumpDests> #computeValidJumpDests(Flapper_bin_runtime) </jumpDests>
+            <id> ACCT_ID </id>
+            <caller> CALLER_ID </caller>
+            <callData> _ => ?_ </callData>
+            <callValue> VCallValue </callValue>
+            <wordStack> ABI_y : ABI_x : JMPTO : WS  =>  JMPTO : ABI_x +Int ABI_y : WS </wordStack>
+            <localMem> _ </localMem>
+            <pc> 8945 => 8986 </pc>
+            <gas> #gas(VGas) => #gas ( ( VGas +Int -66 ) ) </gas>
+            <memoryUsed> VMemoryUsed </memoryUsed>
+            <callGas> _ => ?_ </callGas>
+            <static> _ </static>
+            <callDepth> VCallDepth </callDepth>
+          </callState>
+          <substate>
+            <selfDestruct> _VSelfDestruct </selfDestruct>
+            <log> _ => ?_ </log>
+            <refund> _Vrefund => ?_ </refund>
+          </substate>
+          <gasPrice> _ </gasPrice>
+          <origin> ORIGIN_ID </origin>
+          <blockhashes> _ </blockhashes>
+          <block>
+            <previousHash> _ </previousHash>
+            <ommersHash> _ </ommersHash>
+            <coinbase> _ </coinbase>
+            <stateRoot> _ </stateRoot>
+            <transactionsRoot> _ </transactionsRoot>
+            <receiptsRoot> _ </receiptsRoot>
+            <logsBloom> _ </logsBloom>
+            <difficulty> _ </difficulty>
+            <number> _BLOCK_NUMBER </number>
+            <gasLimit> _ </gasLimit>
+            <gasUsed> _ </gasUsed>
+            <timestamp> TIME </timestamp>
+            <extraData> _ </extraData>
+            <mixHash> _ </mixHash>
+            <blockNonce> _ </blockNonce>
+            <ommerBlockHeaders> _ </ommerBlockHeaders>
+          </block>
+        </evm>
+        <network>
+          <chainID> VChainId </chainID>
+          <activeAccounts> SetItem(ACCT_ID)
+          SetItem(1)
+          SetItem(2)
+          SetItem(3)
+          SetItem(4)
+          SetItem(5)
+          SetItem(6)
+          SetItem(7)
+          SetItem(8)
+          SetItem(9) _ </activeAccounts>
+          <accounts>
+            <account>
+              <acctID> ACCT_ID </acctID>
+              <balance> ACCT_ID_balance </balance>
+              <code> Flapper_bin_runtime </code>
+              <storage> ACCT_ID_STORAGE => ACCT_ID_STORAGE  </storage>
+              <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
+              <nonce> _Nonce_Flapper => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> 1 </acctID>
+              <balance> ECREC_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 2 </acctID>
+              <balance> SHA256_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 3 </acctID>
+              <balance> RIP160_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 4 </acctID>
+              <balance> ID_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 5 </acctID>
+              <balance> MODEXP_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 6 </acctID>
+              <balance> ECADD_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 7 </acctID>
+              <balance> ECMUL_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 8 </acctID>
+              <balance> ECPAIRING_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 9 </acctID>
+              <balance> BLAKE2_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+           ...
+          </accounts>
+          <txOrder> _ </txOrder>
+          <txPending> _ </txPending>
+          <messages> _ </messages>
+        </network>
+      </ethereum>
+      requires #rangeAddress(ACCT_ID)
+       andBool ACCT_ID =/=Int 0
+       andBool #notPrecompileAddress(ACCT_ID)
+       andBool #rangeAddress(CALLER_ID)
+       andBool #rangeAddress(ORIGIN_ID)
+       andBool #rangeUInt(256, TIME)
+       andBool #rangeUInt(256, ACCT_ID_balance)
+       andBool #rangeUInt(256, ECREC_BAL)
+       andBool #rangeUInt(256, SHA256_BAL)
+       andBool #rangeUInt(256, RIP160_BAL)
+       andBool #rangeUInt(256, ID_BAL)
+       andBool #rangeUInt(256, MODEXP_BAL)
+       andBool #rangeUInt(256, ECADD_BAL)
+       andBool #rangeUInt(256, ECMUL_BAL)
+       andBool #rangeUInt(256, ECPAIRING_BAL)
+       andBool #rangeUInt(256, BLAKE2_BAL)
+       andBool VCallDepth <=Int 1024
+       andBool #rangeUInt(256, VCallValue)
+       andBool #rangeUInt(256, VChainId)
+
+       andBool (#rangeUInt(48, ABI_x)
+       andBool (#rangeUInt(48, ABI_y)
+       andBool ((#sizeWordStack(WS) <=Int 100)
+       andBool (#rangeUInt(256, VMemoryUsed)
+       andBool ((#rangeUInt(48, ABI_x +Int ABI_y)))))))
+
+
+    [trusted, matching(infGas)]
+
+
+    // Flapper_muluu
+    claim [Flapper.muluu.pass]:
+      <k> #execute ~> CONTINUATION => #execute ~> CONTINUATION </k>
+      <exit-code> 1 </exit-code>
+      <mode> NORMAL </mode>
+      <schedule> ISTANBUL </schedule>
+      <ethereum>
+        <evm>
+          <output> VOutput => VOutput </output>
+          <statusCode> _ => ?_ </statusCode>
+          <endPC> _ => ?_ </endPC>
+          <callStack> _VCallStack </callStack>
+          <interimStates> _ </interimStates>
+          <touchedAccounts> _ => ?_ </touchedAccounts>
+          <callState>
+            <program> Flapper_bin_runtime </program>
+            <jumpDests> #computeValidJumpDests(Flapper_bin_runtime) </jumpDests>
+            <id> ACCT_ID </id>
+            <caller> CALLER_ID </caller>
+            <callData> _ => ?_ </callData>
+            <callValue> VCallValue </callValue>
+            <wordStack> ABI_y : ABI_x : JMPTO : WS  =>  JMPTO : ABI_x *Int ABI_y : WS </wordStack>
+            <localMem> _ </localMem>
+            <pc> 8901 => 8944 </pc>
+            <gas> #gas(VGas) => #if ABI_y ==Int 0
+              #then   #gas ( ( VGas +Int -54 ) )
+              #else   #gas ( ( VGas +Int -106 ) )
+            #fi </gas>
+            <memoryUsed> VMemoryUsed </memoryUsed>
+            <callGas> _ => ?_ </callGas>
+            <static> _ </static>
+            <callDepth> VCallDepth </callDepth>
+          </callState>
+          <substate>
+            <selfDestruct> _VSelfDestruct </selfDestruct>
+            <log> _ => ?_ </log>
+            <refund> _Vrefund => ?_ </refund>
+          </substate>
+          <gasPrice> _ </gasPrice>
+          <origin> ORIGIN_ID </origin>
+          <blockhashes> _ </blockhashes>
+          <block>
+            <previousHash> _ </previousHash>
+            <ommersHash> _ </ommersHash>
+            <coinbase> _ </coinbase>
+            <stateRoot> _ </stateRoot>
+            <transactionsRoot> _ </transactionsRoot>
+            <receiptsRoot> _ </receiptsRoot>
+            <logsBloom> _ </logsBloom>
+            <difficulty> _ </difficulty>
+            <number> _BLOCK_NUMBER </number>
+            <gasLimit> _ </gasLimit>
+            <gasUsed> _ </gasUsed>
+            <timestamp> TIME </timestamp>
+            <extraData> _ </extraData>
+            <mixHash> _ </mixHash>
+            <blockNonce> _ </blockNonce>
+            <ommerBlockHeaders> _ </ommerBlockHeaders>
+          </block>
+        </evm>
+        <network>
+          <chainID> VChainId </chainID>
+          <activeAccounts> SetItem(ACCT_ID)
+          SetItem(1)
+          SetItem(2)
+          SetItem(3)
+          SetItem(4)
+          SetItem(5)
+          SetItem(6)
+          SetItem(7)
+          SetItem(8)
+          SetItem(9) _ </activeAccounts>
+          <accounts>
+            <account>
+              <acctID> ACCT_ID </acctID>
+              <balance> ACCT_ID_balance </balance>
+              <code> Flapper_bin_runtime </code>
+              <storage> ACCT_ID_STORAGE => ACCT_ID_STORAGE  </storage>
+              <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
+              <nonce> _Nonce_Flapper => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> 1 </acctID>
+              <balance> ECREC_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 2 </acctID>
+              <balance> SHA256_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 3 </acctID>
+              <balance> RIP160_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 4 </acctID>
+              <balance> ID_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 5 </acctID>
+              <balance> MODEXP_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 6 </acctID>
+              <balance> ECADD_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 7 </acctID>
+              <balance> ECMUL_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 8 </acctID>
+              <balance> ECPAIRING_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 9 </acctID>
+              <balance> BLAKE2_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+           ...
+          </accounts>
+          <txOrder> _ </txOrder>
+          <txPending> _ </txPending>
+          <messages> _ </messages>
+        </network>
+      </ethereum>
+      requires #rangeAddress(ACCT_ID)
+       andBool ACCT_ID =/=Int 0
+       andBool #notPrecompileAddress(ACCT_ID)
+       andBool #rangeAddress(CALLER_ID)
+       andBool #rangeAddress(ORIGIN_ID)
+       andBool #rangeUInt(256, TIME)
+       andBool #rangeUInt(256, ACCT_ID_balance)
+       andBool #rangeUInt(256, ECREC_BAL)
+       andBool #rangeUInt(256, SHA256_BAL)
+       andBool #rangeUInt(256, RIP160_BAL)
+       andBool #rangeUInt(256, ID_BAL)
+       andBool #rangeUInt(256, MODEXP_BAL)
+       andBool #rangeUInt(256, ECADD_BAL)
+       andBool #rangeUInt(256, ECMUL_BAL)
+       andBool #rangeUInt(256, ECPAIRING_BAL)
+       andBool #rangeUInt(256, BLAKE2_BAL)
+       andBool VCallDepth <=Int 1024
+       andBool #rangeUInt(256, VCallValue)
+       andBool #rangeUInt(256, VChainId)
+
+       andBool (#rangeUInt(256, ABI_x)
+       andBool (#rangeUInt(256, ABI_y)
+       andBool ((#sizeWordStack(WS) <=Int 1000)
+       andBool (#rangeUInt(256, VMemoryUsed)
+       andBool ((#rangeUInt(256, ABI_x *Int ABI_y)))))))
+
+
+    [trusted, matching(infGas)]
+
+
+    // DSToken_move
+    claim [DSToken.move.pass]:
+      <k> #execute ~> CONTINUATION => #halt ~> CONTINUATION </k>
+      <exit-code> 1 </exit-code>
+      <mode> NORMAL </mode>
+      <schedule> ISTANBUL </schedule>
+      <ethereum>
+        <evm>
+          <output> .ByteArray </output>
+          <statusCode> _ => EVMC_SUCCESS </statusCode>
+          <endPC> _ => ?_ </endPC>
+          <callStack> _VCallStack </callStack>
+          <interimStates> _ </interimStates>
+          <touchedAccounts> _ => ?_ </touchedAccounts>
+          <callState>
+            <program> DSToken_bin_runtime </program>
+            <jumpDests> #computeValidJumpDests(DSToken_bin_runtime) </jumpDests>
+            <id> ACCT_ID </id>
+            <caller> CALLER_ID </caller>
+            <callData> #abiCallData("move", #address(ABI_src), #address(ABI_dst), #uint256(ABI_wad)) ++ CD => ?_ </callData>
+            <callValue> VCallValue </callValue>
+            <wordStack> .WordStack => ?_ </wordStack>
+            <localMem> .Memory => ?_ </localMem>
+            <pc> 0 => ?_ </pc>
+            <gas> #gas(VGas) => #if ( #lookup( ACCT_ID_STORAGE , hash2 ( CALLER_ID , hash2 ( ABI_src , 2 ) ) ) ==Int maxUInt256 andBool ( Allowance ==Int maxUInt256 andBool ( maxUInt256 ==Int maxUInt256 orBool ABI_wad <=Int maxUInt256 ) ) )
+              #then   #gas ( ( ( ( VGas -Int Csstore( ISTANBUL , ( Gem_s -Int ABI_wad ) , Gem_s , Junk_1 ) ) -Int Csstore( ISTANBUL , ( Gem_d +Int ABI_wad ) , Gem_d , Junk_2 ) ) +Int -7281 ) )
+              #else   #gas ( ( ( ( ( VGas -Int Csstore( ISTANBUL , ( Allowance -Int ABI_wad ) , Allowance , Junk_0 ) ) -Int Csstore( ISTANBUL , ( Gem_s -Int ABI_wad ) , Gem_s , Junk_1 ) ) -Int Csstore( ISTANBUL , ( Gem_d +Int ABI_wad ) , Gem_d , Junk_2 ) ) +Int -9538 ) )
+            #fi </gas>
+            <memoryUsed> 0 => ?_ </memoryUsed>
+            <callGas> _ => ?_ </callGas>
+            <static> false </static>
+            <callDepth> VCallDepth </callDepth>
+          </callState>
+          <substate>
+            <selfDestruct> _VSelfDestruct </selfDestruct>
+            <log> _ => ?_ </log>
+            <refund> _Vrefund => ?_ </refund>
+          </substate>
+          <gasPrice> _ </gasPrice>
+          <origin> ORIGIN_ID </origin>
+          <blockhashes> _ </blockhashes>
+          <block>
+            <previousHash> _ </previousHash>
+            <ommersHash> _ </ommersHash>
+            <coinbase> _ </coinbase>
+            <stateRoot> _ </stateRoot>
+            <transactionsRoot> _ </transactionsRoot>
+            <receiptsRoot> _ </receiptsRoot>
+            <logsBloom> _ </logsBloom>
+            <difficulty> _ </difficulty>
+            <number> _BLOCK_NUMBER </number>
+            <gasLimit> _ </gasLimit>
+            <gasUsed> _ </gasUsed>
+            <timestamp> TIME </timestamp>
+            <extraData> _ </extraData>
+            <mixHash> _ </mixHash>
+            <blockNonce> _ </blockNonce>
+            <ommerBlockHeaders> _ </ommerBlockHeaders>
+          </block>
+        </evm>
+        <network>
+          <chainID> VChainId </chainID>
+          <activeAccounts> SetItem(ACCT_ID)
+          SetItem(1)
+          SetItem(2)
+          SetItem(3)
+          SetItem(4)
+          SetItem(5)
+          SetItem(6)
+          SetItem(7)
+          SetItem(8)
+          SetItem(9) _ </activeAccounts>
+          <accounts>
+            <account>
+              <acctID> ACCT_ID </acctID>
+              <balance> ACCT_ID_balance </balance>
+              <code> DSToken_bin_runtime </code>
+              <storage> ACCT_ID_STORAGE => ACCT_ID_STORAGE [ #DSToken.allowance[ABI_src][CALLER_ID] <- #if (ABI_src ==Int CALLER_ID orBool Allowance ==Int maxUInt256) #then Allowance #else Allowance -Int ABI_wad #fi ] [ #DSToken.balances[ABI_src] <- Gem_s -Int ABI_wad ] [ #DSToken.balances[ABI_dst] <- Gem_d +Int ABI_wad ] </storage>
+              <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
+              <nonce> _Nonce_DSToken => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> 1 </acctID>
+              <balance> ECREC_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 2 </acctID>
+              <balance> SHA256_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 3 </acctID>
+              <balance> RIP160_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 4 </acctID>
+              <balance> ID_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 5 </acctID>
+              <balance> MODEXP_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 6 </acctID>
+              <balance> ECADD_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 7 </acctID>
+              <balance> ECMUL_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 8 </acctID>
+              <balance> ECPAIRING_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 9 </acctID>
+              <balance> BLAKE2_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+           ...
+          </accounts>
+          <txOrder> _ </txOrder>
+          <txPending> _ </txPending>
+          <messages> _ </messages>
+        </network>
+      </ethereum>
+      requires #rangeAddress(ACCT_ID)
+       andBool ACCT_ID =/=Int 0
+       andBool #notPrecompileAddress(ACCT_ID)
+       andBool #rangeAddress(CALLER_ID)
+       andBool #rangeAddress(ORIGIN_ID)
+       andBool #rangeUInt(256, TIME)
+       andBool #rangeUInt(256, ACCT_ID_balance)
+       andBool #rangeUInt(256, ECREC_BAL)
+       andBool #rangeUInt(256, SHA256_BAL)
+       andBool #rangeUInt(256, RIP160_BAL)
+       andBool #rangeUInt(256, ID_BAL)
+       andBool #rangeUInt(256, MODEXP_BAL)
+       andBool #rangeUInt(256, ECADD_BAL)
+       andBool #rangeUInt(256, ECMUL_BAL)
+       andBool #rangeUInt(256, ECPAIRING_BAL)
+       andBool #rangeUInt(256, BLAKE2_BAL)
+       andBool VCallDepth <=Int 1024
+       andBool #rangeUInt(256, VCallValue)
+       andBool #rangeUInt(256, VChainId)
+
+       andBool (#rangeAddress(ABI_src)
+       andBool (#rangeAddress(ABI_dst)
+       andBool (#rangeUInt(256, ABI_wad)
+       andBool (#rangeUInt(256, Gem_s)
+       andBool (#rangeUInt(256, Gem_d)
+       andBool (#rangeUInt(256, Allowance)
+       andBool (#rangeAddress(Owner)
+       andBool (#rangeBool(Stopped)
+       andBool ((#sizeByteArray(CD) <=Int 1250000000)
+       andBool ((#notPrecompileAddress(Owner))
+       andBool ((ABI_src =/=Int ABI_dst)
+       andBool ((ABI_src =/=Int CALLER_ID)
+       andBool (#rangeUInt(256, Junk_0)
+       andBool (#rangeUInt(256, Junk_1)
+       andBool (#rangeUInt(256, Junk_2)
+       andBool (#rangeUInt(256, Junk_3)
+       andBool (((#rangeUInt(256, Gem_s -Int ABI_wad)))
+       andBool (((#rangeUInt(256, Gem_d +Int ABI_wad)))
+       andBool (((Allowance ==Int maxUInt256) orBool (ABI_wad <=Int Allowance))
+       andBool ((VCallValue ==Int 0)
+       andBool ((Stopped ==Int 0))))))))))))))))))))))
+
+       andBool #lookup(ACCT_ID_STORAGE, #DSToken.allowance[ABI_src][CALLER_ID]) ==Int Allowance
+       andBool #lookup(ACCT_ID_STORAGE, #DSToken.balances[ABI_src]) ==Int Gem_s
+       andBool #lookup(ACCT_ID_STORAGE, #DSToken.balances[ABI_dst]) ==Int Gem_d
+       andBool #lookup(ACCT_ID_STORAGE, #DSToken.owner_stopped) ==Int #WordPackAddrUInt8(Owner, Stopped)
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #DSToken.allowance[ABI_src][CALLER_ID]) ==Int Junk_0
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #DSToken.balances[ABI_src]) ==Int Junk_1
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #DSToken.balances[ABI_dst]) ==Int Junk_2
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #DSToken.owner_stopped) ==Int Junk_3
+       andBool #DSToken.allowance[ABI_src][CALLER_ID] =/=Int #DSToken.balances[ABI_src]
+       andBool #DSToken.allowance[ABI_src][CALLER_ID] =/=Int #DSToken.balances[ABI_dst]
+       andBool #DSToken.allowance[ABI_src][CALLER_ID] =/=Int #DSToken.owner_stopped
+       andBool #DSToken.balances[ABI_src] =/=Int #DSToken.balances[ABI_dst]
+       andBool #DSToken.balances[ABI_src] =/=Int #DSToken.owner_stopped
+       andBool #DSToken.balances[ABI_dst] =/=Int #DSToken.owner_stopped
+    [trusted, matching(infGas)]
+
+
+endmodule

--- a/tests/specs/mcd/functional-spec.k
+++ b/tests/specs/mcd/functional-spec.k
@@ -22,6 +22,11 @@ module FUNCTIONAL-SPEC
        andBool #rangeSInt(256, Y)
        andBool Y <Int 0
 
+    claim <k> runLemma(chop(Art_i *Int (ABI_rate +Int pow256))) => doneLemma(chop(Art_i *Int ABI_rate)) ... </k>
+      requires #rangeUInt(256, Art_i)
+       andBool Art_i <=Int maxSInt256
+       andBool #rangeSInt(256, Art_i *Int ABI_rate)
+
     // WordPack
 
     claim <k> runLemma((GAL |Int (maskWordPackAddrUInt48UInt48_1 &Int GUY_TIC_END)) modInt pow256) => doneLemma(GAL |Int (maskWordPackAddrUInt48UInt48_1 &Int GUY_TIC_END)) ... </k>

--- a/tests/specs/mcd/gemjoin-exit-pass-rough-spec.k
+++ b/tests/specs/mcd/gemjoin-exit-pass-rough-spec.k
@@ -1,0 +1,673 @@
+requires "verification.k"
+
+module GEMJOIN-EXIT-PASS-ROUGH-SPEC
+    imports VERIFICATION
+
+    // GemJoin_exit
+    claim [GemJoin.exit.pass.rough]:
+      <k> #execute ~> CONTINUATION => #halt ~> CONTINUATION </k>
+      <exit-code> 1 </exit-code>
+      <mode> NORMAL </mode>
+      <schedule> ISTANBUL </schedule>
+      <ethereum>
+        <evm>
+          <output> .ByteArray </output>
+          <statusCode> _ => EVMC_SUCCESS </statusCode>
+          <endPC> _ => ?_ </endPC>
+          <callStack> _VCallStack </callStack>
+          <interimStates> _ </interimStates>
+          <touchedAccounts> _ => ?_ </touchedAccounts>
+          <callState>
+            <program> GemJoin_bin_runtime </program>
+            <jumpDests> #computeValidJumpDests(GemJoin_bin_runtime) </jumpDests>
+            <id> ACCT_ID </id>
+            <caller> CALLER_ID </caller>
+            <callData> #abiCallData("exit", #address(ABI_usr), #uint256(ABI_wad)) ++ CD => ?_ </callData>
+            <callValue> VCallValue </callValue>
+            <wordStack> .WordStack => ?_ </wordStack>
+            <localMem> .Memory => ?_ </localMem>
+            <pc> 0 => ?_ </pc>
+            <gas> #gas(VGas) => ?_ </gas>
+            <memoryUsed> 0 => ?_ </memoryUsed>
+            <callGas> _ => ?_ </callGas>
+            <static> false </static>
+            <callDepth> VCallDepth </callDepth>
+          </callState>
+          <substate>
+            <selfDestruct> _VSelfDestruct </selfDestruct>
+            <log> _ => ?_ </log>
+            <refund> _Vrefund => ?_ </refund>
+          </substate>
+          <gasPrice> _ </gasPrice>
+          <origin> ORIGIN_ID </origin>
+          <blockhashes> _ </blockhashes>
+          <block>
+            <previousHash> _ </previousHash>
+            <ommersHash> _ </ommersHash>
+            <coinbase> _ </coinbase>
+            <stateRoot> _ </stateRoot>
+            <transactionsRoot> _ </transactionsRoot>
+            <receiptsRoot> _ </receiptsRoot>
+            <logsBloom> _ </logsBloom>
+            <difficulty> _ </difficulty>
+            <number> _BLOCK_NUMBER </number>
+            <gasLimit> _ </gasLimit>
+            <gasUsed> _ </gasUsed>
+            <timestamp> TIME </timestamp>
+            <extraData> _ </extraData>
+            <mixHash> _ </mixHash>
+            <blockNonce> _ </blockNonce>
+            <ommerBlockHeaders> _ </ommerBlockHeaders>
+          </block>
+        </evm>
+        <network>
+          <chainID> VChainId </chainID>
+          <activeAccounts> SetItem(ACCT_ID)
+          SetItem(Vat)
+          SetItem(DSToken)
+          SetItem(1)
+          SetItem(2)
+          SetItem(3)
+          SetItem(4)
+          SetItem(5)
+          SetItem(6)
+          SetItem(7)
+          SetItem(8)
+          SetItem(9) _ </activeAccounts>
+          <accounts>
+            <account>
+              <acctID> ACCT_ID </acctID>
+              <balance> ACCT_ID_balance </balance>
+              <code> GemJoin_bin_runtime </code>
+              <storage> ACCT_ID_STORAGE => ACCT_ID_STORAGE  </storage>
+              <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
+              <nonce> _Nonce_GemJoin => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> Vat </acctID>
+              <balance> Vat_balance </balance>
+              <code> Vat_bin_runtime </code>
+              <storage> Vat_STORAGE => Vat_STORAGE [ #Vat.gem[Ilk][CALLER_ID] <- Wad -Int ABI_wad ] </storage>
+              <origStorage> Vat_ORIG_STORAGE </origStorage>
+              <nonce> _Nonce_Vat => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> DSToken </acctID>
+              <balance> DSToken_balance </balance>
+              <code> DSToken_bin_runtime </code>
+              <storage> DSToken_STORAGE => DSToken_STORAGE [ #DSToken.balances[ACCT_ID] <- Bal_adapter -Int ABI_wad ] [ #DSToken.balances[ABI_usr] <- Bal_usr     +Int ABI_wad ] </storage>
+              <origStorage> DSToken_ORIG_STORAGE </origStorage>
+              <nonce> _Nonce_DSToken => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> 1 </acctID>
+              <balance> ECREC_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 2 </acctID>
+              <balance> SHA256_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 3 </acctID>
+              <balance> RIP160_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 4 </acctID>
+              <balance> ID_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 5 </acctID>
+              <balance> MODEXP_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 6 </acctID>
+              <balance> ECADD_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 7 </acctID>
+              <balance> ECMUL_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 8 </acctID>
+              <balance> ECPAIRING_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 9 </acctID>
+              <balance> BLAKE2_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+           ...
+          </accounts>
+          <txOrder> _ </txOrder>
+          <txPending> _ </txPending>
+          <messages> _ </messages>
+        </network>
+      </ethereum>
+      requires #rangeAddress(ACCT_ID)
+       andBool ACCT_ID =/=Int 0
+       andBool #notPrecompileAddress(ACCT_ID)
+       andBool #rangeAddress(CALLER_ID)
+       andBool #rangeAddress(ORIGIN_ID)
+       andBool #rangeUInt(256, TIME)
+       andBool #rangeUInt(256, ACCT_ID_balance)
+       andBool #rangeUInt(256, ECREC_BAL)
+       andBool #rangeUInt(256, SHA256_BAL)
+       andBool #rangeUInt(256, RIP160_BAL)
+       andBool #rangeUInt(256, ID_BAL)
+       andBool #rangeUInt(256, MODEXP_BAL)
+       andBool #rangeUInt(256, ECADD_BAL)
+       andBool #rangeUInt(256, ECMUL_BAL)
+       andBool #rangeUInt(256, ECPAIRING_BAL)
+       andBool #rangeUInt(256, BLAKE2_BAL)
+       andBool VCallDepth <=Int 1024
+       andBool #rangeUInt(256, VCallValue)
+       andBool #rangeUInt(256, VChainId)
+
+       andBool (#rangeAddress(ABI_usr)
+       andBool (#rangeUInt(256, ABI_wad)
+       andBool (#rangeAddress(Vat)
+       andBool (#rangeBytes(32, Ilk)
+       andBool (#rangeAddress(DSToken)
+       andBool (#rangeUInt(256, May)
+       andBool (#rangeUInt(256, Wad)
+       andBool (#rangeUInt(256, Bal_usr)
+       andBool (#rangeUInt(256, Bal_adapter)
+       andBool (#rangeAddress(Owner)
+       andBool (#rangeBool(Stopped)
+       andBool (#rangeUInt(256, Vat_balance)
+       andBool (#rangeUInt(256, DSToken_balance)
+       andBool ((#sizeByteArray(CD) <=Int 1250000000)
+       andBool ((#notPrecompileAddress(Vat))
+       andBool ((#notPrecompileAddress(DSToken))
+       andBool ((#notPrecompileAddress(Owner))
+       andBool ((ACCT_ID =/=Int Vat)
+       andBool ((ACCT_ID =/=Int DSToken)
+       andBool ((ACCT_ID =/=Int ABI_usr)
+       andBool ((Vat =/=Int 0)
+       andBool ((DSToken =/=Int 0)
+       andBool (#rangeUInt(256, Junk_0)
+       andBool (#rangeUInt(256, Junk_1)
+       andBool (#rangeUInt(256, Junk_2)
+       andBool (#rangeUInt(256, Junk_3)
+       andBool (#rangeUInt(256, Junk_4)
+       andBool (#rangeUInt(256, Junk_5)
+       andBool (#rangeUInt(256, Junk_6)
+       andBool (#rangeUInt(256, Junk_7)
+       andBool (((VCallValue ==Int 0))
+       andBool (((VCallDepth <Int 1024))
+       andBool (((Stopped ==Int 0))
+       andBool (((May ==Int 1))
+       andBool (((ABI_wad <=Int pow255))
+       andBool ((#rangeUInt(256, Wad         -Int ABI_wad))
+       andBool ((#rangeUInt(256, Bal_adapter -Int ABI_wad))
+       andBool ((#rangeUInt(256, Bal_usr     +Int ABI_wad))))))))))))))))))))))))))))))))))))))))
+
+       andBool #lookup(ACCT_ID_STORAGE, #GemJoin.vat) ==Int Vat
+       andBool #lookup(ACCT_ID_STORAGE, #GemJoin.ilk) ==Int Ilk
+       andBool #lookup(ACCT_ID_STORAGE, #GemJoin.gem) ==Int DSToken
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #GemJoin.vat) ==Int Junk_0
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #GemJoin.ilk) ==Int Junk_1
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #GemJoin.gem) ==Int Junk_2
+       andBool #GemJoin.vat =/=Int #GemJoin.ilk
+       andBool #GemJoin.vat =/=Int #GemJoin.gem
+       andBool #GemJoin.ilk =/=Int #GemJoin.gem
+       andBool #lookup(Vat_STORAGE, #Vat.wards[ACCT_ID]) ==Int May
+       andBool #lookup(Vat_STORAGE, #Vat.gem[Ilk][CALLER_ID]) ==Int Wad
+       andBool #lookup(Vat_ORIG_STORAGE, #Vat.wards[ACCT_ID]) ==Int Junk_3
+       andBool #lookup(Vat_ORIG_STORAGE, #Vat.gem[Ilk][CALLER_ID]) ==Int Junk_4
+       andBool #Vat.wards[ACCT_ID] =/=Int #Vat.gem[Ilk][CALLER_ID]
+       andBool #lookup(DSToken_STORAGE, #DSToken.balances[ACCT_ID]) ==Int Bal_adapter
+       andBool #lookup(DSToken_STORAGE, #DSToken.balances[ABI_usr]) ==Int Bal_usr
+       andBool #lookup(DSToken_STORAGE, #DSToken.owner_stopped) ==Int #WordPackAddrUInt8(Owner, Stopped)
+       andBool #lookup(DSToken_ORIG_STORAGE, #DSToken.balances[ACCT_ID]) ==Int Junk_5
+       andBool #lookup(DSToken_ORIG_STORAGE, #DSToken.balances[ABI_usr]) ==Int Junk_6
+       andBool #lookup(DSToken_ORIG_STORAGE, #DSToken.owner_stopped) ==Int Junk_7
+       andBool #DSToken.balances[ACCT_ID] =/=Int #DSToken.balances[ABI_usr]
+       andBool #DSToken.balances[ACCT_ID] =/=Int #DSToken.owner_stopped
+       andBool #DSToken.balances[ABI_usr] =/=Int #DSToken.owner_stopped
+
+    // Vat_slip
+    claim [Vat.slip.pass]:
+      <k> #execute ~> CONTINUATION => #halt ~> CONTINUATION </k>
+      <exit-code> 1 </exit-code>
+      <mode> NORMAL </mode>
+      <schedule> ISTANBUL </schedule>
+      <ethereum>
+        <evm>
+          <output> .ByteArray </output>
+          <statusCode> _ => EVMC_SUCCESS </statusCode>
+          <endPC> _ => ?_ </endPC>
+          <callStack> _VCallStack </callStack>
+          <interimStates> _ </interimStates>
+          <touchedAccounts> _ => ?_ </touchedAccounts>
+          <callState>
+            <program> Vat_bin_runtime </program>
+            <jumpDests> #computeValidJumpDests(Vat_bin_runtime) </jumpDests>
+            <id> ACCT_ID </id>
+            <caller> CALLER_ID </caller>
+            <callData> #abiCallData("slip", #bytes32(ABI_ilk), #address(ABI_usr), #int256(ABI_wad)) ++ CD => ?_ </callData>
+            <callValue> VCallValue </callValue>
+            <wordStack> .WordStack => ?_ </wordStack>
+            <localMem> .Memory => ?_ </localMem>
+            <pc> 0 => ?_ </pc>
+            <gas> #gas(VGas) => #if ( ABI_wad <Int 0 andBool ( minSInt256 <=Int ABI_wad andBool ( ABI_wad <=Int maxSInt256 andBool 0 <=Int ( Gem +Int ABI_wad ) ) ) )
+              #then   #gas ( ( ( VGas -Int Csstore( ISTANBUL , ( Gem +Int ABI_wad ) , Gem , Junk_1 ) ) +Int -6884 ) )
+              #else   #if ABI_wad <=Int 0
+                #then   #gas ( ( ( VGas -Int Csstore( ISTANBUL , ( Gem +Int ABI_wad ) , Gem , Junk_1 ) ) +Int -6870 ) )
+                #else   #gas ( ( ( VGas -Int Csstore( ISTANBUL , ( Gem +Int ABI_wad ) , Gem , Junk_1 ) ) +Int -6884 ) )
+              #fi
+            #fi </gas>
+            <memoryUsed> 0 => ?_ </memoryUsed>
+            <callGas> _ => ?_ </callGas>
+            <static> false </static>
+            <callDepth> VCallDepth </callDepth>
+          </callState>
+          <substate>
+            <selfDestruct> _VSelfDestruct </selfDestruct>
+            <log> _ => ?_ </log>
+            <refund> _Vrefund => ?_ </refund>
+          </substate>
+          <gasPrice> _ </gasPrice>
+          <origin> ORIGIN_ID </origin>
+          <blockhashes> _ </blockhashes>
+          <block>
+            <previousHash> _ </previousHash>
+            <ommersHash> _ </ommersHash>
+            <coinbase> _ </coinbase>
+            <stateRoot> _ </stateRoot>
+            <transactionsRoot> _ </transactionsRoot>
+            <receiptsRoot> _ </receiptsRoot>
+            <logsBloom> _ </logsBloom>
+            <difficulty> _ </difficulty>
+            <number> _BLOCK_NUMBER </number>
+            <gasLimit> _ </gasLimit>
+            <gasUsed> _ </gasUsed>
+            <timestamp> TIME </timestamp>
+            <extraData> _ </extraData>
+            <mixHash> _ </mixHash>
+            <blockNonce> _ </blockNonce>
+            <ommerBlockHeaders> _ </ommerBlockHeaders>
+          </block>
+        </evm>
+        <network>
+          <chainID> VChainId </chainID>
+          <activeAccounts> SetItem(ACCT_ID)
+          SetItem(1)
+          SetItem(2)
+          SetItem(3)
+          SetItem(4)
+          SetItem(5)
+          SetItem(6)
+          SetItem(7)
+          SetItem(8)
+          SetItem(9) _ </activeAccounts>
+          <accounts>
+            <account>
+              <acctID> ACCT_ID </acctID>
+              <balance> ACCT_ID_balance </balance>
+              <code> Vat_bin_runtime </code>
+              <storage> ACCT_ID_STORAGE => ACCT_ID_STORAGE [ #Vat.gem[ABI_ilk][ABI_usr] <- Gem +Int ABI_wad ] </storage>
+              <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
+              <nonce> _Nonce_Vat => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> 1 </acctID>
+              <balance> ECREC_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 2 </acctID>
+              <balance> SHA256_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 3 </acctID>
+              <balance> RIP160_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 4 </acctID>
+              <balance> ID_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 5 </acctID>
+              <balance> MODEXP_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 6 </acctID>
+              <balance> ECADD_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 7 </acctID>
+              <balance> ECMUL_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 8 </acctID>
+              <balance> ECPAIRING_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 9 </acctID>
+              <balance> BLAKE2_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+           ...
+          </accounts>
+          <txOrder> _ </txOrder>
+          <txPending> _ </txPending>
+          <messages> _ </messages>
+        </network>
+      </ethereum>
+      requires #rangeAddress(ACCT_ID)
+       andBool ACCT_ID =/=Int 0
+       andBool #notPrecompileAddress(ACCT_ID)
+       andBool #rangeAddress(CALLER_ID)
+       andBool #rangeAddress(ORIGIN_ID)
+       andBool #rangeUInt(256, TIME)
+       andBool #rangeUInt(256, ACCT_ID_balance)
+       andBool #rangeUInt(256, ECREC_BAL)
+       andBool #rangeUInt(256, SHA256_BAL)
+       andBool #rangeUInt(256, RIP160_BAL)
+       andBool #rangeUInt(256, ID_BAL)
+       andBool #rangeUInt(256, MODEXP_BAL)
+       andBool #rangeUInt(256, ECADD_BAL)
+       andBool #rangeUInt(256, ECMUL_BAL)
+       andBool #rangeUInt(256, ECPAIRING_BAL)
+       andBool #rangeUInt(256, BLAKE2_BAL)
+       andBool VCallDepth <=Int 1024
+       andBool #rangeUInt(256, VCallValue)
+       andBool #rangeUInt(256, VChainId)
+
+       andBool (#rangeBytes(32, ABI_ilk)
+       andBool (#rangeAddress(ABI_usr)
+       andBool (#rangeSInt(256, ABI_wad)
+       andBool (#rangeUInt(256, May)
+       andBool (#rangeUInt(256, Gem)
+       andBool (#sizeByteArray(CD) <=Int 1250000000
+       andBool (#rangeUInt(256, Junk_0)
+       andBool (#rangeUInt(256, Junk_1)
+       andBool (((May ==Int 1))
+       andBool (((VCallValue ==Int 0))
+       andBool ((#rangeUInt(256, Gem +Int ABI_wad)))))))))))))
+
+       andBool #lookup(ACCT_ID_STORAGE, #Vat.wards[CALLER_ID]) ==Int May
+       andBool #lookup(ACCT_ID_STORAGE, #Vat.gem[ABI_ilk][ABI_usr]) ==Int Gem
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Vat.wards[CALLER_ID]) ==Int Junk_0
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Vat.gem[ABI_ilk][ABI_usr]) ==Int Junk_1
+       andBool #Vat.wards[CALLER_ID] =/=Int #Vat.gem[ABI_ilk][ABI_usr]
+    [trusted, matching(infGas)]
+
+
+    // DSToken_transfer
+    claim [DSToken.transfer.pass]:
+      <k> #execute ~> CONTINUATION => #halt ~> CONTINUATION </k>
+      <exit-code> 1 </exit-code>
+      <mode> NORMAL </mode>
+      <schedule> ISTANBUL </schedule>
+      <ethereum>
+        <evm>
+          <output> _ => #buf(32, 1) </output>
+          <statusCode> _ => EVMC_SUCCESS </statusCode>
+          <endPC> _ => ?_ </endPC>
+          <callStack> _VCallStack </callStack>
+          <interimStates> _ </interimStates>
+          <touchedAccounts> _ => ?_ </touchedAccounts>
+          <callState>
+            <program> DSToken_bin_runtime </program>
+            <jumpDests> #computeValidJumpDests(DSToken_bin_runtime) </jumpDests>
+            <id> ACCT_ID </id>
+            <caller> CALLER_ID </caller>
+            <callData> #abiCallData("transfer", #address(ABI_usr), #uint256(ABI_wad)) ++ CD => ?_ </callData>
+            <callValue> VCallValue </callValue>
+            <wordStack> .WordStack => ?_ </wordStack>
+            <localMem> .Memory => ?_ </localMem>
+            <pc> 0 => ?_ </pc>
+            <gas> #gas(VGas) => #gas ( ( ( ( VGas -Int Csstore( ISTANBUL , ( Gem_c -Int ABI_wad ) , Gem_c , Junk_0 ) ) -Int Csstore( ISTANBUL , ( Gem_u +Int ABI_wad ) , Gem_u , Junk_1 ) ) +Int -6391 ) ) </gas>
+            <memoryUsed> 0 => ?_ </memoryUsed>
+            <callGas> _ => ?_ </callGas>
+            <static> false </static>
+            <callDepth> VCallDepth </callDepth>
+          </callState>
+          <substate>
+            <selfDestruct> _VSelfDestruct </selfDestruct>
+            <log> _ => ?_ </log>
+            <refund> _Vrefund => ?_ </refund>
+          </substate>
+          <gasPrice> _ </gasPrice>
+          <origin> ORIGIN_ID </origin>
+          <blockhashes> _ </blockhashes>
+          <block>
+            <previousHash> _ </previousHash>
+            <ommersHash> _ </ommersHash>
+            <coinbase> _ </coinbase>
+            <stateRoot> _ </stateRoot>
+            <transactionsRoot> _ </transactionsRoot>
+            <receiptsRoot> _ </receiptsRoot>
+            <logsBloom> _ </logsBloom>
+            <difficulty> _ </difficulty>
+            <number> _BLOCK_NUMBER </number>
+            <gasLimit> _ </gasLimit>
+            <gasUsed> _ </gasUsed>
+            <timestamp> TIME </timestamp>
+            <extraData> _ </extraData>
+            <mixHash> _ </mixHash>
+            <blockNonce> _ </blockNonce>
+            <ommerBlockHeaders> _ </ommerBlockHeaders>
+          </block>
+        </evm>
+        <network>
+          <chainID> VChainId </chainID>
+          <activeAccounts> SetItem(ACCT_ID)
+          SetItem(1)
+          SetItem(2)
+          SetItem(3)
+          SetItem(4)
+          SetItem(5)
+          SetItem(6)
+          SetItem(7)
+          SetItem(8)
+          SetItem(9) _ </activeAccounts>
+          <accounts>
+            <account>
+              <acctID> ACCT_ID </acctID>
+              <balance> ACCT_ID_balance </balance>
+              <code> DSToken_bin_runtime </code>
+              <storage> ACCT_ID_STORAGE => ACCT_ID_STORAGE [ #DSToken.balances[CALLER_ID] <- Gem_c -Int ABI_wad ] [ #DSToken.balances[ABI_usr] <- Gem_u +Int ABI_wad ] </storage>
+              <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
+              <nonce> _Nonce_DSToken => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> 1 </acctID>
+              <balance> ECREC_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 2 </acctID>
+              <balance> SHA256_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 3 </acctID>
+              <balance> RIP160_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 4 </acctID>
+              <balance> ID_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 5 </acctID>
+              <balance> MODEXP_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 6 </acctID>
+              <balance> ECADD_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 7 </acctID>
+              <balance> ECMUL_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 8 </acctID>
+              <balance> ECPAIRING_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 9 </acctID>
+              <balance> BLAKE2_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+           ...
+          </accounts>
+          <txOrder> _ </txOrder>
+          <txPending> _ </txPending>
+          <messages> _ </messages>
+        </network>
+      </ethereum>
+      requires #rangeAddress(ACCT_ID)
+       andBool ACCT_ID =/=Int 0
+       andBool #notPrecompileAddress(ACCT_ID)
+       andBool #rangeAddress(CALLER_ID)
+       andBool #rangeAddress(ORIGIN_ID)
+       andBool #rangeUInt(256, TIME)
+       andBool #rangeUInt(256, ACCT_ID_balance)
+       andBool #rangeUInt(256, ECREC_BAL)
+       andBool #rangeUInt(256, SHA256_BAL)
+       andBool #rangeUInt(256, RIP160_BAL)
+       andBool #rangeUInt(256, ID_BAL)
+       andBool #rangeUInt(256, MODEXP_BAL)
+       andBool #rangeUInt(256, ECADD_BAL)
+       andBool #rangeUInt(256, ECMUL_BAL)
+       andBool #rangeUInt(256, ECPAIRING_BAL)
+       andBool #rangeUInt(256, BLAKE2_BAL)
+       andBool VCallDepth <=Int 1024
+       andBool #rangeUInt(256, VCallValue)
+       andBool #rangeUInt(256, VChainId)
+
+       andBool (#rangeAddress(ABI_usr)
+       andBool (#rangeUInt(256, ABI_wad)
+       andBool (#rangeUInt(256, Gem_c)
+       andBool (#rangeUInt(256, Gem_u)
+       andBool (#rangeAddress(Owner)
+       andBool (#rangeBool(Stopped)
+       andBool ((#sizeByteArray(CD) <=Int 1250000000)
+       andBool ((#notPrecompileAddress(Owner))
+       andBool ((ABI_usr =/=Int CALLER_ID)
+       andBool (#rangeUInt(256, Junk_0)
+       andBool (#rangeUInt(256, Junk_1)
+       andBool (#rangeUInt(256, Junk_2)
+       andBool (((#rangeUInt(256, Gem_c -Int ABI_wad)))
+       andBool (((#rangeUInt(256, Gem_u +Int ABI_wad)))
+       andBool ((Stopped ==Int 0)
+       andBool ((VCallValue ==Int 0)))))))))))))))))
+
+       andBool #lookup(ACCT_ID_STORAGE, #DSToken.balances[CALLER_ID]) ==Int Gem_c
+       andBool #lookup(ACCT_ID_STORAGE, #DSToken.balances[ABI_usr]) ==Int Gem_u
+       andBool #lookup(ACCT_ID_STORAGE, #DSToken.owner_stopped) ==Int #WordPackAddrUInt8(Owner, Stopped)
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #DSToken.balances[CALLER_ID]) ==Int Junk_0
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #DSToken.balances[ABI_usr]) ==Int Junk_1
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #DSToken.owner_stopped) ==Int Junk_2
+       andBool #DSToken.balances[CALLER_ID] =/=Int #DSToken.balances[ABI_usr]
+       andBool #DSToken.balances[CALLER_ID] =/=Int #DSToken.owner_stopped
+       andBool #DSToken.balances[ABI_usr] =/=Int #DSToken.owner_stopped
+    [trusted, matching(infGas)]
+
+
+endmodule

--- a/tests/specs/mcd/vat-fold-pass-rough-spec.k
+++ b/tests/specs/mcd/vat-fold-pass-rough-spec.k
@@ -1,0 +1,619 @@
+requires "verification.k"
+
+module VAT-FOLD-PASS-ROUGH-SPEC
+    imports VERIFICATION
+
+    // Vat_fold
+    claim [Vat.fold.pass.rough]:
+      <k> #execute ~> CONTINUATION => #halt ~> CONTINUATION </k>
+      <exit-code> 1 </exit-code>
+      <mode> NORMAL </mode>
+      <schedule> ISTANBUL </schedule>
+      <ethereum>
+        <evm>
+          <output> .ByteArray </output>
+          <statusCode> _ => EVMC_SUCCESS </statusCode>
+          <endPC> _ => ?_ </endPC>
+          <callStack> _VCallStack </callStack>
+          <interimStates> _ </interimStates>
+          <touchedAccounts> _ => ?_ </touchedAccounts>
+          <callState>
+            <program> Vat_bin_runtime </program>
+            <jumpDests> #computeValidJumpDests(Vat_bin_runtime) </jumpDests>
+            <id> ACCT_ID </id>
+            <caller> CALLER_ID </caller>
+            <callData> #abiCallData("fold", #bytes32(ABI_i), #address(ABI_u), #int256(ABI_rate)) ++ CD => ?_ </callData>
+            <callValue> VCallValue </callValue>
+            <wordStack> .WordStack => ?_ </wordStack>
+            <localMem> .Memory => ?_ </localMem>
+            <pc> 0 => ?_ </pc>
+            <gas> #gas(VGas) => ?_ </gas>
+            <memoryUsed> 0 => ?_ </memoryUsed>
+            <callGas> _ => ?_ </callGas>
+            <static> false </static>
+            <callDepth> VCallDepth </callDepth>
+          </callState>
+          <substate>
+            <selfDestruct> _VSelfDestruct </selfDestruct>
+            <log> _ => ?_ </log>
+            <refund> _Vrefund => ?_ </refund>
+          </substate>
+          <gasPrice> _ </gasPrice>
+          <origin> ORIGIN_ID </origin>
+          <blockhashes> _ </blockhashes>
+          <block>
+            <previousHash> _ </previousHash>
+            <ommersHash> _ </ommersHash>
+            <coinbase> _ </coinbase>
+            <stateRoot> _ </stateRoot>
+            <transactionsRoot> _ </transactionsRoot>
+            <receiptsRoot> _ </receiptsRoot>
+            <logsBloom> _ </logsBloom>
+            <difficulty> _ </difficulty>
+            <number> _BLOCK_NUMBER </number>
+            <gasLimit> _ </gasLimit>
+            <gasUsed> _ </gasUsed>
+            <timestamp> TIME </timestamp>
+            <extraData> _ </extraData>
+            <mixHash> _ </mixHash>
+            <blockNonce> _ </blockNonce>
+            <ommerBlockHeaders> _ </ommerBlockHeaders>
+          </block>
+        </evm>
+        <network>
+          <chainID> VChainId </chainID>
+          <activeAccounts> SetItem(ACCT_ID)
+          SetItem(1)
+          SetItem(2)
+          SetItem(3)
+          SetItem(4)
+          SetItem(5)
+          SetItem(6)
+          SetItem(7)
+          SetItem(8)
+          SetItem(9) _ </activeAccounts>
+          <accounts>
+            <account>
+              <acctID> ACCT_ID </acctID>
+              <balance> ACCT_ID_balance </balance>
+              <code> Vat_bin_runtime </code>
+              <storage> ACCT_ID_STORAGE => ACCT_ID_STORAGE [ #Vat.ilks[ABI_i].rate <- Rate_i +Int ABI_rate ] [ #Vat.dai[ABI_u] <- Dai_u +Int Art_i *Int ABI_rate ] [ #Vat.debt <- Debt  +Int Art_i *Int ABI_rate ] </storage>
+              <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
+              <nonce> _Nonce_Vat => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> 1 </acctID>
+              <balance> ECREC_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 2 </acctID>
+              <balance> SHA256_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 3 </acctID>
+              <balance> RIP160_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 4 </acctID>
+              <balance> ID_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 5 </acctID>
+              <balance> MODEXP_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 6 </acctID>
+              <balance> ECADD_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 7 </acctID>
+              <balance> ECMUL_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 8 </acctID>
+              <balance> ECPAIRING_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 9 </acctID>
+              <balance> BLAKE2_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+           ...
+          </accounts>
+          <txOrder> _ </txOrder>
+          <txPending> _ </txPending>
+          <messages> _ </messages>
+        </network>
+      </ethereum>
+      requires #rangeAddress(ACCT_ID)
+       andBool ACCT_ID =/=Int 0
+       andBool #notPrecompileAddress(ACCT_ID)
+       andBool #rangeAddress(CALLER_ID)
+       andBool #rangeAddress(ORIGIN_ID)
+       andBool #rangeUInt(256, TIME)
+       andBool #rangeUInt(256, ACCT_ID_balance)
+       andBool #rangeUInt(256, ECREC_BAL)
+       andBool #rangeUInt(256, SHA256_BAL)
+       andBool #rangeUInt(256, RIP160_BAL)
+       andBool #rangeUInt(256, ID_BAL)
+       andBool #rangeUInt(256, MODEXP_BAL)
+       andBool #rangeUInt(256, ECADD_BAL)
+       andBool #rangeUInt(256, ECMUL_BAL)
+       andBool #rangeUInt(256, ECPAIRING_BAL)
+       andBool #rangeUInt(256, BLAKE2_BAL)
+       andBool VCallDepth <=Int 1024
+       andBool #rangeUInt(256, VCallValue)
+       andBool #rangeUInt(256, VChainId)
+
+       andBool (#rangeBytes(32, ABI_i)
+       andBool (#rangeAddress(ABI_u)
+       andBool (#rangeSInt(256, ABI_rate)
+       andBool (#rangeUInt(256, May)
+       andBool (#rangeUInt(256, Rate_i)
+       andBool (#rangeUInt(256, Dai_u)
+       andBool (#rangeUInt(256, Art_i)
+       andBool (#rangeUInt(256, Debt)
+       andBool (#sizeByteArray(CD) <=Int 1250000000
+       andBool (#rangeUInt(256, Junk_0)
+       andBool (#rangeUInt(256, Junk_1)
+       andBool (#rangeUInt(256, Junk_2)
+       andBool (#rangeUInt(256, Junk_3)
+       andBool (#rangeUInt(256, Junk_4)
+       andBool (#rangeUInt(256, Junk_5)
+       andBool ((((VCallValue ==Int 0)))
+       andBool ((((May ==Int 1)))
+       andBool ((((Live ==Int 1)))
+       andBool ((((Art_i <=Int maxSInt256)))
+       andBool (((#rangeSInt(256, Art_i *Int ABI_rate)))
+       andBool ((#rangeUInt(256, Rate_i +Int ABI_rate))
+       andBool ((#rangeUInt(256, Dai_u  +Int (Art_i *Int ABI_rate)))
+       andBool ((#rangeUInt(256, Debt   +Int (Art_i *Int ABI_rate))))))))))))))))))))))))))
+
+       andBool #lookup(ACCT_ID_STORAGE, #Vat.wards[CALLER_ID]) ==Int May
+       andBool #lookup(ACCT_ID_STORAGE, #Vat.ilks[ABI_i].Art) ==Int Art_i
+       andBool #lookup(ACCT_ID_STORAGE, #Vat.live) ==Int Live
+       andBool #lookup(ACCT_ID_STORAGE, #Vat.ilks[ABI_i].rate) ==Int Rate_i
+       andBool #lookup(ACCT_ID_STORAGE, #Vat.dai[ABI_u]) ==Int Dai_u
+       andBool #lookup(ACCT_ID_STORAGE, #Vat.debt) ==Int Debt
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Vat.wards[CALLER_ID]) ==Int Junk_0
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Vat.ilks[ABI_i].Art) ==Int Junk_1
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Vat.live) ==Int Junk_2
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Vat.ilks[ABI_i].rate) ==Int Junk_3
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Vat.dai[ABI_u]) ==Int Junk_4
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Vat.debt) ==Int Junk_5
+       andBool #Vat.wards[CALLER_ID] =/=Int #Vat.ilks[ABI_i].Art
+       andBool #Vat.wards[CALLER_ID] =/=Int #Vat.live
+       andBool #Vat.wards[CALLER_ID] =/=Int #Vat.ilks[ABI_i].rate
+       andBool #Vat.wards[CALLER_ID] =/=Int #Vat.dai[ABI_u]
+       andBool #Vat.wards[CALLER_ID] =/=Int #Vat.debt
+       andBool #Vat.ilks[ABI_i].Art =/=Int #Vat.live
+       andBool #Vat.ilks[ABI_i].Art =/=Int #Vat.ilks[ABI_i].rate
+       andBool #Vat.ilks[ABI_i].Art =/=Int #Vat.dai[ABI_u]
+       andBool #Vat.ilks[ABI_i].Art =/=Int #Vat.debt
+       andBool #Vat.live =/=Int #Vat.ilks[ABI_i].rate
+       andBool #Vat.live =/=Int #Vat.dai[ABI_u]
+       andBool #Vat.live =/=Int #Vat.debt
+       andBool #Vat.ilks[ABI_i].rate =/=Int #Vat.dai[ABI_u]
+       andBool #Vat.ilks[ABI_i].rate =/=Int #Vat.debt
+       andBool #Vat.dai[ABI_u] =/=Int #Vat.debt
+
+    // Vat_addui
+    claim [Vat.addui.pass]:
+      <k> #execute ~> CONTINUATION => #execute ~> CONTINUATION </k>
+      <exit-code> 1 </exit-code>
+      <mode> NORMAL </mode>
+      <schedule> ISTANBUL </schedule>
+      <ethereum>
+        <evm>
+          <output> VOutput => VOutput </output>
+          <statusCode> _ => ?_ </statusCode>
+          <endPC> _ => ?_ </endPC>
+          <callStack> _VCallStack </callStack>
+          <interimStates> _ </interimStates>
+          <touchedAccounts> _ => ?_ </touchedAccounts>
+          <callState>
+            <program> Vat_bin_runtime </program>
+            <jumpDests> #computeValidJumpDests(Vat_bin_runtime) </jumpDests>
+            <id> ACCT_ID </id>
+            <caller> CALLER_ID </caller>
+            <callData> _ => ?_ </callData>
+            <callValue> VCallValue </callValue>
+            <wordStack> chop(ABI_y) : ABI_x : JMPTO : WS  =>  JMPTO : ABI_x +Int ABI_y : WS </wordStack>
+            <localMem> _ </localMem>
+            <pc> 13112 => 13174 </pc>
+            <gas> #gas(VGas) => #if ( ABI_y <Int 0 andBool ( minSInt256 <=Int ABI_y andBool ( ABI_y <=Int maxSInt256 andBool 0 <=Int ( ABI_x +Int ABI_y ) ) ) )
+              #then   #gas ( ( VGas +Int -128 ) )
+              #else   #if ABI_y <=Int 0
+                #then   #gas ( ( VGas +Int -114 ) )
+                #else   #gas ( ( VGas +Int -128 ) )
+              #fi
+            #fi </gas>
+            <memoryUsed> VMemoryUsed </memoryUsed>
+            <callGas> _ => ?_ </callGas>
+            <static> _ </static>
+            <callDepth> VCallDepth </callDepth>
+          </callState>
+          <substate>
+            <selfDestruct> _VSelfDestruct </selfDestruct>
+            <log> _ => ?_ </log>
+            <refund> _Vrefund => ?_ </refund>
+          </substate>
+          <gasPrice> _ </gasPrice>
+          <origin> ORIGIN_ID </origin>
+          <blockhashes> _ </blockhashes>
+          <block>
+            <previousHash> _ </previousHash>
+            <ommersHash> _ </ommersHash>
+            <coinbase> _ </coinbase>
+            <stateRoot> _ </stateRoot>
+            <transactionsRoot> _ </transactionsRoot>
+            <receiptsRoot> _ </receiptsRoot>
+            <logsBloom> _ </logsBloom>
+            <difficulty> _ </difficulty>
+            <number> _BLOCK_NUMBER </number>
+            <gasLimit> _ </gasLimit>
+            <gasUsed> _ </gasUsed>
+            <timestamp> TIME </timestamp>
+            <extraData> _ </extraData>
+            <mixHash> _ </mixHash>
+            <blockNonce> _ </blockNonce>
+            <ommerBlockHeaders> _ </ommerBlockHeaders>
+          </block>
+        </evm>
+        <network>
+          <chainID> VChainId </chainID>
+          <activeAccounts> SetItem(ACCT_ID)
+          SetItem(1)
+          SetItem(2)
+          SetItem(3)
+          SetItem(4)
+          SetItem(5)
+          SetItem(6)
+          SetItem(7)
+          SetItem(8)
+          SetItem(9) _ </activeAccounts>
+          <accounts>
+            <account>
+              <acctID> ACCT_ID </acctID>
+              <balance> ACCT_ID_balance </balance>
+              <code> Vat_bin_runtime </code>
+              <storage> ACCT_ID_STORAGE => ACCT_ID_STORAGE  </storage>
+              <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
+              <nonce> _Nonce_Vat => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> 1 </acctID>
+              <balance> ECREC_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 2 </acctID>
+              <balance> SHA256_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 3 </acctID>
+              <balance> RIP160_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 4 </acctID>
+              <balance> ID_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 5 </acctID>
+              <balance> MODEXP_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 6 </acctID>
+              <balance> ECADD_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 7 </acctID>
+              <balance> ECMUL_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 8 </acctID>
+              <balance> ECPAIRING_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 9 </acctID>
+              <balance> BLAKE2_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+           ...
+          </accounts>
+          <txOrder> _ </txOrder>
+          <txPending> _ </txPending>
+          <messages> _ </messages>
+        </network>
+      </ethereum>
+      requires #rangeAddress(ACCT_ID)
+       andBool ACCT_ID =/=Int 0
+       andBool #notPrecompileAddress(ACCT_ID)
+       andBool #rangeAddress(CALLER_ID)
+       andBool #rangeAddress(ORIGIN_ID)
+       andBool #rangeUInt(256, TIME)
+       andBool #rangeUInt(256, ACCT_ID_balance)
+       andBool #rangeUInt(256, ECREC_BAL)
+       andBool #rangeUInt(256, SHA256_BAL)
+       andBool #rangeUInt(256, RIP160_BAL)
+       andBool #rangeUInt(256, ID_BAL)
+       andBool #rangeUInt(256, MODEXP_BAL)
+       andBool #rangeUInt(256, ECADD_BAL)
+       andBool #rangeUInt(256, ECMUL_BAL)
+       andBool #rangeUInt(256, ECPAIRING_BAL)
+       andBool #rangeUInt(256, BLAKE2_BAL)
+       andBool VCallDepth <=Int 1024
+       andBool #rangeUInt(256, VCallValue)
+       andBool #rangeUInt(256, VChainId)
+
+       andBool (#rangeUInt(256, ABI_x)
+       andBool (#rangeSInt(256, ABI_y)
+       andBool ((#sizeWordStack(WS) <=Int 1015)
+       andBool (#rangeUInt(256, VMemoryUsed)
+       andBool ((#rangeUInt(256, ABI_x +Int ABI_y)))))))
+
+
+    [trusted, matching(infGas)]
+
+
+    // Vat_mului
+    claim [Vat.mului.pass]:
+      <k> #execute ~> CONTINUATION => #execute ~> CONTINUATION </k>
+      <exit-code> 1 </exit-code>
+      <mode> NORMAL </mode>
+      <schedule> ISTANBUL </schedule>
+      <ethereum>
+        <evm>
+          <output> VOutput => VOutput </output>
+          <statusCode> _ => ?_ </statusCode>
+          <endPC> _ => ?_ </endPC>
+          <callStack> _VCallStack </callStack>
+          <interimStates> _ </interimStates>
+          <touchedAccounts> _ => ?_ </touchedAccounts>
+          <callState>
+            <program> Vat_bin_runtime </program>
+            <jumpDests> #computeValidJumpDests(Vat_bin_runtime) </jumpDests>
+            <id> ACCT_ID </id>
+            <caller> CALLER_ID </caller>
+            <callData> _ => ?_ </callData>
+            <callValue> VCallValue </callValue>
+            <wordStack> chop(ABI_y) : ABI_x : JMPTO : WS  =>  JMPTO : chop(ABI_x *Int ABI_y) : WS </wordStack>
+            <localMem> _ </localMem>
+            <pc> 13175 => 13233 </pc>
+            <gas> #gas(VGas) => #if ABI_y ==Int 0
+              #then   #gas ( ( VGas +Int -96 ) )
+              #else   #gas ( ( VGas +Int -132 ) )
+            #fi </gas>
+            <memoryUsed> VMemoryUsed </memoryUsed>
+            <callGas> _ => ?_ </callGas>
+            <static> _ </static>
+            <callDepth> VCallDepth </callDepth>
+          </callState>
+          <substate>
+            <selfDestruct> _VSelfDestruct </selfDestruct>
+            <log> _ => ?_ </log>
+            <refund> _Vrefund => ?_ </refund>
+          </substate>
+          <gasPrice> _ </gasPrice>
+          <origin> ORIGIN_ID </origin>
+          <blockhashes> _ </blockhashes>
+          <block>
+            <previousHash> _ </previousHash>
+            <ommersHash> _ </ommersHash>
+            <coinbase> _ </coinbase>
+            <stateRoot> _ </stateRoot>
+            <transactionsRoot> _ </transactionsRoot>
+            <receiptsRoot> _ </receiptsRoot>
+            <logsBloom> _ </logsBloom>
+            <difficulty> _ </difficulty>
+            <number> _BLOCK_NUMBER </number>
+            <gasLimit> _ </gasLimit>
+            <gasUsed> _ </gasUsed>
+            <timestamp> TIME </timestamp>
+            <extraData> _ </extraData>
+            <mixHash> _ </mixHash>
+            <blockNonce> _ </blockNonce>
+            <ommerBlockHeaders> _ </ommerBlockHeaders>
+          </block>
+        </evm>
+        <network>
+          <chainID> VChainId </chainID>
+          <activeAccounts> SetItem(ACCT_ID)
+          SetItem(1)
+          SetItem(2)
+          SetItem(3)
+          SetItem(4)
+          SetItem(5)
+          SetItem(6)
+          SetItem(7)
+          SetItem(8)
+          SetItem(9) _ </activeAccounts>
+          <accounts>
+            <account>
+              <acctID> ACCT_ID </acctID>
+              <balance> ACCT_ID_balance </balance>
+              <code> Vat_bin_runtime </code>
+              <storage> ACCT_ID_STORAGE => ACCT_ID_STORAGE  </storage>
+              <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
+              <nonce> _Nonce_Vat => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> 1 </acctID>
+              <balance> ECREC_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 2 </acctID>
+              <balance> SHA256_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 3 </acctID>
+              <balance> RIP160_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 4 </acctID>
+              <balance> ID_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 5 </acctID>
+              <balance> MODEXP_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 6 </acctID>
+              <balance> ECADD_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 7 </acctID>
+              <balance> ECMUL_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 8 </acctID>
+              <balance> ECPAIRING_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 9 </acctID>
+              <balance> BLAKE2_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+           ...
+          </accounts>
+          <txOrder> _ </txOrder>
+          <txPending> _ </txPending>
+          <messages> _ </messages>
+        </network>
+      </ethereum>
+      requires #rangeAddress(ACCT_ID)
+       andBool ACCT_ID =/=Int 0
+       andBool #notPrecompileAddress(ACCT_ID)
+       andBool #rangeAddress(CALLER_ID)
+       andBool #rangeAddress(ORIGIN_ID)
+       andBool #rangeUInt(256, TIME)
+       andBool #rangeUInt(256, ACCT_ID_balance)
+       andBool #rangeUInt(256, ECREC_BAL)
+       andBool #rangeUInt(256, SHA256_BAL)
+       andBool #rangeUInt(256, RIP160_BAL)
+       andBool #rangeUInt(256, ID_BAL)
+       andBool #rangeUInt(256, MODEXP_BAL)
+       andBool #rangeUInt(256, ECADD_BAL)
+       andBool #rangeUInt(256, ECMUL_BAL)
+       andBool #rangeUInt(256, ECPAIRING_BAL)
+       andBool #rangeUInt(256, BLAKE2_BAL)
+       andBool VCallDepth <=Int 1024
+       andBool #rangeUInt(256, VCallValue)
+       andBool #rangeUInt(256, VChainId)
+
+       andBool (#rangeUInt(256, ABI_x)
+       andBool (#rangeSInt(256, ABI_y)
+       andBool ((#sizeWordStack(WS) <=Int 1000)
+       andBool (#rangeUInt(256, VMemoryUsed)
+       andBool ((#rangeSInt(256, ABI_x))
+       andBool ((#rangeSInt(256, ABI_x *Int ABI_y))))))))
+
+
+    [trusted, matching(infGas)]
+
+
+endmodule

--- a/tests/specs/mcd/vat-fork-diff-pass-rough-spec.k
+++ b/tests/specs/mcd/vat-fork-diff-pass-rough-spec.k
@@ -1,0 +1,853 @@
+requires "verification.k"
+
+module VAT-FORK-DIFF-PASS-ROUGH-SPEC
+    imports VERIFICATION
+
+    // Vat_fork-diff
+    claim [Vat.fork-diff.pass.rough]:
+      <k> #execute ~> CONTINUATION => #halt ~> CONTINUATION </k>
+      <exit-code> 1 </exit-code>
+      <mode> NORMAL </mode>
+      <schedule> ISTANBUL </schedule>
+      <ethereum>
+        <evm>
+          <output> .ByteArray </output>
+          <statusCode> _ => EVMC_SUCCESS </statusCode>
+          <endPC> _ => ?_ </endPC>
+          <callStack> _VCallStack </callStack>
+          <interimStates> _ </interimStates>
+          <touchedAccounts> _ => ?_ </touchedAccounts>
+          <callState>
+            <program> Vat_bin_runtime </program>
+            <jumpDests> #computeValidJumpDests(Vat_bin_runtime) </jumpDests>
+            <id> ACCT_ID </id>
+            <caller> CALLER_ID </caller>
+            <callData> #abiCallData("fork", #bytes32(ABI_ilk), #address(ABI_src), #address(ABI_dst), #int256(ABI_dink), #int256(ABI_dart)) ++ CD => ?_ </callData>
+            <callValue> VCallValue </callValue>
+            <wordStack> .WordStack => ?_ </wordStack>
+            <localMem> .Memory => ?_ </localMem>
+            <pc> 0 => ?_ </pc>
+            <gas> #gas(VGas) => ?_ </gas>
+            <memoryUsed> 0 => ?_ </memoryUsed>
+            <callGas> _ => ?_ </callGas>
+            <static> false </static>
+            <callDepth> VCallDepth </callDepth>
+          </callState>
+          <substate>
+            <selfDestruct> _VSelfDestruct </selfDestruct>
+            <log> _ => ?_ </log>
+            <refund> _Vrefund => ?_ </refund>
+          </substate>
+          <gasPrice> _ </gasPrice>
+          <origin> ORIGIN_ID </origin>
+          <blockhashes> _ </blockhashes>
+          <block>
+            <previousHash> _ </previousHash>
+            <ommersHash> _ </ommersHash>
+            <coinbase> _ </coinbase>
+            <stateRoot> _ </stateRoot>
+            <transactionsRoot> _ </transactionsRoot>
+            <receiptsRoot> _ </receiptsRoot>
+            <logsBloom> _ </logsBloom>
+            <difficulty> _ </difficulty>
+            <number> _BLOCK_NUMBER </number>
+            <gasLimit> _ </gasLimit>
+            <gasUsed> _ </gasUsed>
+            <timestamp> TIME </timestamp>
+            <extraData> _ </extraData>
+            <mixHash> _ </mixHash>
+            <blockNonce> _ </blockNonce>
+            <ommerBlockHeaders> _ </ommerBlockHeaders>
+          </block>
+        </evm>
+        <network>
+          <chainID> VChainId </chainID>
+          <activeAccounts> SetItem(ACCT_ID)
+          SetItem(1)
+          SetItem(2)
+          SetItem(3)
+          SetItem(4)
+          SetItem(5)
+          SetItem(6)
+          SetItem(7)
+          SetItem(8)
+          SetItem(9) _ </activeAccounts>
+          <accounts>
+            <account>
+              <acctID> ACCT_ID </acctID>
+              <balance> ACCT_ID_balance </balance>
+              <code> Vat_bin_runtime </code>
+              <storage> ACCT_ID_STORAGE => ACCT_ID_STORAGE [ #Vat.urns[ABI_ilk][ABI_src].ink <- Ink_u -Int ABI_dink ] [ #Vat.urns[ABI_ilk][ABI_src].art <- Art_u -Int ABI_dart ] [ #Vat.urns[ABI_ilk][ABI_dst].ink <- Ink_v +Int ABI_dink ] [ #Vat.urns[ABI_ilk][ABI_dst].art <- Art_v +Int ABI_dart ] </storage>
+              <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
+              <nonce> _Nonce_Vat => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> 1 </acctID>
+              <balance> ECREC_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 2 </acctID>
+              <balance> SHA256_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 3 </acctID>
+              <balance> RIP160_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 4 </acctID>
+              <balance> ID_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 5 </acctID>
+              <balance> MODEXP_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 6 </acctID>
+              <balance> ECADD_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 7 </acctID>
+              <balance> ECMUL_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 8 </acctID>
+              <balance> ECPAIRING_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 9 </acctID>
+              <balance> BLAKE2_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+           ...
+          </accounts>
+          <txOrder> _ </txOrder>
+          <txPending> _ </txPending>
+          <messages> _ </messages>
+        </network>
+      </ethereum>
+      requires #rangeAddress(ACCT_ID)
+       andBool ACCT_ID =/=Int 0
+       andBool #notPrecompileAddress(ACCT_ID)
+       andBool #rangeAddress(CALLER_ID)
+       andBool #rangeAddress(ORIGIN_ID)
+       andBool #rangeUInt(256, TIME)
+       andBool #rangeUInt(256, ACCT_ID_balance)
+       andBool #rangeUInt(256, ECREC_BAL)
+       andBool #rangeUInt(256, SHA256_BAL)
+       andBool #rangeUInt(256, RIP160_BAL)
+       andBool #rangeUInt(256, ID_BAL)
+       andBool #rangeUInt(256, MODEXP_BAL)
+       andBool #rangeUInt(256, ECADD_BAL)
+       andBool #rangeUInt(256, ECMUL_BAL)
+       andBool #rangeUInt(256, ECPAIRING_BAL)
+       andBool #rangeUInt(256, BLAKE2_BAL)
+       andBool VCallDepth <=Int 1024
+       andBool #rangeUInt(256, VCallValue)
+       andBool #rangeUInt(256, VChainId)
+
+       andBool (#rangeBytes(32, ABI_ilk)
+       andBool (#rangeAddress(ABI_src)
+       andBool (#rangeAddress(ABI_dst)
+       andBool (#rangeSInt(256, ABI_dink)
+       andBool (#rangeSInt(256, ABI_dart)
+       andBool (#rangeUInt(256, Can_src)
+       andBool (#rangeUInt(256, Can_dst)
+       andBool (#rangeUInt(256, Rate)
+       andBool (#rangeUInt(256, Spot)
+       andBool (#rangeUInt(256, Dust)
+       andBool (#rangeUInt(256, Ink_u)
+       andBool (#rangeUInt(256, Art_u)
+       andBool (#rangeUInt(256, Ink_v)
+       andBool (#rangeUInt(256, Art_v)
+       andBool ((#sizeByteArray(CD) <=Int 1250000000)
+       andBool ((ABI_src =/=Int ABI_dst)
+       andBool (#rangeUInt(256, Junk_0)
+       andBool (#rangeUInt(256, Junk_1)
+       andBool (#rangeUInt(256, Junk_2)
+       andBool (#rangeUInt(256, Junk_3)
+       andBool (#rangeUInt(256, Junk_4)
+       andBool (#rangeUInt(256, Junk_5)
+       andBool (#rangeUInt(256, Junk_6)
+       andBool (#rangeUInt(256, Junk_7)
+       andBool (#rangeUInt(256, Junk_8)
+       andBool (((VCallValue ==Int 0))
+       andBool ((((ABI_src ==Int CALLER_ID) orBool (Can_src ==Int 1)))
+       andBool ((((ABI_dst ==Int CALLER_ID) orBool (Can_dst ==Int 1)))
+       andBool ((((Art_u -Int ABI_dart) *Int Rate <=Int (Ink_u -Int ABI_dink) *Int Spot))
+       andBool ((((Art_v +Int ABI_dart) *Int Rate <=Int (Ink_v +Int ABI_dink) *Int Spot))
+       andBool (((((Art_u -Int ABI_dart) *Int Rate >=Int Dust) orBool (Art_u -Int ABI_dart ==Int 0)))
+       andBool (((((Art_v +Int ABI_dart) *Int Rate >=Int Dust) orBool (Art_v +Int ABI_dart ==Int 0)))
+       andBool ((#rangeUInt(256, Ink_u -Int ABI_dink))
+       andBool ((#rangeUInt(256, Ink_v +Int ABI_dink))
+       andBool ((#rangeUInt(256, Art_u -Int ABI_dart))
+       andBool ((#rangeUInt(256, Art_v +Int ABI_dart))
+       andBool ((#rangeUInt(256, (Ink_u -Int ABI_dink) *Int Spot))
+       andBool ((#rangeUInt(256, (Ink_v +Int ABI_dink) *Int Spot))))))))))))))))))))))))))))))))))))))))
+
+       andBool #lookup(ACCT_ID_STORAGE, #Vat.can[ABI_src][CALLER_ID]) ==Int Can_src
+       andBool #lookup(ACCT_ID_STORAGE, #Vat.can[ABI_dst][CALLER_ID]) ==Int Can_dst
+       andBool #lookup(ACCT_ID_STORAGE, #Vat.ilks[ABI_ilk].rate) ==Int Rate
+       andBool #lookup(ACCT_ID_STORAGE, #Vat.ilks[ABI_ilk].spot) ==Int Spot
+       andBool #lookup(ACCT_ID_STORAGE, #Vat.ilks[ABI_ilk].dust) ==Int Dust
+       andBool #lookup(ACCT_ID_STORAGE, #Vat.urns[ABI_ilk][ABI_src].ink) ==Int Ink_u
+       andBool #lookup(ACCT_ID_STORAGE, #Vat.urns[ABI_ilk][ABI_src].art) ==Int Art_u
+       andBool #lookup(ACCT_ID_STORAGE, #Vat.urns[ABI_ilk][ABI_dst].ink) ==Int Ink_v
+       andBool #lookup(ACCT_ID_STORAGE, #Vat.urns[ABI_ilk][ABI_dst].art) ==Int Art_v
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Vat.can[ABI_src][CALLER_ID]) ==Int Junk_0
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Vat.can[ABI_dst][CALLER_ID]) ==Int Junk_1
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Vat.ilks[ABI_ilk].rate) ==Int Junk_2
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Vat.ilks[ABI_ilk].spot) ==Int Junk_3
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Vat.ilks[ABI_ilk].dust) ==Int Junk_4
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Vat.urns[ABI_ilk][ABI_src].ink) ==Int Junk_5
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Vat.urns[ABI_ilk][ABI_src].art) ==Int Junk_6
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Vat.urns[ABI_ilk][ABI_dst].ink) ==Int Junk_7
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Vat.urns[ABI_ilk][ABI_dst].art) ==Int Junk_8
+       andBool #Vat.can[ABI_src][CALLER_ID] =/=Int #Vat.can[ABI_dst][CALLER_ID]
+       andBool #Vat.can[ABI_src][CALLER_ID] =/=Int #Vat.ilks[ABI_ilk].rate
+       andBool #Vat.can[ABI_src][CALLER_ID] =/=Int #Vat.ilks[ABI_ilk].spot
+       andBool #Vat.can[ABI_src][CALLER_ID] =/=Int #Vat.ilks[ABI_ilk].dust
+       andBool #Vat.can[ABI_src][CALLER_ID] =/=Int #Vat.urns[ABI_ilk][ABI_src].ink
+       andBool #Vat.can[ABI_src][CALLER_ID] =/=Int #Vat.urns[ABI_ilk][ABI_src].art
+       andBool #Vat.can[ABI_src][CALLER_ID] =/=Int #Vat.urns[ABI_ilk][ABI_dst].ink
+       andBool #Vat.can[ABI_src][CALLER_ID] =/=Int #Vat.urns[ABI_ilk][ABI_dst].art
+       andBool #Vat.can[ABI_dst][CALLER_ID] =/=Int #Vat.ilks[ABI_ilk].rate
+       andBool #Vat.can[ABI_dst][CALLER_ID] =/=Int #Vat.ilks[ABI_ilk].spot
+       andBool #Vat.can[ABI_dst][CALLER_ID] =/=Int #Vat.ilks[ABI_ilk].dust
+       andBool #Vat.can[ABI_dst][CALLER_ID] =/=Int #Vat.urns[ABI_ilk][ABI_src].ink
+       andBool #Vat.can[ABI_dst][CALLER_ID] =/=Int #Vat.urns[ABI_ilk][ABI_src].art
+       andBool #Vat.can[ABI_dst][CALLER_ID] =/=Int #Vat.urns[ABI_ilk][ABI_dst].ink
+       andBool #Vat.can[ABI_dst][CALLER_ID] =/=Int #Vat.urns[ABI_ilk][ABI_dst].art
+       andBool #Vat.ilks[ABI_ilk].rate =/=Int #Vat.ilks[ABI_ilk].spot
+       andBool #Vat.ilks[ABI_ilk].rate =/=Int #Vat.ilks[ABI_ilk].dust
+       andBool #Vat.ilks[ABI_ilk].rate =/=Int #Vat.urns[ABI_ilk][ABI_src].ink
+       andBool #Vat.ilks[ABI_ilk].rate =/=Int #Vat.urns[ABI_ilk][ABI_src].art
+       andBool #Vat.ilks[ABI_ilk].rate =/=Int #Vat.urns[ABI_ilk][ABI_dst].ink
+       andBool #Vat.ilks[ABI_ilk].rate =/=Int #Vat.urns[ABI_ilk][ABI_dst].art
+       andBool #Vat.ilks[ABI_ilk].spot =/=Int #Vat.ilks[ABI_ilk].dust
+       andBool #Vat.ilks[ABI_ilk].spot =/=Int #Vat.urns[ABI_ilk][ABI_src].ink
+       andBool #Vat.ilks[ABI_ilk].spot =/=Int #Vat.urns[ABI_ilk][ABI_src].art
+       andBool #Vat.ilks[ABI_ilk].spot =/=Int #Vat.urns[ABI_ilk][ABI_dst].ink
+       andBool #Vat.ilks[ABI_ilk].spot =/=Int #Vat.urns[ABI_ilk][ABI_dst].art
+       andBool #Vat.ilks[ABI_ilk].dust =/=Int #Vat.urns[ABI_ilk][ABI_src].ink
+       andBool #Vat.ilks[ABI_ilk].dust =/=Int #Vat.urns[ABI_ilk][ABI_src].art
+       andBool #Vat.ilks[ABI_ilk].dust =/=Int #Vat.urns[ABI_ilk][ABI_dst].ink
+       andBool #Vat.ilks[ABI_ilk].dust =/=Int #Vat.urns[ABI_ilk][ABI_dst].art
+       andBool #Vat.urns[ABI_ilk][ABI_src].ink =/=Int #Vat.urns[ABI_ilk][ABI_src].art
+       andBool #Vat.urns[ABI_ilk][ABI_src].ink =/=Int #Vat.urns[ABI_ilk][ABI_dst].ink
+       andBool #Vat.urns[ABI_ilk][ABI_src].ink =/=Int #Vat.urns[ABI_ilk][ABI_dst].art
+       andBool #Vat.urns[ABI_ilk][ABI_src].art =/=Int #Vat.urns[ABI_ilk][ABI_dst].ink
+       andBool #Vat.urns[ABI_ilk][ABI_src].art =/=Int #Vat.urns[ABI_ilk][ABI_dst].art
+       andBool #Vat.urns[ABI_ilk][ABI_dst].ink =/=Int #Vat.urns[ABI_ilk][ABI_dst].art
+
+    // Vat_addui
+    claim [Vat.addui.pass]:
+      <k> #execute ~> CONTINUATION => #execute ~> CONTINUATION </k>
+      <exit-code> 1 </exit-code>
+      <mode> NORMAL </mode>
+      <schedule> ISTANBUL </schedule>
+      <ethereum>
+        <evm>
+          <output> VOutput => VOutput </output>
+          <statusCode> _ => ?_ </statusCode>
+          <endPC> _ => ?_ </endPC>
+          <callStack> _VCallStack </callStack>
+          <interimStates> _ </interimStates>
+          <touchedAccounts> _ => ?_ </touchedAccounts>
+          <callState>
+            <program> Vat_bin_runtime </program>
+            <jumpDests> #computeValidJumpDests(Vat_bin_runtime) </jumpDests>
+            <id> ACCT_ID </id>
+            <caller> CALLER_ID </caller>
+            <callData> _ => ?_ </callData>
+            <callValue> VCallValue </callValue>
+            <wordStack> chop(ABI_y) : ABI_x : JMPTO : WS  =>  JMPTO : ABI_x +Int ABI_y : WS </wordStack>
+            <localMem> _ </localMem>
+            <pc> 13112 => 13174 </pc>
+            <gas> #gas(VGas) => #if ( ABI_y <Int 0 andBool 0 <=Int ( ABI_x +Int ABI_y ) )
+              #then   #gas ( ( VGas +Int -128 ) )
+              #else   #if chop( ABI_y ) <=Int 0
+                #then   #gas ( ( VGas +Int -114 ) )
+                #else   #gas ( ( VGas +Int -128 ) )
+              #fi
+            #fi </gas>
+            <memoryUsed> VMemoryUsed </memoryUsed>
+            <callGas> _ => ?_ </callGas>
+            <static> _ </static>
+            <callDepth> VCallDepth </callDepth>
+          </callState>
+          <substate>
+            <selfDestruct> _VSelfDestruct </selfDestruct>
+            <log> _ => ?_ </log>
+            <refund> _Vrefund => ?_ </refund>
+          </substate>
+          <gasPrice> _ </gasPrice>
+          <origin> ORIGIN_ID </origin>
+          <blockhashes> _ </blockhashes>
+          <block>
+            <previousHash> _ </previousHash>
+            <ommersHash> _ </ommersHash>
+            <coinbase> _ </coinbase>
+            <stateRoot> _ </stateRoot>
+            <transactionsRoot> _ </transactionsRoot>
+            <receiptsRoot> _ </receiptsRoot>
+            <logsBloom> _ </logsBloom>
+            <difficulty> _ </difficulty>
+            <number> _BLOCK_NUMBER </number>
+            <gasLimit> _ </gasLimit>
+            <gasUsed> _ </gasUsed>
+            <timestamp> TIME </timestamp>
+            <extraData> _ </extraData>
+            <mixHash> _ </mixHash>
+            <blockNonce> _ </blockNonce>
+            <ommerBlockHeaders> _ </ommerBlockHeaders>
+          </block>
+        </evm>
+        <network>
+          <chainID> VChainId </chainID>
+          <activeAccounts> SetItem(ACCT_ID)
+          SetItem(1)
+          SetItem(2)
+          SetItem(3)
+          SetItem(4)
+          SetItem(5)
+          SetItem(6)
+          SetItem(7)
+          SetItem(8)
+          SetItem(9) _ </activeAccounts>
+          <accounts>
+            <account>
+              <acctID> ACCT_ID </acctID>
+              <balance> ACCT_ID_balance </balance>
+              <code> Vat_bin_runtime </code>
+              <storage> ACCT_ID_STORAGE => ACCT_ID_STORAGE  </storage>
+              <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
+              <nonce> _Nonce_Vat => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> 1 </acctID>
+              <balance> ECREC_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 2 </acctID>
+              <balance> SHA256_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 3 </acctID>
+              <balance> RIP160_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 4 </acctID>
+              <balance> ID_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 5 </acctID>
+              <balance> MODEXP_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 6 </acctID>
+              <balance> ECADD_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 7 </acctID>
+              <balance> ECMUL_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 8 </acctID>
+              <balance> ECPAIRING_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 9 </acctID>
+              <balance> BLAKE2_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+           ...
+          </accounts>
+          <txOrder> _ </txOrder>
+          <txPending> _ </txPending>
+          <messages> _ </messages>
+        </network>
+      </ethereum>
+      requires #rangeAddress(ACCT_ID)
+       andBool ACCT_ID =/=Int 0
+       andBool #notPrecompileAddress(ACCT_ID)
+       andBool #rangeAddress(CALLER_ID)
+       andBool #rangeAddress(ORIGIN_ID)
+       andBool #rangeUInt(256, TIME)
+       andBool #rangeUInt(256, ACCT_ID_balance)
+       andBool #rangeUInt(256, ECREC_BAL)
+       andBool #rangeUInt(256, SHA256_BAL)
+       andBool #rangeUInt(256, RIP160_BAL)
+       andBool #rangeUInt(256, ID_BAL)
+       andBool #rangeUInt(256, MODEXP_BAL)
+       andBool #rangeUInt(256, ECADD_BAL)
+       andBool #rangeUInt(256, ECMUL_BAL)
+       andBool #rangeUInt(256, ECPAIRING_BAL)
+       andBool #rangeUInt(256, BLAKE2_BAL)
+       andBool VCallDepth <=Int 1024
+       andBool #rangeUInt(256, VCallValue)
+       andBool #rangeUInt(256, VChainId)
+
+       andBool (#rangeUInt(256, ABI_x)
+       andBool (#rangeSInt(256, ABI_y)
+       andBool ((#sizeWordStack(WS) <=Int 1015)
+       andBool (#rangeUInt(256, VMemoryUsed)
+       andBool ((#rangeUInt(256, ABI_x +Int ABI_y)))))))
+
+
+    [trusted, matching(infGas)]
+
+
+    // Vat_subui
+    claim [Vat.subui.pass]:
+      <k> #execute ~> CONTINUATION => #execute ~> CONTINUATION </k>
+      <exit-code> 1 </exit-code>
+      <mode> NORMAL </mode>
+      <schedule> ISTANBUL </schedule>
+      <ethereum>
+        <evm>
+          <output> VOutput => VOutput </output>
+          <statusCode> _ => ?_ </statusCode>
+          <endPC> _ => ?_ </endPC>
+          <callStack> _VCallStack </callStack>
+          <interimStates> _ </interimStates>
+          <touchedAccounts> _ => ?_ </touchedAccounts>
+          <callState>
+            <program> Vat_bin_runtime </program>
+            <jumpDests> #computeValidJumpDests(Vat_bin_runtime) </jumpDests>
+            <id> ACCT_ID </id>
+            <caller> CALLER_ID </caller>
+            <callData> _ => ?_ </callData>
+            <callValue> VCallValue </callValue>
+            <wordStack> chop(ABI_y) : ABI_x : JMPTO : WS  =>  JMPTO : ABI_x -Int ABI_y : WS </wordStack>
+            <localMem> _ </localMem>
+            <pc> 13304 => 13366 </pc>
+            <gas> #gas(VGas) => #if ( ABI_y =/=Int 0 andBool 0 <=Int ABI_y )
+              #then   #gas ( ( VGas +Int -128 ) )
+              #else   #if 0 <=Int ABI_y
+                #then   #gas ( ( VGas +Int -114 ) )
+                #else   #gas ( ( VGas +Int -128 ) )
+              #fi
+            #fi </gas>
+            <memoryUsed> VMemoryUsed </memoryUsed>
+            <callGas> _ => ?_ </callGas>
+            <static> _ </static>
+            <callDepth> VCallDepth </callDepth>
+          </callState>
+          <substate>
+            <selfDestruct> _VSelfDestruct </selfDestruct>
+            <log> _ => ?_ </log>
+            <refund> _Vrefund => ?_ </refund>
+          </substate>
+          <gasPrice> _ </gasPrice>
+          <origin> ORIGIN_ID </origin>
+          <blockhashes> _ </blockhashes>
+          <block>
+            <previousHash> _ </previousHash>
+            <ommersHash> _ </ommersHash>
+            <coinbase> _ </coinbase>
+            <stateRoot> _ </stateRoot>
+            <transactionsRoot> _ </transactionsRoot>
+            <receiptsRoot> _ </receiptsRoot>
+            <logsBloom> _ </logsBloom>
+            <difficulty> _ </difficulty>
+            <number> _BLOCK_NUMBER </number>
+            <gasLimit> _ </gasLimit>
+            <gasUsed> _ </gasUsed>
+            <timestamp> TIME </timestamp>
+            <extraData> _ </extraData>
+            <mixHash> _ </mixHash>
+            <blockNonce> _ </blockNonce>
+            <ommerBlockHeaders> _ </ommerBlockHeaders>
+          </block>
+        </evm>
+        <network>
+          <chainID> VChainId </chainID>
+          <activeAccounts> SetItem(ACCT_ID)
+          SetItem(1)
+          SetItem(2)
+          SetItem(3)
+          SetItem(4)
+          SetItem(5)
+          SetItem(6)
+          SetItem(7)
+          SetItem(8)
+          SetItem(9) _ </activeAccounts>
+          <accounts>
+            <account>
+              <acctID> ACCT_ID </acctID>
+              <balance> ACCT_ID_balance </balance>
+              <code> Vat_bin_runtime </code>
+              <storage> ACCT_ID_STORAGE => ACCT_ID_STORAGE  </storage>
+              <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
+              <nonce> _Nonce_Vat => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> 1 </acctID>
+              <balance> ECREC_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 2 </acctID>
+              <balance> SHA256_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 3 </acctID>
+              <balance> RIP160_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 4 </acctID>
+              <balance> ID_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 5 </acctID>
+              <balance> MODEXP_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 6 </acctID>
+              <balance> ECADD_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 7 </acctID>
+              <balance> ECMUL_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 8 </acctID>
+              <balance> ECPAIRING_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 9 </acctID>
+              <balance> BLAKE2_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+           ...
+          </accounts>
+          <txOrder> _ </txOrder>
+          <txPending> _ </txPending>
+          <messages> _ </messages>
+        </network>
+      </ethereum>
+      requires #rangeAddress(ACCT_ID)
+       andBool ACCT_ID =/=Int 0
+       andBool #notPrecompileAddress(ACCT_ID)
+       andBool #rangeAddress(CALLER_ID)
+       andBool #rangeAddress(ORIGIN_ID)
+       andBool #rangeUInt(256, TIME)
+       andBool #rangeUInt(256, ACCT_ID_balance)
+       andBool #rangeUInt(256, ECREC_BAL)
+       andBool #rangeUInt(256, SHA256_BAL)
+       andBool #rangeUInt(256, RIP160_BAL)
+       andBool #rangeUInt(256, ID_BAL)
+       andBool #rangeUInt(256, MODEXP_BAL)
+       andBool #rangeUInt(256, ECADD_BAL)
+       andBool #rangeUInt(256, ECMUL_BAL)
+       andBool #rangeUInt(256, ECPAIRING_BAL)
+       andBool #rangeUInt(256, BLAKE2_BAL)
+       andBool VCallDepth <=Int 1024
+       andBool #rangeUInt(256, VCallValue)
+       andBool #rangeUInt(256, VChainId)
+
+       andBool (#rangeUInt(256, ABI_x)
+       andBool (#rangeSInt(256, ABI_y)
+       andBool ((#sizeWordStack(WS) <=Int 1015)
+       andBool (#rangeUInt(256, VMemoryUsed)
+       andBool ((#rangeUInt(256, ABI_x -Int ABI_y)))))))
+
+
+    [trusted, matching(infGas)]
+
+
+    // Vat_muluu
+    claim [Vat.muluu.pass]:
+      <k> #execute ~> CONTINUATION => #execute ~> CONTINUATION </k>
+      <exit-code> 1 </exit-code>
+      <mode> NORMAL </mode>
+      <schedule> ISTANBUL </schedule>
+      <ethereum>
+        <evm>
+          <output> VOutput => VOutput </output>
+          <statusCode> _ => ?_ </statusCode>
+          <endPC> _ => ?_ </endPC>
+          <callStack> _VCallStack </callStack>
+          <interimStates> _ </interimStates>
+          <touchedAccounts> _ => ?_ </touchedAccounts>
+          <callState>
+            <program> Vat_bin_runtime </program>
+            <jumpDests> #computeValidJumpDests(Vat_bin_runtime) </jumpDests>
+            <id> ACCT_ID </id>
+            <caller> CALLER_ID </caller>
+            <callData> _ => ?_ </callData>
+            <callValue> VCallValue </callValue>
+            <wordStack> ABI_y : ABI_x : JMPTO : WS  =>  JMPTO : ABI_x *Int ABI_y : WS </wordStack>
+            <localMem> _ </localMem>
+            <pc> 13234 => 13277 </pc>
+            <gas> #gas(VGas) => #if ABI_y ==Int 0
+              #then   #gas ( ( VGas +Int -54 ) )
+              #else   #gas ( ( VGas +Int -106 ) )
+            #fi </gas>
+            <memoryUsed> VMemoryUsed </memoryUsed>
+            <callGas> _ => ?_ </callGas>
+            <static> _ </static>
+            <callDepth> VCallDepth </callDepth>
+          </callState>
+          <substate>
+            <selfDestruct> _VSelfDestruct </selfDestruct>
+            <log> _ => ?_ </log>
+            <refund> _Vrefund => ?_ </refund>
+          </substate>
+          <gasPrice> _ </gasPrice>
+          <origin> ORIGIN_ID </origin>
+          <blockhashes> _ </blockhashes>
+          <block>
+            <previousHash> _ </previousHash>
+            <ommersHash> _ </ommersHash>
+            <coinbase> _ </coinbase>
+            <stateRoot> _ </stateRoot>
+            <transactionsRoot> _ </transactionsRoot>
+            <receiptsRoot> _ </receiptsRoot>
+            <logsBloom> _ </logsBloom>
+            <difficulty> _ </difficulty>
+            <number> _BLOCK_NUMBER </number>
+            <gasLimit> _ </gasLimit>
+            <gasUsed> _ </gasUsed>
+            <timestamp> TIME </timestamp>
+            <extraData> _ </extraData>
+            <mixHash> _ </mixHash>
+            <blockNonce> _ </blockNonce>
+            <ommerBlockHeaders> _ </ommerBlockHeaders>
+          </block>
+        </evm>
+        <network>
+          <chainID> VChainId </chainID>
+          <activeAccounts> SetItem(ACCT_ID)
+          SetItem(1)
+          SetItem(2)
+          SetItem(3)
+          SetItem(4)
+          SetItem(5)
+          SetItem(6)
+          SetItem(7)
+          SetItem(8)
+          SetItem(9) _ </activeAccounts>
+          <accounts>
+            <account>
+              <acctID> ACCT_ID </acctID>
+              <balance> ACCT_ID_balance </balance>
+              <code> Vat_bin_runtime </code>
+              <storage> ACCT_ID_STORAGE => ACCT_ID_STORAGE  </storage>
+              <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
+              <nonce> _Nonce_Vat => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> 1 </acctID>
+              <balance> ECREC_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 2 </acctID>
+              <balance> SHA256_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 3 </acctID>
+              <balance> RIP160_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 4 </acctID>
+              <balance> ID_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 5 </acctID>
+              <balance> MODEXP_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 6 </acctID>
+              <balance> ECADD_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 7 </acctID>
+              <balance> ECMUL_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 8 </acctID>
+              <balance> ECPAIRING_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 9 </acctID>
+              <balance> BLAKE2_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+           ...
+          </accounts>
+          <txOrder> _ </txOrder>
+          <txPending> _ </txPending>
+          <messages> _ </messages>
+        </network>
+      </ethereum>
+      requires #rangeAddress(ACCT_ID)
+       andBool ACCT_ID =/=Int 0
+       andBool #notPrecompileAddress(ACCT_ID)
+       andBool #rangeAddress(CALLER_ID)
+       andBool #rangeAddress(ORIGIN_ID)
+       andBool #rangeUInt(256, TIME)
+       andBool #rangeUInt(256, ACCT_ID_balance)
+       andBool #rangeUInt(256, ECREC_BAL)
+       andBool #rangeUInt(256, SHA256_BAL)
+       andBool #rangeUInt(256, RIP160_BAL)
+       andBool #rangeUInt(256, ID_BAL)
+       andBool #rangeUInt(256, MODEXP_BAL)
+       andBool #rangeUInt(256, ECADD_BAL)
+       andBool #rangeUInt(256, ECMUL_BAL)
+       andBool #rangeUInt(256, ECPAIRING_BAL)
+       andBool #rangeUInt(256, BLAKE2_BAL)
+       andBool VCallDepth <=Int 1024
+       andBool #rangeUInt(256, VCallValue)
+       andBool #rangeUInt(256, VChainId)
+
+       andBool (#rangeUInt(256, ABI_x)
+       andBool (#rangeUInt(256, ABI_y)
+       andBool ((#sizeWordStack(WS) <=Int 1000)
+       andBool (#rangeUInt(256, VMemoryUsed)
+       andBool ((#rangeUInt(256, ABI_x *Int ABI_y)))))))
+
+
+    [trusted, matching(infGas)]
+
+
+endmodule

--- a/tests/specs/mcd/verification.k
+++ b/tests/specs/mcd/verification.k
@@ -420,4 +420,8 @@ module VERIFICATION-COMMON
     rule chop(X +Int pow256)  => chop(X)        [simplification]
     rule chop(chop(X) *Int Y) => chop(X *Int Y) [simplification]
 
+    // ### vow-cage-deficit-pass-rough
+
+    rule (I1 +Int I2) -Int I1 => I2 [simplification]
+
 endmodule

--- a/tests/specs/mcd/verification.k
+++ b/tests/specs/mcd/verification.k
@@ -413,7 +413,8 @@ module VERIFICATION-COMMON
 
     // ### vat-frob-diff-zero-dart-pass-rough
 
-    rule chop(X) => X +Int pow256 requires #rangeSInt(256, X) andBool X <Int 0 [simplification]
+    rule chop( X -Int chop(Y))         => chop( X -Int Y)         [simplification]
+    rule chop((X -Int chop(Y)) *Int Z) => chop((X -Int Y) *Int Z) [simplification]
 
     // ### vat-fork-diff-pass-rough
 
@@ -429,5 +430,9 @@ module VERIFICATION-COMMON
     rule ((I1 -Int I2) -Int I3) +Int I2 => I1 -Int I3 [simplification]
 
     rule M:Map [ K1 <- V1 ] [ K2 <- V2 ] [ K3 <- V3 ] [ K1 <- V4 ] => M [ K1 <- V4 ] [ K2 <- V2 ] [ K3 <- V3 ] requires K1 =/=Int K2 andBool K1 =/=Int K3 [simplification]
+
+    // ### vat-fold-pass-rough
+
+    rule chop(X *Int (Y +Int pow256)) => chop(X *Int Y) [simplification]
 
 endmodule

--- a/tests/specs/mcd/verification.k
+++ b/tests/specs/mcd/verification.k
@@ -186,7 +186,7 @@ module VERIFICATION-COMMON
     //      chop(X *Int Y) /sWord chop(Y)
     //   => #sgnInterp(sgn(chop(X *Int Y)) *Int sgn(chop(Y)), abs(chop(X *Int Y)) /Word abs(chop(Y)))
     // Focus: sgn(chop(X *Int Y)) *Int sgn(chop(Y))
-    //      case 0 <=Int chop(Y)
+    //      case 0 <=Int Y
     //           sgn(chop(X *Int Y)) *Int sgn(chop(Y))
     //        => sgn(chop(X *Int Y)) *Int sgn(Y)                     // chop(Y) ==Int Y
     //        => sgn(X *Int Y) *Int sgn(Y)                           // 0 <=Int X andBool 0 <=Int Y
@@ -399,7 +399,7 @@ module VERIFICATION-COMMON
 
     rule M:Map [ K1 <- V1 ] [ K2 <- V2 ] [ K1 <- V1' ] => M [ K1 <- V1' ] [ K2 <- V2 ] requires K1 =/=Int K2 [simplification]
 
-    // end-cage-ilk-pass-rough
+    // ### end-cage-ilk-pass-rough
 
     rule M:Memory [ K1 := BUF1 ] [ K2 := BUF2 ] => M [ K2 := BUF2 ]
       requires K2 <=Int K1

--- a/tests/specs/mcd/verification.k
+++ b/tests/specs/mcd/verification.k
@@ -415,4 +415,9 @@ module VERIFICATION-COMMON
 
     rule chop(X) => X +Int pow256 requires #rangeSInt(256, X) andBool X <Int 0 [simplification]
 
+    // ### vat-fork-diff-pass-rough
+
+    rule chop(X +Int pow256)  => chop(X)        [simplification]
+    rule chop(chop(X) *Int Y) => chop(X *Int Y) [simplification]
+
 endmodule

--- a/tests/specs/mcd/verification.k
+++ b/tests/specs/mcd/verification.k
@@ -424,4 +424,10 @@ module VERIFICATION-COMMON
 
     rule (I1 +Int I2) -Int I1 => I2 [simplification]
 
+    // ### flapper-tend-guy-diff-pass-rough
+
+    rule ((I1 -Int I2) -Int I3) +Int I2 => I1 -Int I3 [simplification]
+
+    rule M:Map [ K1 <- V1 ] [ K2 <- V2 ] [ K3 <- V3 ] [ K1 <- V4 ] => M [ K1 <- V4 ] [ K2 <- V2 ] [ K3 <- V3 ] requires K1 =/=Int K2 andBool K1 =/=Int K3 [simplification]
+
 endmodule

--- a/tests/specs/mcd/vow-cage-deficit-pass-rough-spec.k
+++ b/tests/specs/mcd/vow-cage-deficit-pass-rough-spec.k
@@ -1,0 +1,1566 @@
+requires "verification.k"
+
+module VOW-CAGE-DEFICIT-PASS-ROUGH-SPEC
+    imports VERIFICATION
+
+    // Vow_cage-deficit
+    claim [Vow.cage-deficit.pass.rough]:
+      <k> #execute ~> CONTINUATION => #halt ~> CONTINUATION </k>
+      <exit-code> 1 </exit-code>
+      <mode> NORMAL </mode>
+      <schedule> ISTANBUL </schedule>
+      <ethereum>
+        <evm>
+          <output> .ByteArray </output>
+          <statusCode> _ => EVMC_SUCCESS </statusCode>
+          <endPC> _ => ?_ </endPC>
+          <callStack> _VCallStack </callStack>
+          <interimStates> _ </interimStates>
+          <touchedAccounts> _ => ?_ </touchedAccounts>
+          <callState>
+            <program> Vow_bin_runtime </program>
+            <jumpDests> #computeValidJumpDests(Vow_bin_runtime) </jumpDests>
+            <id> ACCT_ID </id>
+            <caller> CALLER_ID </caller>
+            <callData> #abiCallData("cage", .TypedArgs) ++ CD => ?_ </callData>
+            <callValue> VCallValue </callValue>
+            <wordStack> .WordStack => ?_ </wordStack>
+            <localMem> .Memory => ?_ </localMem>
+            <pc> 0 => ?_ </pc>
+            <gas> #gas(VGas) => ?_ </gas>
+            <memoryUsed> 0 => ?_ </memoryUsed>
+            <callGas> _ => ?_ </callGas>
+            <static> false </static>
+            <callDepth> VCallDepth </callDepth>
+          </callState>
+          <substate>
+            <selfDestruct> _VSelfDestruct </selfDestruct>
+            <log> _ => ?_ </log>
+            <refund> _Vrefund => ?_ </refund>
+          </substate>
+          <gasPrice> _ </gasPrice>
+          <origin> ORIGIN_ID </origin>
+          <blockhashes> _ </blockhashes>
+          <block>
+            <previousHash> _ </previousHash>
+            <ommersHash> _ </ommersHash>
+            <coinbase> _ </coinbase>
+            <stateRoot> _ </stateRoot>
+            <transactionsRoot> _ </transactionsRoot>
+            <receiptsRoot> _ </receiptsRoot>
+            <logsBloom> _ </logsBloom>
+            <difficulty> _ </difficulty>
+            <number> _BLOCK_NUMBER </number>
+            <gasLimit> _ </gasLimit>
+            <gasUsed> _ </gasUsed>
+            <timestamp> TIME </timestamp>
+            <extraData> _ </extraData>
+            <mixHash> _ </mixHash>
+            <blockNonce> _ </blockNonce>
+            <ommerBlockHeaders> _ </ommerBlockHeaders>
+          </block>
+        </evm>
+        <network>
+          <chainID> VChainId </chainID>
+          <activeAccounts> SetItem(ACCT_ID)
+          SetItem(Vat)
+          SetItem(Flapper)
+          SetItem(Flopper)
+          SetItem(1)
+          SetItem(2)
+          SetItem(3)
+          SetItem(4)
+          SetItem(5)
+          SetItem(6)
+          SetItem(7)
+          SetItem(8)
+          SetItem(9) _ </activeAccounts>
+          <accounts>
+            <account>
+              <acctID> ACCT_ID </acctID>
+              <balance> ACCT_ID_balance </balance>
+              <code> Vow_bin_runtime </code>
+              <storage> ACCT_ID_STORAGE => ACCT_ID_STORAGE [ #Vow.live <- 0 ] [ #Vow.Sin <- 0 ] [ #Vow.Ash <- 0 ] </storage>
+              <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
+              <nonce> _Nonce_Vow => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> Vat </acctID>
+              <balance> Vat_balance </balance>
+              <code> Vat_bin_runtime </code>
+              <storage> Vat_STORAGE => Vat_STORAGE [ #Vat.dai[Flapper] <- 0 ] [ #Vat.dai[ACCT_ID] <- 0 ] [ #Vat.sin[ACCT_ID] <- Sin_v -Int (Dai_v +Int Dai_f) ] [ #Vat.vice <- Vice -Int (Dai_v +Int Dai_f) ] [ #Vat.debt <- Debt -Int (Dai_v +Int Dai_f) ] </storage>
+              <origStorage> Vat_ORIG_STORAGE </origStorage>
+              <nonce> _Nonce_Vat => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> Flapper </acctID>
+              <balance> Flapper_balance </balance>
+              <code> Flapper_bin_runtime </code>
+              <storage> Flapper_STORAGE => Flapper_STORAGE [ #Flapper.live <- 0 ] </storage>
+              <origStorage> Flapper_ORIG_STORAGE </origStorage>
+              <nonce> _Nonce_Flapper => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> Flopper </acctID>
+              <balance> Flopper_balance </balance>
+              <code> Flopper_bin_runtime </code>
+              <storage> Flopper_STORAGE => Flopper_STORAGE [ #Flopper.live <- 0 ] [ #Flopper.vow <- ACCT_ID ] </storage>
+              <origStorage> Flopper_ORIG_STORAGE </origStorage>
+              <nonce> _Nonce_Flopper => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> 1 </acctID>
+              <balance> ECREC_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 2 </acctID>
+              <balance> SHA256_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 3 </acctID>
+              <balance> RIP160_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 4 </acctID>
+              <balance> ID_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 5 </acctID>
+              <balance> MODEXP_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 6 </acctID>
+              <balance> ECADD_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 7 </acctID>
+              <balance> ECMUL_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 8 </acctID>
+              <balance> ECPAIRING_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 9 </acctID>
+              <balance> BLAKE2_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+           ...
+          </accounts>
+          <txOrder> _ </txOrder>
+          <txPending> _ </txPending>
+          <messages> _ </messages>
+        </network>
+      </ethereum>
+      requires #rangeAddress(ACCT_ID)
+       andBool ACCT_ID =/=Int 0
+       andBool #notPrecompileAddress(ACCT_ID)
+       andBool #rangeAddress(CALLER_ID)
+       andBool #rangeAddress(ORIGIN_ID)
+       andBool #rangeUInt(256, TIME)
+       andBool #rangeUInt(256, ACCT_ID_balance)
+       andBool #rangeUInt(256, ECREC_BAL)
+       andBool #rangeUInt(256, SHA256_BAL)
+       andBool #rangeUInt(256, RIP160_BAL)
+       andBool #rangeUInt(256, ID_BAL)
+       andBool #rangeUInt(256, MODEXP_BAL)
+       andBool #rangeUInt(256, ECADD_BAL)
+       andBool #rangeUInt(256, ECMUL_BAL)
+       andBool #rangeUInt(256, ECPAIRING_BAL)
+       andBool #rangeUInt(256, BLAKE2_BAL)
+       andBool VCallDepth <=Int 1024
+       andBool #rangeUInt(256, VCallValue)
+       andBool #rangeUInt(256, VChainId)
+
+       andBool (#rangeAddress(Vat)
+       andBool (#rangeAddress(Flapper)
+       andBool (#rangeAddress(Flopper)
+       andBool (#rangeAddress(FlapVat)
+       andBool (#rangeUInt(256, MayFlap)
+       andBool (#rangeUInt(256, MayFlop)
+       andBool (#rangeUInt(256, Dai_v)
+       andBool (#rangeUInt(256, Sin_v)
+       andBool (#rangeUInt(256, Dai_f)
+       andBool (#rangeUInt(256, Debt)
+       andBool (#rangeUInt(256, Vice)
+       andBool (#rangeUInt(256, Live)
+       andBool (#rangeUInt(256, Sin)
+       andBool (#rangeUInt(256, Ash)
+       andBool (#rangeUInt(256, FlapLive)
+       andBool (#rangeUInt(256, FlopLive)
+       andBool (#rangeAddress(FlopVow)
+       andBool (#rangeUInt(256, Vat_balance)
+       andBool (#rangeUInt(256, Flapper_balance)
+       andBool (#rangeUInt(256, Flopper_balance)
+       andBool ((#sizeByteArray(CD) <=Int 1250000000)
+       andBool ((#notPrecompileAddress(Vat))
+       andBool ((#notPrecompileAddress(Flapper))
+       andBool ((#notPrecompileAddress(Flopper))
+       andBool ((#notPrecompileAddress(FlapVat))
+       andBool ((#notPrecompileAddress(FlopVow))
+       andBool ((ACCT_ID =/=Int Vat)
+       andBool ((ACCT_ID =/=Int Flapper)
+       andBool ((ACCT_ID =/=Int Flopper)
+       andBool ((Dai_v +Int Dai_f <Int Sin_v)
+       andBool ((Flapper =/=Int ACCT_ID)
+       andBool ((Flapper =/=Int Vat)
+       andBool ((Flopper =/=Int ACCT_ID)
+       andBool ((Flopper =/=Int Vat)
+       andBool ((Flopper =/=Int Flapper)
+       andBool ((FlapVat ==Int  Vat)
+       andBool ((Vat =/=Int 0)
+       andBool ((Flapper =/=Int 0)
+       andBool ((Flopper =/=Int 0)
+       andBool (#rangeUInt(256, Junk_0)
+       andBool (#rangeUInt(256, Junk_1)
+       andBool (#rangeUInt(256, Junk_2)
+       andBool (#rangeUInt(256, Junk_3)
+       andBool (#rangeUInt(256, Junk_4)
+       andBool (#rangeUInt(256, Junk_5)
+       andBool (#rangeUInt(256, Junk_6)
+       andBool (#rangeUInt(256, Junk_7)
+       andBool (#rangeUInt(256, Junk_8)
+       andBool (#rangeUInt(256, Junk_9)
+       andBool (#rangeUInt(256, Junk_10)
+       andBool (#rangeUInt(256, Junk_11)
+       andBool (#rangeUInt(256, Junk_12)
+       andBool (#rangeUInt(256, Junk_13)
+       andBool (#rangeUInt(256, Junk_14)
+       andBool (#rangeUInt(256, Junk_15)
+       andBool (#rangeUInt(256, Junk_16)
+       andBool (#rangeUInt(256, Junk_17)
+       andBool (#rangeUInt(256, Junk_18)
+       andBool (#rangeUInt(256, Junk_19)
+       andBool (((VCallValue ==Int 0))
+       andBool (((VCallDepth <Int 1023))
+       andBool (((Live ==Int 1))
+       andBool (((Can ==Int 1))
+       andBool (((MayFlap ==Int 1))
+       andBool (((MayFlop ==Int 1))
+       andBool ((#rangeUInt(256, Debt -Int (Dai_v +Int Dai_f)))
+       andBool ((#rangeUInt(256, Vice -Int (Dai_v +Int Dai_f))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))
+
+       andBool #lookup(ACCT_ID_STORAGE, #Vow.wards[CALLER_ID]) ==Int Can
+       andBool #lookup(ACCT_ID_STORAGE, #Vow.vat) ==Int Vat
+       andBool #lookup(ACCT_ID_STORAGE, #Vow.flopper) ==Int Flopper
+       andBool #lookup(ACCT_ID_STORAGE, #Vow.flapper) ==Int Flapper
+       andBool #lookup(ACCT_ID_STORAGE, #Vow.live) ==Int Live
+       andBool #lookup(ACCT_ID_STORAGE, #Vow.Sin) ==Int Sin
+       andBool #lookup(ACCT_ID_STORAGE, #Vow.Ash) ==Int Ash
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Vow.wards[CALLER_ID]) ==Int Junk_0
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Vow.vat) ==Int Junk_1
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Vow.flopper) ==Int Junk_2
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Vow.flapper) ==Int Junk_3
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Vow.live) ==Int Junk_4
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Vow.Sin) ==Int Junk_5
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Vow.Ash) ==Int Junk_6
+       andBool #Vow.wards[CALLER_ID] =/=Int #Vow.vat
+       andBool #Vow.wards[CALLER_ID] =/=Int #Vow.flopper
+       andBool #Vow.wards[CALLER_ID] =/=Int #Vow.flapper
+       andBool #Vow.wards[CALLER_ID] =/=Int #Vow.live
+       andBool #Vow.wards[CALLER_ID] =/=Int #Vow.Sin
+       andBool #Vow.wards[CALLER_ID] =/=Int #Vow.Ash
+       andBool #Vow.vat =/=Int #Vow.flopper
+       andBool #Vow.vat =/=Int #Vow.flapper
+       andBool #Vow.vat =/=Int #Vow.live
+       andBool #Vow.vat =/=Int #Vow.Sin
+       andBool #Vow.vat =/=Int #Vow.Ash
+       andBool #Vow.flopper =/=Int #Vow.flapper
+       andBool #Vow.flopper =/=Int #Vow.live
+       andBool #Vow.flopper =/=Int #Vow.Sin
+       andBool #Vow.flopper =/=Int #Vow.Ash
+       andBool #Vow.flapper =/=Int #Vow.live
+       andBool #Vow.flapper =/=Int #Vow.Sin
+       andBool #Vow.flapper =/=Int #Vow.Ash
+       andBool #Vow.live =/=Int #Vow.Sin
+       andBool #Vow.live =/=Int #Vow.Ash
+       andBool #Vow.Sin =/=Int #Vow.Ash
+       andBool #lookup(Vat_STORAGE, #Vat.can[Flapper][Flapper]) ==Int Junk_7
+       andBool #lookup(Vat_STORAGE, #Vat.dai[Flapper]) ==Int Dai_f
+       andBool #lookup(Vat_STORAGE, #Vat.dai[ACCT_ID]) ==Int Dai_v
+       andBool #lookup(Vat_STORAGE, #Vat.sin[ACCT_ID]) ==Int Sin_v
+       andBool #lookup(Vat_STORAGE, #Vat.vice) ==Int Vice
+       andBool #lookup(Vat_STORAGE, #Vat.debt) ==Int Debt
+       andBool #lookup(Vat_ORIG_STORAGE, #Vat.can[Flapper][Flapper]) ==Int Junk_8
+       andBool #lookup(Vat_ORIG_STORAGE, #Vat.dai[Flapper]) ==Int Junk_9
+       andBool #lookup(Vat_ORIG_STORAGE, #Vat.dai[ACCT_ID]) ==Int Junk_10
+       andBool #lookup(Vat_ORIG_STORAGE, #Vat.sin[ACCT_ID]) ==Int Junk_11
+       andBool #lookup(Vat_ORIG_STORAGE, #Vat.vice) ==Int Junk_12
+       andBool #lookup(Vat_ORIG_STORAGE, #Vat.debt) ==Int Junk_13
+       andBool #Vat.can[Flapper][Flapper] =/=Int #Vat.dai[Flapper]
+       andBool #Vat.can[Flapper][Flapper] =/=Int #Vat.dai[ACCT_ID]
+       andBool #Vat.can[Flapper][Flapper] =/=Int #Vat.sin[ACCT_ID]
+       andBool #Vat.can[Flapper][Flapper] =/=Int #Vat.vice
+       andBool #Vat.can[Flapper][Flapper] =/=Int #Vat.debt
+       andBool #Vat.dai[Flapper] =/=Int #Vat.dai[ACCT_ID]
+       andBool #Vat.dai[Flapper] =/=Int #Vat.sin[ACCT_ID]
+       andBool #Vat.dai[Flapper] =/=Int #Vat.vice
+       andBool #Vat.dai[Flapper] =/=Int #Vat.debt
+       andBool #Vat.dai[ACCT_ID] =/=Int #Vat.sin[ACCT_ID]
+       andBool #Vat.dai[ACCT_ID] =/=Int #Vat.vice
+       andBool #Vat.dai[ACCT_ID] =/=Int #Vat.debt
+       andBool #Vat.sin[ACCT_ID] =/=Int #Vat.vice
+       andBool #Vat.sin[ACCT_ID] =/=Int #Vat.debt
+       andBool #Vat.vice =/=Int #Vat.debt
+       andBool #lookup(Flapper_STORAGE, #Flapper.wards[ACCT_ID]) ==Int MayFlap
+       andBool #lookup(Flapper_STORAGE, #Flapper.vat) ==Int FlapVat
+       andBool #lookup(Flapper_STORAGE, #Flapper.live) ==Int FlapLive
+       andBool #lookup(Flapper_ORIG_STORAGE, #Flapper.wards[ACCT_ID]) ==Int Junk_14
+       andBool #lookup(Flapper_ORIG_STORAGE, #Flapper.vat) ==Int Junk_15
+       andBool #lookup(Flapper_ORIG_STORAGE, #Flapper.live) ==Int Junk_16
+       andBool #Flapper.wards[ACCT_ID] =/=Int #Flapper.vat
+       andBool #Flapper.wards[ACCT_ID] =/=Int #Flapper.live
+       andBool #Flapper.vat =/=Int #Flapper.live
+       andBool #lookup(Flopper_STORAGE, #Flopper.wards[ACCT_ID]) ==Int MayFlop
+       andBool #lookup(Flopper_STORAGE, #Flopper.live) ==Int FlopLive
+       andBool #lookup(Flopper_STORAGE, #Flopper.vow) ==Int FlopVow
+       andBool #lookup(Flopper_ORIG_STORAGE, #Flopper.wards[ACCT_ID]) ==Int Junk_17
+       andBool #lookup(Flopper_ORIG_STORAGE, #Flopper.live) ==Int Junk_18
+       andBool #lookup(Flopper_ORIG_STORAGE, #Flopper.vow) ==Int Junk_19
+       andBool #Flopper.wards[ACCT_ID] =/=Int #Flopper.live
+       andBool #Flopper.wards[ACCT_ID] =/=Int #Flopper.vow
+       andBool #Flopper.live =/=Int #Flopper.vow
+
+    // Vow_minuu
+    claim [Vow.minuu.pass]:
+      <k> #execute ~> CONTINUATION => #execute ~> CONTINUATION </k>
+      <exit-code> 1 </exit-code>
+      <mode> NORMAL </mode>
+      <schedule> ISTANBUL </schedule>
+      <ethereum>
+        <evm>
+          <output> VOutput => VOutput </output>
+          <statusCode> _ => ?_ </statusCode>
+          <endPC> _ => ?_ </endPC>
+          <callStack> _VCallStack </callStack>
+          <interimStates> _ </interimStates>
+          <touchedAccounts> _ => ?_ </touchedAccounts>
+          <callState>
+            <program> Vow_bin_runtime </program>
+            <jumpDests> #computeValidJumpDests(Vow_bin_runtime) </jumpDests>
+            <id> ACCT_ID </id>
+            <caller> CALLER_ID </caller>
+            <callData> _ => ?_ </callData>
+            <callValue> VCallValue </callValue>
+            <wordStack> ABI_y : ABI_x : JMPTO : WS  =>  JMPTO : #if ABI_x >Int ABI_y #then ABI_y #else ABI_x #fi : WS </wordStack>
+            <localMem> _ </localMem>
+            <pc> 9829 => 9854 </pc>
+            <gas> #gas(VGas) => #if ABI_x <=Int ABI_y
+              #then   #gas ( ( VGas +Int -49 ) )
+              #else   #gas ( ( VGas +Int -59 ) )
+            #fi </gas>
+            <memoryUsed> VMemoryUsed </memoryUsed>
+            <callGas> _ => ?_ </callGas>
+            <static> _ </static>
+            <callDepth> VCallDepth </callDepth>
+          </callState>
+          <substate>
+            <selfDestruct> _VSelfDestruct </selfDestruct>
+            <log> _ => ?_ </log>
+            <refund> _Vrefund => ?_ </refund>
+          </substate>
+          <gasPrice> _ </gasPrice>
+          <origin> ORIGIN_ID </origin>
+          <blockhashes> _ </blockhashes>
+          <block>
+            <previousHash> _ </previousHash>
+            <ommersHash> _ </ommersHash>
+            <coinbase> _ </coinbase>
+            <stateRoot> _ </stateRoot>
+            <transactionsRoot> _ </transactionsRoot>
+            <receiptsRoot> _ </receiptsRoot>
+            <logsBloom> _ </logsBloom>
+            <difficulty> _ </difficulty>
+            <number> _BLOCK_NUMBER </number>
+            <gasLimit> _ </gasLimit>
+            <gasUsed> _ </gasUsed>
+            <timestamp> TIME </timestamp>
+            <extraData> _ </extraData>
+            <mixHash> _ </mixHash>
+            <blockNonce> _ </blockNonce>
+            <ommerBlockHeaders> _ </ommerBlockHeaders>
+          </block>
+        </evm>
+        <network>
+          <chainID> VChainId </chainID>
+          <activeAccounts> SetItem(ACCT_ID)
+          SetItem(1)
+          SetItem(2)
+          SetItem(3)
+          SetItem(4)
+          SetItem(5)
+          SetItem(6)
+          SetItem(7)
+          SetItem(8)
+          SetItem(9) _ </activeAccounts>
+          <accounts>
+            <account>
+              <acctID> ACCT_ID </acctID>
+              <balance> ACCT_ID_balance </balance>
+              <code> Vow_bin_runtime </code>
+              <storage> ACCT_ID_STORAGE => ACCT_ID_STORAGE  </storage>
+              <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
+              <nonce> _Nonce_Vow => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> 1 </acctID>
+              <balance> ECREC_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 2 </acctID>
+              <balance> SHA256_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 3 </acctID>
+              <balance> RIP160_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 4 </acctID>
+              <balance> ID_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 5 </acctID>
+              <balance> MODEXP_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 6 </acctID>
+              <balance> ECADD_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 7 </acctID>
+              <balance> ECMUL_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 8 </acctID>
+              <balance> ECPAIRING_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 9 </acctID>
+              <balance> BLAKE2_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+           ...
+          </accounts>
+          <txOrder> _ </txOrder>
+          <txPending> _ </txPending>
+          <messages> _ </messages>
+        </network>
+      </ethereum>
+      requires #rangeAddress(ACCT_ID)
+       andBool ACCT_ID =/=Int 0
+       andBool #notPrecompileAddress(ACCT_ID)
+       andBool #rangeAddress(CALLER_ID)
+       andBool #rangeAddress(ORIGIN_ID)
+       andBool #rangeUInt(256, TIME)
+       andBool #rangeUInt(256, ACCT_ID_balance)
+       andBool #rangeUInt(256, ECREC_BAL)
+       andBool #rangeUInt(256, SHA256_BAL)
+       andBool #rangeUInt(256, RIP160_BAL)
+       andBool #rangeUInt(256, ID_BAL)
+       andBool #rangeUInt(256, MODEXP_BAL)
+       andBool #rangeUInt(256, ECADD_BAL)
+       andBool #rangeUInt(256, ECMUL_BAL)
+       andBool #rangeUInt(256, ECPAIRING_BAL)
+       andBool #rangeUInt(256, BLAKE2_BAL)
+       andBool VCallDepth <=Int 1024
+       andBool #rangeUInt(256, VCallValue)
+       andBool #rangeUInt(256, VChainId)
+
+       andBool (#rangeUInt(256, ABI_x)
+       andBool (#rangeUInt(256, ABI_y)
+       andBool ((#sizeWordStack(WS) <=Int 1000)
+       andBool (#rangeUInt(256, VMemoryUsed)))))
+
+
+    [trusted, matching(infGas)]
+
+
+    // Vat_dai
+    claim [Vat.dai.pass]:
+      <k> #execute ~> CONTINUATION => #halt ~> CONTINUATION </k>
+      <exit-code> 1 </exit-code>
+      <mode> NORMAL </mode>
+      <schedule> ISTANBUL </schedule>
+      <ethereum>
+        <evm>
+          <output> _ => #buf(32, Rad) </output>
+          <statusCode> _ => EVMC_SUCCESS </statusCode>
+          <endPC> _ => ?_ </endPC>
+          <callStack> _VCallStack </callStack>
+          <interimStates> _ </interimStates>
+          <touchedAccounts> _ => ?_ </touchedAccounts>
+          <callState>
+            <program> Vat_bin_runtime </program>
+            <jumpDests> #computeValidJumpDests(Vat_bin_runtime) </jumpDests>
+            <id> ACCT_ID </id>
+            <caller> CALLER_ID </caller>
+            <callData> #abiCallData("dai", #address(ABI_usr)) ++ CD => ?_ </callData>
+            <callValue> VCallValue </callValue>
+            <wordStack> .WordStack => ?_ </wordStack>
+            <localMem> .Memory => ?_ </localMem>
+            <pc> 0 => ?_ </pc>
+            <gas> #gas(VGas) => #gas ( ( VGas +Int -1236 ) ) </gas>
+            <memoryUsed> 0 => ?_ </memoryUsed>
+            <callGas> _ => ?_ </callGas>
+            <static> _ </static>
+            <callDepth> VCallDepth </callDepth>
+          </callState>
+          <substate>
+            <selfDestruct> _VSelfDestruct </selfDestruct>
+            <log> _ => ?_ </log>
+            <refund> _Vrefund => ?_ </refund>
+          </substate>
+          <gasPrice> _ </gasPrice>
+          <origin> ORIGIN_ID </origin>
+          <blockhashes> _ </blockhashes>
+          <block>
+            <previousHash> _ </previousHash>
+            <ommersHash> _ </ommersHash>
+            <coinbase> _ </coinbase>
+            <stateRoot> _ </stateRoot>
+            <transactionsRoot> _ </transactionsRoot>
+            <receiptsRoot> _ </receiptsRoot>
+            <logsBloom> _ </logsBloom>
+            <difficulty> _ </difficulty>
+            <number> _BLOCK_NUMBER </number>
+            <gasLimit> _ </gasLimit>
+            <gasUsed> _ </gasUsed>
+            <timestamp> TIME </timestamp>
+            <extraData> _ </extraData>
+            <mixHash> _ </mixHash>
+            <blockNonce> _ </blockNonce>
+            <ommerBlockHeaders> _ </ommerBlockHeaders>
+          </block>
+        </evm>
+        <network>
+          <chainID> VChainId </chainID>
+          <activeAccounts> SetItem(ACCT_ID)
+          SetItem(1)
+          SetItem(2)
+          SetItem(3)
+          SetItem(4)
+          SetItem(5)
+          SetItem(6)
+          SetItem(7)
+          SetItem(8)
+          SetItem(9) _ </activeAccounts>
+          <accounts>
+            <account>
+              <acctID> ACCT_ID </acctID>
+              <balance> ACCT_ID_balance </balance>
+              <code> Vat_bin_runtime </code>
+              <storage> ACCT_ID_STORAGE => ACCT_ID_STORAGE  </storage>
+              <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
+              <nonce> _Nonce_Vat => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> 1 </acctID>
+              <balance> ECREC_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 2 </acctID>
+              <balance> SHA256_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 3 </acctID>
+              <balance> RIP160_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 4 </acctID>
+              <balance> ID_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 5 </acctID>
+              <balance> MODEXP_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 6 </acctID>
+              <balance> ECADD_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 7 </acctID>
+              <balance> ECMUL_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 8 </acctID>
+              <balance> ECPAIRING_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 9 </acctID>
+              <balance> BLAKE2_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+           ...
+          </accounts>
+          <txOrder> _ </txOrder>
+          <txPending> _ </txPending>
+          <messages> _ </messages>
+        </network>
+      </ethereum>
+      requires #rangeAddress(ACCT_ID)
+       andBool ACCT_ID =/=Int 0
+       andBool #notPrecompileAddress(ACCT_ID)
+       andBool #rangeAddress(CALLER_ID)
+       andBool #rangeAddress(ORIGIN_ID)
+       andBool #rangeUInt(256, TIME)
+       andBool #rangeUInt(256, ACCT_ID_balance)
+       andBool #rangeUInt(256, ECREC_BAL)
+       andBool #rangeUInt(256, SHA256_BAL)
+       andBool #rangeUInt(256, RIP160_BAL)
+       andBool #rangeUInt(256, ID_BAL)
+       andBool #rangeUInt(256, MODEXP_BAL)
+       andBool #rangeUInt(256, ECADD_BAL)
+       andBool #rangeUInt(256, ECMUL_BAL)
+       andBool #rangeUInt(256, ECPAIRING_BAL)
+       andBool #rangeUInt(256, BLAKE2_BAL)
+       andBool VCallDepth <=Int 1024
+       andBool #rangeUInt(256, VCallValue)
+       andBool #rangeUInt(256, VChainId)
+
+       andBool (#rangeAddress(ABI_usr)
+       andBool (#rangeUInt(256, Rad)
+       andBool (#sizeByteArray(CD) <=Int 1250000000
+       andBool (#rangeUInt(256, Junk_0)
+       andBool ((VCallValue ==Int 0))))))
+
+       andBool #lookup(ACCT_ID_STORAGE, #Vat.dai[ABI_usr]) ==Int Rad
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Vat.dai[ABI_usr]) ==Int Junk_0
+    [trusted, matching(infGas)]
+
+
+    // Vat_sin
+    claim [Vat.sin.pass]:
+      <k> #execute ~> CONTINUATION => #halt ~> CONTINUATION </k>
+      <exit-code> 1 </exit-code>
+      <mode> NORMAL </mode>
+      <schedule> ISTANBUL </schedule>
+      <ethereum>
+        <evm>
+          <output> _ => #buf(32, Rad) </output>
+          <statusCode> _ => EVMC_SUCCESS </statusCode>
+          <endPC> _ => ?_ </endPC>
+          <callStack> _VCallStack </callStack>
+          <interimStates> _ </interimStates>
+          <touchedAccounts> _ => ?_ </touchedAccounts>
+          <callState>
+            <program> Vat_bin_runtime </program>
+            <jumpDests> #computeValidJumpDests(Vat_bin_runtime) </jumpDests>
+            <id> ACCT_ID </id>
+            <caller> CALLER_ID </caller>
+            <callData> #abiCallData("sin", #address(ABI_usr)) ++ CD => ?_ </callData>
+            <callValue> VCallValue </callValue>
+            <wordStack> .WordStack => ?_ </wordStack>
+            <localMem> .Memory => ?_ </localMem>
+            <pc> 0 => ?_ </pc>
+            <gas> #gas(VGas) => #gas ( ( VGas +Int -1235 ) ) </gas>
+            <memoryUsed> 0 => ?_ </memoryUsed>
+            <callGas> _ => ?_ </callGas>
+            <static> _ </static>
+            <callDepth> VCallDepth </callDepth>
+          </callState>
+          <substate>
+            <selfDestruct> _VSelfDestruct </selfDestruct>
+            <log> _ => ?_ </log>
+            <refund> _Vrefund => ?_ </refund>
+          </substate>
+          <gasPrice> _ </gasPrice>
+          <origin> ORIGIN_ID </origin>
+          <blockhashes> _ </blockhashes>
+          <block>
+            <previousHash> _ </previousHash>
+            <ommersHash> _ </ommersHash>
+            <coinbase> _ </coinbase>
+            <stateRoot> _ </stateRoot>
+            <transactionsRoot> _ </transactionsRoot>
+            <receiptsRoot> _ </receiptsRoot>
+            <logsBloom> _ </logsBloom>
+            <difficulty> _ </difficulty>
+            <number> _BLOCK_NUMBER </number>
+            <gasLimit> _ </gasLimit>
+            <gasUsed> _ </gasUsed>
+            <timestamp> TIME </timestamp>
+            <extraData> _ </extraData>
+            <mixHash> _ </mixHash>
+            <blockNonce> _ </blockNonce>
+            <ommerBlockHeaders> _ </ommerBlockHeaders>
+          </block>
+        </evm>
+        <network>
+          <chainID> VChainId </chainID>
+          <activeAccounts> SetItem(ACCT_ID)
+          SetItem(1)
+          SetItem(2)
+          SetItem(3)
+          SetItem(4)
+          SetItem(5)
+          SetItem(6)
+          SetItem(7)
+          SetItem(8)
+          SetItem(9) _ </activeAccounts>
+          <accounts>
+            <account>
+              <acctID> ACCT_ID </acctID>
+              <balance> ACCT_ID_balance </balance>
+              <code> Vat_bin_runtime </code>
+              <storage> ACCT_ID_STORAGE => ACCT_ID_STORAGE  </storage>
+              <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
+              <nonce> _Nonce_Vat => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> 1 </acctID>
+              <balance> ECREC_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 2 </acctID>
+              <balance> SHA256_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 3 </acctID>
+              <balance> RIP160_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 4 </acctID>
+              <balance> ID_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 5 </acctID>
+              <balance> MODEXP_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 6 </acctID>
+              <balance> ECADD_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 7 </acctID>
+              <balance> ECMUL_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 8 </acctID>
+              <balance> ECPAIRING_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 9 </acctID>
+              <balance> BLAKE2_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+           ...
+          </accounts>
+          <txOrder> _ </txOrder>
+          <txPending> _ </txPending>
+          <messages> _ </messages>
+        </network>
+      </ethereum>
+      requires #rangeAddress(ACCT_ID)
+       andBool ACCT_ID =/=Int 0
+       andBool #notPrecompileAddress(ACCT_ID)
+       andBool #rangeAddress(CALLER_ID)
+       andBool #rangeAddress(ORIGIN_ID)
+       andBool #rangeUInt(256, TIME)
+       andBool #rangeUInt(256, ACCT_ID_balance)
+       andBool #rangeUInt(256, ECREC_BAL)
+       andBool #rangeUInt(256, SHA256_BAL)
+       andBool #rangeUInt(256, RIP160_BAL)
+       andBool #rangeUInt(256, ID_BAL)
+       andBool #rangeUInt(256, MODEXP_BAL)
+       andBool #rangeUInt(256, ECADD_BAL)
+       andBool #rangeUInt(256, ECMUL_BAL)
+       andBool #rangeUInt(256, ECPAIRING_BAL)
+       andBool #rangeUInt(256, BLAKE2_BAL)
+       andBool VCallDepth <=Int 1024
+       andBool #rangeUInt(256, VCallValue)
+       andBool #rangeUInt(256, VChainId)
+
+       andBool (#rangeAddress(ABI_usr)
+       andBool (#rangeUInt(256, Rad)
+       andBool (#sizeByteArray(CD) <=Int 1250000000
+       andBool (#rangeUInt(256, Junk_0)
+       andBool ((VCallValue ==Int 0))))))
+
+       andBool #lookup(ACCT_ID_STORAGE, #Vat.sin[ABI_usr]) ==Int Rad
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Vat.sin[ABI_usr]) ==Int Junk_0
+    [trusted, matching(infGas)]
+
+
+    // Vat_heal
+    claim [Vat.heal.pass]:
+      <k> #execute ~> CONTINUATION => #halt ~> CONTINUATION </k>
+      <exit-code> 1 </exit-code>
+      <mode> NORMAL </mode>
+      <schedule> ISTANBUL </schedule>
+      <ethereum>
+        <evm>
+          <output> .ByteArray </output>
+          <statusCode> _ => EVMC_SUCCESS </statusCode>
+          <endPC> _ => ?_ </endPC>
+          <callStack> _VCallStack </callStack>
+          <interimStates> _ </interimStates>
+          <touchedAccounts> _ => ?_ </touchedAccounts>
+          <callState>
+            <program> Vat_bin_runtime </program>
+            <jumpDests> #computeValidJumpDests(Vat_bin_runtime) </jumpDests>
+            <id> ACCT_ID </id>
+            <caller> CALLER_ID </caller>
+            <callData> #abiCallData("heal", #uint256(ABI_rad)) ++ CD => ?_ </callData>
+            <callValue> VCallValue </callValue>
+            <wordStack> .WordStack => ?_ </wordStack>
+            <localMem> .Memory => ?_ </localMem>
+            <pc> 0 => ?_ </pc>
+            <gas> #gas(VGas) => #gas ( ( ( ( ( ( VGas -Int Csstore( ISTANBUL , ( Sin -Int ABI_rad ) , Sin , Junk_0 ) ) -Int Csstore( ISTANBUL , ( Dai -Int ABI_rad ) , Dai , Junk_1 ) ) -Int Csstore( ISTANBUL , ( Vice -Int ABI_rad ) , Vice , Junk_2 ) ) -Int Csstore( ISTANBUL , ( Debt -Int ABI_rad ) , Debt , Junk_3 ) ) +Int -8616 ) ) </gas>
+            <memoryUsed> 0 => ?_ </memoryUsed>
+            <callGas> _ => ?_ </callGas>
+            <static> false </static>
+            <callDepth> VCallDepth </callDepth>
+          </callState>
+          <substate>
+            <selfDestruct> _VSelfDestruct </selfDestruct>
+            <log> _ => ?_ </log>
+            <refund> _Vrefund => ?_ </refund>
+          </substate>
+          <gasPrice> _ </gasPrice>
+          <origin> ORIGIN_ID </origin>
+          <blockhashes> _ </blockhashes>
+          <block>
+            <previousHash> _ </previousHash>
+            <ommersHash> _ </ommersHash>
+            <coinbase> _ </coinbase>
+            <stateRoot> _ </stateRoot>
+            <transactionsRoot> _ </transactionsRoot>
+            <receiptsRoot> _ </receiptsRoot>
+            <logsBloom> _ </logsBloom>
+            <difficulty> _ </difficulty>
+            <number> _BLOCK_NUMBER </number>
+            <gasLimit> _ </gasLimit>
+            <gasUsed> _ </gasUsed>
+            <timestamp> TIME </timestamp>
+            <extraData> _ </extraData>
+            <mixHash> _ </mixHash>
+            <blockNonce> _ </blockNonce>
+            <ommerBlockHeaders> _ </ommerBlockHeaders>
+          </block>
+        </evm>
+        <network>
+          <chainID> VChainId </chainID>
+          <activeAccounts> SetItem(ACCT_ID)
+          SetItem(1)
+          SetItem(2)
+          SetItem(3)
+          SetItem(4)
+          SetItem(5)
+          SetItem(6)
+          SetItem(7)
+          SetItem(8)
+          SetItem(9) _ </activeAccounts>
+          <accounts>
+            <account>
+              <acctID> ACCT_ID </acctID>
+              <balance> ACCT_ID_balance </balance>
+              <code> Vat_bin_runtime </code>
+              <storage> ACCT_ID_STORAGE => ACCT_ID_STORAGE [ #Vat.sin[CALLER_ID] <- Sin -Int ABI_rad ] [ #Vat.dai[CALLER_ID] <- Dai -Int ABI_rad ] [ #Vat.vice <- Vice  -Int ABI_rad ] [ #Vat.debt <- Debt  -Int ABI_rad ] </storage>
+              <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
+              <nonce> _Nonce_Vat => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> 1 </acctID>
+              <balance> ECREC_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 2 </acctID>
+              <balance> SHA256_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 3 </acctID>
+              <balance> RIP160_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 4 </acctID>
+              <balance> ID_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 5 </acctID>
+              <balance> MODEXP_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 6 </acctID>
+              <balance> ECADD_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 7 </acctID>
+              <balance> ECMUL_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 8 </acctID>
+              <balance> ECPAIRING_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 9 </acctID>
+              <balance> BLAKE2_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+           ...
+          </accounts>
+          <txOrder> _ </txOrder>
+          <txPending> _ </txPending>
+          <messages> _ </messages>
+        </network>
+      </ethereum>
+      requires #rangeAddress(ACCT_ID)
+       andBool ACCT_ID =/=Int 0
+       andBool #notPrecompileAddress(ACCT_ID)
+       andBool #rangeAddress(CALLER_ID)
+       andBool #rangeAddress(ORIGIN_ID)
+       andBool #rangeUInt(256, TIME)
+       andBool #rangeUInt(256, ACCT_ID_balance)
+       andBool #rangeUInt(256, ECREC_BAL)
+       andBool #rangeUInt(256, SHA256_BAL)
+       andBool #rangeUInt(256, RIP160_BAL)
+       andBool #rangeUInt(256, ID_BAL)
+       andBool #rangeUInt(256, MODEXP_BAL)
+       andBool #rangeUInt(256, ECADD_BAL)
+       andBool #rangeUInt(256, ECMUL_BAL)
+       andBool #rangeUInt(256, ECPAIRING_BAL)
+       andBool #rangeUInt(256, BLAKE2_BAL)
+       andBool VCallDepth <=Int 1024
+       andBool #rangeUInt(256, VCallValue)
+       andBool #rangeUInt(256, VChainId)
+
+       andBool (#rangeUInt(256, ABI_rad)
+       andBool (#rangeUInt(256, Dai)
+       andBool (#rangeUInt(256, Sin)
+       andBool (#rangeUInt(256, Debt)
+       andBool (#rangeUInt(256, Vice)
+       andBool (#sizeByteArray(CD) <=Int 1250000000
+       andBool (#rangeUInt(256, Junk_0)
+       andBool (#rangeUInt(256, Junk_1)
+       andBool (#rangeUInt(256, Junk_2)
+       andBool (#rangeUInt(256, Junk_3)
+       andBool (((VCallValue ==Int 0))
+       andBool ((#rangeUInt(256, Dai -Int ABI_rad))
+       andBool ((#rangeUInt(256, Sin -Int ABI_rad))
+       andBool ((#rangeUInt(256, Debt  -Int ABI_rad))
+       andBool ((#rangeUInt(256, Vice  -Int ABI_rad)))))))))))))))))
+
+       andBool #lookup(ACCT_ID_STORAGE, #Vat.sin[CALLER_ID]) ==Int Sin
+       andBool #lookup(ACCT_ID_STORAGE, #Vat.dai[CALLER_ID]) ==Int Dai
+       andBool #lookup(ACCT_ID_STORAGE, #Vat.vice) ==Int Vice
+       andBool #lookup(ACCT_ID_STORAGE, #Vat.debt) ==Int Debt
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Vat.sin[CALLER_ID]) ==Int Junk_0
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Vat.dai[CALLER_ID]) ==Int Junk_1
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Vat.vice) ==Int Junk_2
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Vat.debt) ==Int Junk_3
+       andBool #Vat.sin[CALLER_ID] =/=Int #Vat.dai[CALLER_ID]
+       andBool #Vat.sin[CALLER_ID] =/=Int #Vat.vice
+       andBool #Vat.sin[CALLER_ID] =/=Int #Vat.debt
+       andBool #Vat.dai[CALLER_ID] =/=Int #Vat.vice
+       andBool #Vat.dai[CALLER_ID] =/=Int #Vat.debt
+       andBool #Vat.vice =/=Int #Vat.debt
+    [trusted, matching(infGas)]
+
+
+    // Flapper_cage
+    claim [Flapper.cage.pass]:
+      <k> #execute ~> CONTINUATION => #halt ~> CONTINUATION </k>
+      <exit-code> 1 </exit-code>
+      <mode> NORMAL </mode>
+      <schedule> ISTANBUL </schedule>
+      <ethereum>
+        <evm>
+          <output> .ByteArray </output>
+          <statusCode> _ => EVMC_SUCCESS </statusCode>
+          <endPC> _ => ?_ </endPC>
+          <callStack> _VCallStack </callStack>
+          <interimStates> _ </interimStates>
+          <touchedAccounts> _ => ?_ </touchedAccounts>
+          <callState>
+            <program> Flapper_bin_runtime </program>
+            <jumpDests> #computeValidJumpDests(Flapper_bin_runtime) </jumpDests>
+            <id> ACCT_ID </id>
+            <caller> CALLER_ID </caller>
+            <callData> #abiCallData("cage", #uint256(ABI_rad)) ++ CD => ?_ </callData>
+            <callValue> VCallValue </callValue>
+            <wordStack> .WordStack => ?_ </wordStack>
+            <localMem> .Memory => ?_ </localMem>
+            <pc> 0 => ?_ </pc>
+            <gas> #gas(VGas) => #gas ( ( ( ( ( VGas -Int Csstore( ISTANBUL , 0 , Live , Junk_2 ) ) -Int Csstore( ISTANBUL , ( Dai_a -Int ABI_rad ) , Dai_a , Junk_5 ) ) -Int Csstore( ISTANBUL , ( Dai_u +Int ABI_rad ) , Dai_u , Junk_6 ) ) +Int -15964 ) ) </gas>
+            <memoryUsed> 0 => ?_ </memoryUsed>
+            <callGas> _ => ?_ </callGas>
+            <static> false </static>
+            <callDepth> VCallDepth </callDepth>
+          </callState>
+          <substate>
+            <selfDestruct> _VSelfDestruct </selfDestruct>
+            <log> _ => ?_ </log>
+            <refund> _Vrefund => ?_ </refund>
+          </substate>
+          <gasPrice> _ </gasPrice>
+          <origin> ORIGIN_ID </origin>
+          <blockhashes> _ </blockhashes>
+          <block>
+            <previousHash> _ </previousHash>
+            <ommersHash> _ </ommersHash>
+            <coinbase> _ </coinbase>
+            <stateRoot> _ </stateRoot>
+            <transactionsRoot> _ </transactionsRoot>
+            <receiptsRoot> _ </receiptsRoot>
+            <logsBloom> _ </logsBloom>
+            <difficulty> _ </difficulty>
+            <number> _BLOCK_NUMBER </number>
+            <gasLimit> _ </gasLimit>
+            <gasUsed> _ </gasUsed>
+            <timestamp> TIME </timestamp>
+            <extraData> _ </extraData>
+            <mixHash> _ </mixHash>
+            <blockNonce> _ </blockNonce>
+            <ommerBlockHeaders> _ </ommerBlockHeaders>
+          </block>
+        </evm>
+        <network>
+          <chainID> VChainId </chainID>
+          <activeAccounts> SetItem(ACCT_ID)
+          SetItem(Vat)
+          SetItem(1)
+          SetItem(2)
+          SetItem(3)
+          SetItem(4)
+          SetItem(5)
+          SetItem(6)
+          SetItem(7)
+          SetItem(8)
+          SetItem(9) _ </activeAccounts>
+          <accounts>
+            <account>
+              <acctID> ACCT_ID </acctID>
+              <balance> ACCT_ID_balance </balance>
+              <code> Flapper_bin_runtime </code>
+              <storage> ACCT_ID_STORAGE => ACCT_ID_STORAGE [ #Flapper.live <- 0 ] </storage>
+              <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
+              <nonce> _Nonce_Flapper => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> Vat </acctID>
+              <balance> Vat_balance </balance>
+              <code> Vat_bin_runtime </code>
+              <storage> Vat_STORAGE => Vat_STORAGE [ #Vat.dai[ACCT_ID] <- Dai_a -Int ABI_rad ] [ #Vat.dai[CALLER_ID] <- Dai_u +Int ABI_rad ] </storage>
+              <origStorage> Vat_ORIG_STORAGE </origStorage>
+              <nonce> _Nonce_Vat => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> 1 </acctID>
+              <balance> ECREC_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 2 </acctID>
+              <balance> SHA256_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 3 </acctID>
+              <balance> RIP160_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 4 </acctID>
+              <balance> ID_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 5 </acctID>
+              <balance> MODEXP_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 6 </acctID>
+              <balance> ECADD_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 7 </acctID>
+              <balance> ECMUL_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 8 </acctID>
+              <balance> ECPAIRING_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 9 </acctID>
+              <balance> BLAKE2_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+           ...
+          </accounts>
+          <txOrder> _ </txOrder>
+          <txPending> _ </txPending>
+          <messages> _ </messages>
+        </network>
+      </ethereum>
+      requires #rangeAddress(ACCT_ID)
+       andBool ACCT_ID =/=Int 0
+       andBool #notPrecompileAddress(ACCT_ID)
+       andBool #rangeAddress(CALLER_ID)
+       andBool #rangeAddress(ORIGIN_ID)
+       andBool #rangeUInt(256, TIME)
+       andBool #rangeUInt(256, ACCT_ID_balance)
+       andBool #rangeUInt(256, ECREC_BAL)
+       andBool #rangeUInt(256, SHA256_BAL)
+       andBool #rangeUInt(256, RIP160_BAL)
+       andBool #rangeUInt(256, ID_BAL)
+       andBool #rangeUInt(256, MODEXP_BAL)
+       andBool #rangeUInt(256, ECADD_BAL)
+       andBool #rangeUInt(256, ECMUL_BAL)
+       andBool #rangeUInt(256, ECPAIRING_BAL)
+       andBool #rangeUInt(256, BLAKE2_BAL)
+       andBool VCallDepth <=Int 1024
+       andBool #rangeUInt(256, VCallValue)
+       andBool #rangeUInt(256, VChainId)
+
+       andBool (#rangeUInt(256, ABI_rad)
+       andBool (#rangeAddress(Vat)
+       andBool (#rangeUInt(256, Ward)
+       andBool (#rangeUInt(256, Live)
+       andBool (#rangeUInt(256, Dai_a)
+       andBool (#rangeUInt(256, Dai_u)
+       andBool (#rangeUInt(256, Vat_balance)
+       andBool ((#sizeByteArray(CD) <=Int 1250000000)
+       andBool ((#notPrecompileAddress(Vat))
+       andBool ((CALLER_ID =/=Int ACCT_ID)
+       andBool (ACCT_ID =/=Int Vat
+       andBool ((Vat =/=Int 0)
+       andBool (#rangeUInt(256, Junk_0)
+       andBool (#rangeUInt(256, Junk_1)
+       andBool (#rangeUInt(256, Junk_2)
+       andBool (#rangeUInt(256, Junk_3)
+       andBool (#rangeUInt(256, Junk_4)
+       andBool (#rangeUInt(256, Junk_5)
+       andBool (#rangeUInt(256, Junk_6)
+       andBool (((Ward ==Int 1))
+       andBool (((VCallDepth <Int 1024))
+       andBool (((VCallValue ==Int 0))
+       andBool ((#rangeUInt(256, Dai_a -Int ABI_rad))
+       andBool ((#rangeUInt(256, Dai_u +Int ABI_rad))))))))))))))))))))))))))
+
+       andBool #lookup(ACCT_ID_STORAGE, #Flapper.wards[CALLER_ID]) ==Int Ward
+       andBool #lookup(ACCT_ID_STORAGE, #Flapper.vat) ==Int Vat
+       andBool #lookup(ACCT_ID_STORAGE, #Flapper.live) ==Int Live
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Flapper.wards[CALLER_ID]) ==Int Junk_0
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Flapper.vat) ==Int Junk_1
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Flapper.live) ==Int Junk_2
+       andBool #Flapper.wards[CALLER_ID] =/=Int #Flapper.vat
+       andBool #Flapper.wards[CALLER_ID] =/=Int #Flapper.live
+       andBool #Flapper.vat =/=Int #Flapper.live
+       andBool #lookup(Vat_STORAGE, #Vat.can[ACCT_ID][ACCT_ID]) ==Int Junk_3
+       andBool #lookup(Vat_STORAGE, #Vat.dai[ACCT_ID]) ==Int Dai_a
+       andBool #lookup(Vat_STORAGE, #Vat.dai[CALLER_ID]) ==Int Dai_u
+       andBool #lookup(Vat_ORIG_STORAGE, #Vat.can[ACCT_ID][ACCT_ID]) ==Int Junk_4
+       andBool #lookup(Vat_ORIG_STORAGE, #Vat.dai[ACCT_ID]) ==Int Junk_5
+       andBool #lookup(Vat_ORIG_STORAGE, #Vat.dai[CALLER_ID]) ==Int Junk_6
+       andBool #Vat.can[ACCT_ID][ACCT_ID] =/=Int #Vat.dai[ACCT_ID]
+       andBool #Vat.can[ACCT_ID][ACCT_ID] =/=Int #Vat.dai[CALLER_ID]
+       andBool #Vat.dai[ACCT_ID] =/=Int #Vat.dai[CALLER_ID]
+    [trusted, matching(infGas)]
+
+
+    // Flopper_cage
+    claim [Flopper.cage.pass]:
+      <k> #execute ~> CONTINUATION => #halt ~> CONTINUATION </k>
+      <exit-code> 1 </exit-code>
+      <mode> NORMAL </mode>
+      <schedule> ISTANBUL </schedule>
+      <ethereum>
+        <evm>
+          <output> .ByteArray </output>
+          <statusCode> _ => EVMC_SUCCESS </statusCode>
+          <endPC> _ => ?_ </endPC>
+          <callStack> _VCallStack </callStack>
+          <interimStates> _ </interimStates>
+          <touchedAccounts> _ => ?_ </touchedAccounts>
+          <callState>
+            <program> Flopper_bin_runtime </program>
+            <jumpDests> #computeValidJumpDests(Flopper_bin_runtime) </jumpDests>
+            <id> ACCT_ID </id>
+            <caller> CALLER_ID </caller>
+            <callData> #abiCallData("cage", .TypedArgs) ++ CD => ?_ </callData>
+            <callValue> VCallValue </callValue>
+            <wordStack> .WordStack => ?_ </wordStack>
+            <localMem> .Memory => ?_ </localMem>
+            <pc> 0 => ?_ </pc>
+            <gas> #gas(VGas) => #gas ( ( ( ( VGas -Int Csstore( ISTANBUL , 0 , Live , Junk_1 ) ) -Int Csstore( ISTANBUL , CALLER_ID , Vow , Junk_2 ) ) +Int -6351 ) ) </gas>
+            <memoryUsed> 0 => ?_ </memoryUsed>
+            <callGas> _ => ?_ </callGas>
+            <static> false </static>
+            <callDepth> VCallDepth </callDepth>
+          </callState>
+          <substate>
+            <selfDestruct> _VSelfDestruct </selfDestruct>
+            <log> _ => ?_ </log>
+            <refund> _Vrefund => ?_ </refund>
+          </substate>
+          <gasPrice> _ </gasPrice>
+          <origin> ORIGIN_ID </origin>
+          <blockhashes> _ </blockhashes>
+          <block>
+            <previousHash> _ </previousHash>
+            <ommersHash> _ </ommersHash>
+            <coinbase> _ </coinbase>
+            <stateRoot> _ </stateRoot>
+            <transactionsRoot> _ </transactionsRoot>
+            <receiptsRoot> _ </receiptsRoot>
+            <logsBloom> _ </logsBloom>
+            <difficulty> _ </difficulty>
+            <number> _BLOCK_NUMBER </number>
+            <gasLimit> _ </gasLimit>
+            <gasUsed> _ </gasUsed>
+            <timestamp> TIME </timestamp>
+            <extraData> _ </extraData>
+            <mixHash> _ </mixHash>
+            <blockNonce> _ </blockNonce>
+            <ommerBlockHeaders> _ </ommerBlockHeaders>
+          </block>
+        </evm>
+        <network>
+          <chainID> VChainId </chainID>
+          <activeAccounts> SetItem(ACCT_ID)
+          SetItem(1)
+          SetItem(2)
+          SetItem(3)
+          SetItem(4)
+          SetItem(5)
+          SetItem(6)
+          SetItem(7)
+          SetItem(8)
+          SetItem(9) _ </activeAccounts>
+          <accounts>
+            <account>
+              <acctID> ACCT_ID </acctID>
+              <balance> ACCT_ID_balance </balance>
+              <code> Flopper_bin_runtime </code>
+              <storage> ACCT_ID_STORAGE => ACCT_ID_STORAGE [ #Flopper.live <- 0 ] [ #Flopper.vow <- CALLER_ID ] </storage>
+              <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
+              <nonce> _Nonce_Flopper => ?_ </nonce>
+            </account>
+            <account>
+              <acctID> 1 </acctID>
+              <balance> ECREC_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 2 </acctID>
+              <balance> SHA256_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 3 </acctID>
+              <balance> RIP160_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 4 </acctID>
+              <balance> ID_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 5 </acctID>
+              <balance> MODEXP_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 6 </acctID>
+              <balance> ECADD_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 7 </acctID>
+              <balance> ECMUL_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 8 </acctID>
+              <balance> ECPAIRING_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+            <account>
+              <acctID> 9 </acctID>
+              <balance> BLAKE2_BAL </balance>
+              <code> .ByteArray </code>
+              <storage> _:Map </storage>
+              <origStorage> _ </origStorage>
+              <nonce> _ </nonce>
+            </account>
+           ...
+          </accounts>
+          <txOrder> _ </txOrder>
+          <txPending> _ </txPending>
+          <messages> _ </messages>
+        </network>
+      </ethereum>
+      requires #rangeAddress(ACCT_ID)
+       andBool ACCT_ID =/=Int 0
+       andBool #notPrecompileAddress(ACCT_ID)
+       andBool #rangeAddress(CALLER_ID)
+       andBool #rangeAddress(ORIGIN_ID)
+       andBool #rangeUInt(256, TIME)
+       andBool #rangeUInt(256, ACCT_ID_balance)
+       andBool #rangeUInt(256, ECREC_BAL)
+       andBool #rangeUInt(256, SHA256_BAL)
+       andBool #rangeUInt(256, RIP160_BAL)
+       andBool #rangeUInt(256, ID_BAL)
+       andBool #rangeUInt(256, MODEXP_BAL)
+       andBool #rangeUInt(256, ECADD_BAL)
+       andBool #rangeUInt(256, ECMUL_BAL)
+       andBool #rangeUInt(256, ECPAIRING_BAL)
+       andBool #rangeUInt(256, BLAKE2_BAL)
+       andBool VCallDepth <=Int 1024
+       andBool #rangeUInt(256, VCallValue)
+       andBool #rangeUInt(256, VChainId)
+
+       andBool (#rangeUInt(256, Ward)
+       andBool (#rangeUInt(256, Live)
+       andBool (#rangeAddress(Vow)
+       andBool (#sizeByteArray(CD) <=Int 1250000000
+       andBool (#notPrecompileAddress(Vow)
+       andBool (#rangeUInt(256, Junk_0)
+       andBool (#rangeUInt(256, Junk_1)
+       andBool (#rangeUInt(256, Junk_2)
+       andBool ((Ward ==Int 1)
+       andBool ((VCallValue ==Int 0)))))))))))
+
+       andBool #lookup(ACCT_ID_STORAGE, #Flopper.wards[CALLER_ID]) ==Int Ward
+       andBool #lookup(ACCT_ID_STORAGE, #Flopper.live) ==Int Live
+       andBool #lookup(ACCT_ID_STORAGE, #Flopper.vow) ==Int Vow
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Flopper.wards[CALLER_ID]) ==Int Junk_0
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Flopper.live) ==Int Junk_1
+       andBool #lookup(ACCT_ID_ORIG_STORAGE, #Flopper.vow) ==Int Junk_2
+       andBool #Flopper.wards[CALLER_ID] =/=Int #Flopper.live
+       andBool #Flopper.wards[CALLER_ID] =/=Int #Flopper.vow
+       andBool #Flopper.live =/=Int #Flopper.vow
+    [trusted, matching(infGas)]
+
+
+endmodule

--- a/tests/specs/opcodes/create-spec.k
+++ b/tests/specs/opcodes/create-spec.k
@@ -89,6 +89,7 @@ module CREATE-SPEC
       requires G -Int (Cmem(PETERSBURG, #memoryUsageUpdate(MU, #memStart, #memWidth)) -Int Cmem(PETERSBURG, MU)) -Int 32000 >Int 0
        andBool 0 <=Int CALL_DEPTH andBool CALL_DEPTH <Int 1023
        andBool #rangeUInt(256, VALUE)
+       andBool #rangeUInt(256, BAL)
        andBool BAL >=Int VALUE
        andBool notBool (#newAddr(ACCT_ID, NONCE) in (SetItem(ACCT_ID) ACCTS))
        andBool ACCT_ID =/=Int #newAddr(ACCT_ID, NONCE)


### PR DESCRIPTION
-   Adds the following proofs: flapper-tend-guy-diff-pass-rough, gemjoin-exit-pass-rough, vow-cage-deficit-pass-rough, vat-fold-pass-rough, vat-fork-diff-pass-rough
-   Adds some rules to `infinite-gas.k` where subtractions of concrete numbers were not being moved outermost/rightmost in the term.
-   Changes the lemmas for `vat-frob-diff-zero-pass-rough` to only apply in more specific circumstances, to avoid generating larger terms (keep the `chop` instead of simplifying to `+Int pow256`).
-   Integer simplification lemmas added for some specific proofs.
-   Map update lemma where multiple writes to the same storage location are simplified out to just the latter write.
-   Lemma simplifying `chop` expressions.
-   Inline the definition of `#sgnInterp` in the handful of places that it is used.
-   Simplify the definition of `-Word` to a single rule.