### PR TITLE
KEVM runner script can kompile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,9 +161,9 @@ $(KEVM_INCLUDE)/kframework/%.md: %.md
 $(KEVM_INCLUDE)/kframework/lemmas/%.k: tests/specs/%.k
 	install -D $< $@
 
-tangle_concrete := k & (! ceil) & ( ( ! ( symbolic | nobytes ) ) | concrete | bytes   )
-tangle_java     := k & (! ceil) & ( ( ! ( concrete | bytes   ) ) | symbolic | nobytes )
-tangle_haskell  := k            & ( ( ! ( concrete | nobytes ) ) | symbolic | bytes   )
+tangle_concrete := k & ( ( ! ( symbolic | nobytes ) ) | concrete | bytes   )
+tangle_java     := k & ( ( ! ( concrete | bytes   ) ) | symbolic | nobytes )
+tangle_haskell  := k & ( ( ! ( concrete | nobytes ) ) | symbolic | bytes   )
 
 HOOK_NAMESPACES    = KRYPTO JSON
 KOMPILE_INCLUDES   = $(KEVM_INCLUDE)/kframework $(INSTALL_INCLUDE)/kframework

--- a/kevm
+++ b/kevm
@@ -30,7 +30,10 @@ export KLAB_OUT="${KLAB_OUT:-~/.klab}"
 # User Commands
 
 run_kompile() {
-   kompile --backend "$backend" "$run_file" -I ${INSTALL_LIB}/include/kframework "$@"
+   kompile --backend "$backend" "$run_file"    \
+        -I "${INSTALL_LIB}/include/kframework" \
+        --hook-namespaces "$hook_namespaces"   \
+        "$@"
 }
 
 run_krun() {
@@ -235,6 +238,7 @@ bug_report=false
 mode=NORMAL
 schedule=ISTANBUL
 chainid=1
+hook_namespaces="KRYPTO JSON"
 [[ ! "$run_command" == 'prove' ]] || backend='java'
 [[ ! "$run_command" =~ klab*   ]] || backend='java'
 kevm_port='8545'
@@ -253,6 +257,7 @@ while [[ $# -gt 0 ]]; do
         --mode)               mode="$2"                 ; shift 2 ;;
         --schedule)           schedule="$2"             ; shift 2 ;;
         --chainid)            chainid="$2"              ; shift 2 ;;
+        --hook-namespaces)    hook_namespaces="$2"      ; shift 2 ;;
         -p|--port)            kevm_port="$2"            ; shift 2 ;;
         -h|--host|--hostname) kevm_host="$2"            ; shift 2 ;;
         *)                    args+=("$1")              ; shift   ;;

--- a/kevm
+++ b/kevm
@@ -190,6 +190,7 @@ if [[ "$run_command" == 'help' ]] || [[ "$run_command" == '--help' ]] ; then
                $0 kast         [--backend (llvm|java|haskell)]           <KEVM_arg>* <pgm>  <output format> <K arg>*
                $0 prove        [--backend (java|haskell)]                            <spec> <def_module> <K arg>*
                $0 search       [--backend (java|haskell)]                            <pgm>  <pattern> <K arg>*
+               $0 kompile      [--backend (llvm|haskell)]                            <main> <K arg>*
                $0 klab-run                                                           <pgm>  <K arg>*
                $0 klab-prove                                                         <spec> <def_module> <K arg>*
                $0 klab-view                                                          <spec>
@@ -201,6 +202,7 @@ if [[ "$run_command" == 'help' ]] || [[ "$run_command" == '--help' ]] ; then
            $0 kast      : Parse an EVM program and output it in a supported format
            $0 prove     : Run an EVM K proof
            $0 search    : Search for a K pattern in an EVM program execution
+           $0 kompile   : Run kompile with arguments setup to include KEVM parameters as defaults
            $0 klab-(run|prove) : Run program or prove spec and dump StateLogs which KLab can read
            $0 klab-view : View the statelog associated with a given program or spec
 
@@ -209,6 +211,7 @@ if [[ "$run_command" == 'help' ]] || [[ "$run_command" == '--help' ]] ; then
 
            Note: <pgm> is a path to a file containing an EVM program/test.
                  <spec> is a K specification to be proved.
+                 <main> is a K definition to be kompiled, which may include files from KEVM.
                  <KEVM arg> is one of [--mode (NORMAL|VMTESTS)]
                                       [--schedule (ISTANBUL|PETERSBURG|CONSTANTINOPLE|BYZANTIUM|SPURIOUS_DRAGON|TANGERINE_WHISTLE|HOMESTEAD|FRONTIER|DEFAULT)]
                                       [--chainid NNN]

--- a/kevm
+++ b/kevm
@@ -190,7 +190,7 @@ if [[ "$run_command" == 'help' ]] || [[ "$run_command" == '--help' ]] ; then
                $0 kast         [--backend (llvm|java|haskell)]           <KEVM_arg>* <pgm>  <output format> <K arg>*
                $0 prove        [--backend (java|haskell)]                            <spec> <def_module> <K arg>*
                $0 search       [--backend (java|haskell)]                            <pgm>  <pattern> <K arg>*
-               $0 kompile      [--backend (llvm|haskell)]                            <main> <K arg>*
+               $0 kompile      [--backend (java|llvm|haskell)]                       <main> <K arg>*
                $0 klab-run                                                           <pgm>  <K arg>*
                $0 klab-prove                                                         <spec> <def_module> <K arg>*
                $0 klab-view                                                          <spec>

--- a/kevm
+++ b/kevm
@@ -32,7 +32,7 @@ export KLAB_OUT="${KLAB_OUT:-~/.klab}"
 run_kompile() {
    kompile --backend "$backend" "$run_file"    \
         -I "${INSTALL_LIB}/include/kframework" \
-        --hook-namespaces "$hook_namespaces"   \
+        --hook-namespaces "JSON KRYPTO"        \
         "$@"
 }
 
@@ -238,7 +238,6 @@ bug_report=false
 mode=NORMAL
 schedule=ISTANBUL
 chainid=1
-hook_namespaces="KRYPTO JSON"
 [[ ! "$run_command" == 'prove' ]] || backend='java'
 [[ ! "$run_command" =~ klab*   ]] || backend='java'
 kevm_port='8545'
@@ -257,7 +256,6 @@ while [[ $# -gt 0 ]]; do
         --mode)               mode="$2"                 ; shift 2 ;;
         --schedule)           schedule="$2"             ; shift 2 ;;
         --chainid)            chainid="$2"              ; shift 2 ;;
-        --hook-namespaces)    hook_namespaces="$2"      ; shift 2 ;;
         -p|--port)            kevm_port="$2"            ; shift 2 ;;
         -h|--host|--hostname) kevm_host="$2"            ; shift 2 ;;
         *)                    args+=("$1")              ; shift   ;;

--- a/kevm
+++ b/kevm
@@ -29,6 +29,10 @@ export KLAB_OUT="${KLAB_OUT:-~/.klab}"
 
 # User Commands
 
+run_kompile() {
+   kompile --backend "$backend" "$run_file" -I ${INSTALL_LIB}/include/kframework "$@"
+}
+
 run_krun() {
     local cschedule cmode cchainid parser
 
@@ -278,6 +282,7 @@ cSCHEDULE_kast="\`${schedule}_EVM\`(.KList)"
 cCHAINID_kast="#token(\"${chainid}\",\"Int\")"
 
 case "$run_command-$backend" in
+    kompile-@(java|llvm|haskell)   ) run_kompile                     "$@" ;;
     run-@(java|llvm|haskell)       ) run_krun                        "$@" ;;
     kast-@(java|llvm|haskell)      ) run_kast                        "$@" ;;
     interpret-@(llvm|haskell|java) ) run_interpret                   "$@" ;;


### PR DESCRIPTION
This PR does:

-  Add a `kevm kompile` command, which will call `kompile` with the correct arguments to include the KEVM build in.
-  Removes the `ceil` tangle tags, which are no longer used.