### PR TITLE
kevm: no need to check for kore-exec for all installs of KEVM

### DIFF
--- a/kevm
+++ b/kevm
@@ -7,8 +7,6 @@ notif() { echo "== $@" >&2 ; }
 fatal() { echo "[FATAL] $@" ; exit 1 ; }
 
 check_k_install() {
-    which kore-exec &> /dev/null \
-        || fatal "Must have K installed! See https://github.com/kframework/k/releases."
     which kast &> /dev/null \
         || fatal "Must have K installed! See https://github.com/kframework/k/releases."
     which krun &> /dev/null \


### PR DESCRIPTION
The K-DSS project uses KEVM, but does not use the haskell backend build, so it's failing because we're checking for the presence of kore-exec.