### PR TITLE
Updates to KEVM for ERC20 verification tool

### DIFF
--- a/serialization.md
+++ b/serialization.md
@@ -631,10 +631,10 @@ Merkle Tree Aux Functions
                        )
 
     rule #merkleExtensionBuilderAux( PATH, P1, V1, P2, V2 )
-      => #merkleExtensionBuilderAux( PATH ++ (P1[0 .. 1])
-                                   , P1[1 .. #sizeByteArray(P1) -Int 1], V1
-                                   , P2[1 .. #sizeByteArray(P2) -Int 1], V2
-                                   )
+      => #merkleExtensionBuilder( PATH ++ (P1[0 .. 1])
+                                , P1[1 .. #sizeByteArray(P1) -Int 1], V1
+                                , P2[1 .. #sizeByteArray(P2) -Int 1], V2
+                                )
       requires P1[0] ==Int P2[0]
 
     rule #merkleExtensionBuilderAux( PATH, P1, V1, P2, V2 )

--- a/serialization.md
+++ b/serialization.md
@@ -616,22 +616,30 @@ Merkle Tree Aux Functions
     rule #merkleUpdateBranch ( M, BRANCHVALUE, X, PATH, VALUE )
       => MerkleBranch( M[X <- MerkleLeaf( PATH, VALUE )], BRANCHVALUE ) [owise]
 
-    syntax MerkleTree ::= #merkleExtensionBuilder( ByteArray, ByteArray, String, ByteArray, String ) [function]
- // -----------------------------------------------------------------------------------------------------------
-    rule #merkleExtensionBuilder( PATH, P1, V1, P2, V2 )
-      => #merkleExtensionBuilder( PATH ++ (P1[0 .. 1])
-                                , P1[1 .. #sizeByteArray(P1) -Int 1], V1
-                                , P2[1 .. #sizeByteArray(P2) -Int 1], V2
-                                )
+    syntax MerkleTree ::= #merkleExtensionBuilder(    ByteArray , ByteArray , String , ByteArray , String ) [function]
+                        | #merkleExtensionBuilderAux( ByteArray , ByteArray , String , ByteArray , String ) [function]
+ // ------------------------------------------------------------------------------------------------------------------------
+    rule #merkleExtensionBuilder(PATH, P1, V1, P2, V2)
+      => #merkleExtensionBuilderAux(PATH, P1, V1, P2, V2)
       requires #sizeByteArray(P1) >Int 0
        andBool #sizeByteArray(P2) >Int 0
-       andBool P1[0] ==Int P2[0]
 
-    rule #merkleExtensionBuilder( PATH, P1, V1, P2, V2 )
+    rule #merkleExtensionBuilder(PATH, P1, V1, P2, V2)
       => MerkleExtension( PATH, MerklePut( MerklePut( MerkleBranch( .Map, "" ), P1, V1 ), P2, V2 ) )
       requires notBool ( #sizeByteArray(P1) >Int 0
-               andBool   #sizeByteArray(P2) >Int 0
-               andBool   P1[0] ==Int P2[0] )
+                 andBool #sizeByteArray(P2) >Int 0
+                       )
+
+    rule #merkleExtensionBuilderAux( PATH, P1, V1, P2, V2 )
+      => #merkleExtensionBuilderAux( PATH ++ (P1[0 .. 1])
+                                   , P1[1 .. #sizeByteArray(P1) -Int 1], V1
+                                   , P2[1 .. #sizeByteArray(P2) -Int 1], V2
+                                   )
+      requires P1[0] ==Int P2[0]
+
+    rule #merkleExtensionBuilderAux( PATH, P1, V1, P2, V2 )
+      => MerkleExtension( PATH, MerklePut( MerklePut( MerkleBranch( .Map, "" ), P1, V1 ), P2, V2 ) )
+      requires P1[0] =/=Int P2[0]
 
     syntax MerkleTree ::= #merkleExtensionBrancher ( MerkleTree, ByteArray, MerkleTree ) [function]
  // -----------------------------------------------------------------------------------------------

--- a/serialization.md
+++ b/serialization.md
@@ -626,9 +626,7 @@ Merkle Tree Aux Functions
 
     rule #merkleExtensionBuilder(PATH, P1, V1, P2, V2)
       => MerkleExtension( PATH, MerklePut( MerklePut( MerkleBranch( .Map, "" ), P1, V1 ), P2, V2 ) )
-      requires notBool ( #sizeByteArray(P1) >Int 0
-                 andBool #sizeByteArray(P2) >Int 0
-                       )
+      [owise]
 
     rule #merkleExtensionBuilderAux( PATH, P1, V1, P2, V2 )
       => #merkleExtensionBuilder( PATH ++ (P1[0 .. 1])
@@ -639,7 +637,7 @@ Merkle Tree Aux Functions
 
     rule #merkleExtensionBuilderAux( PATH, P1, V1, P2, V2 )
       => MerkleExtension( PATH, MerklePut( MerklePut( MerkleBranch( .Map, "" ), P1, V1 ), P2, V2 ) )
-      requires P1[0] =/=Int P2[0]
+      [owise]
 
     syntax MerkleTree ::= #merkleExtensionBrancher ( MerkleTree, ByteArray, MerkleTree ) [function]
  // -----------------------------------------------------------------------------------------------

--- a/tests/failing/static_callcodecallcodecall_110_OOGMAfter_2_d0g0v0.json.expected
+++ b/tests/failing/static_callcodecallcodecall_110_OOGMAfter_2_d0g0v0.json.expected
@@ -174,12 +174,12 @@
             b"`@`\x00`@`\x00s\x10\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01a\xea\xf6\xf4`\x00UZ`\x01U"
           </code>
           <storage>
-            1 |-> 85121
             0 |-> 0
+            1 |-> 85121
           </storage>
           <origStorage>
-            1 |-> 85121
             0 |-> 0
+            1 |-> 85121
           </origStorage>
           <nonce>
             0

--- a/tests/specs/benchmarks/storagevar02-nooverflow-spec.k
+++ b/tests/specs/benchmarks/storagevar02-nooverflow-spec.k
@@ -27,7 +27,7 @@ module STORAGEVAR02-NOOVERFLOW-SPEC
           <wordStack> .WordStack => ?_ </wordStack>
           <localMem> .Memory => ?_ </localMem>
           <pc> 0 => ?_ </pc>
-          <gas> #gas(INITGAS, 0, 0) => ?_ </gas>
+          <gas> #gas(_, 0, 0) => ?_ </gas>
           <memoryUsed> 0 => ?_ </memoryUsed>
           <callGas> _ => ?_ </callGas>
           <static> false </static> // NOTE: non-static call
@@ -40,7 +40,7 @@ module STORAGEVAR02-NOOVERFLOW-SPEC
         </substate>
         <gasPrice> _ </gasPrice>
         <origin> _ </origin> // tx.origin
-        <blockhashes> BLOCK_HASHES </blockhashes> // block.blockhash
+        <blockhashes> _BLOCK_HASHES </blockhashes> // block.blockhash
         <block>
           <previousHash> _ </previousHash>
           <ommersHash> _ </ommersHash>
@@ -70,7 +70,7 @@ module STORAGEVAR02-NOOVERFLOW-SPEC
             <balance> CONTRACT_BAL </balance>
             <code> #parseByteStack("0x608060405260043610603f576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff16806361461954146044575b600080fd5b348015604f57600080fd5b506056606c565b6040518082815260200191505060405180910390f35b600060016000540160008190555060005490509056fea165627a7a7230582084ad795d13123f60bc7fd2a18dba66eb8d320ddea8765847f2ae5982179470600029") </code>
             <storage> S => S [ #hashedLocation("Solidity", 0, .IntList) <- N0 +Int 1 ] </storage>
-            <origStorage> _OS => ?OS </origStorage>
+            <origStorage> _OS => ?_OS </origStorage>
             <nonce> _ </nonce>
           </account>
 

--- a/tests/specs/functional/infinite-gas-spec.k
+++ b/tests/specs/functional/infinite-gas-spec.k
@@ -67,14 +67,14 @@ module INFINITE-GAS-SPEC
 
     claim <k> runLemma(4822 <Int minInt(#gas(VGas +Int 4544) +Int (#gas(VGas +Int 4544) /Int 64), #gas(VGas +Int 3844))) => doneLemma(true) ... </k>
 
-    claim <k> runLemma(3 <Int minInt(#gas(VGas), 2)) => doneLemma(false) ... </k>
-    claim <k> runLemma(2 <Int minInt(#gas(VGas), 3)) => doneLemma(true ) ... </k>
+    claim <k> runLemma(3 <Int minInt(#gas(_VGas), 2)) => doneLemma(false) ... </k>
+    claim <k> runLemma(2 <Int minInt(#gas(_VGas), 3)) => doneLemma(true ) ... </k>
 
-    claim <k> runLemma(#gas(G) -Int Csstore(_, _, _, _) <Int 2) => doneLemma(false) ... </k>
-    claim <k> runLemma(minInt(#gas(G), #gas(G'')) +Int -2522 <Int Csstore(_, _, _, _)) => doneLemma(false) ... </k>
+    claim <k> runLemma(#gas(_G) -Int Csstore(_, _, _, _) <Int 2) => doneLemma(false) ... </k>
+    claim <k> runLemma(minInt(#gas(_G), #gas(_G'')) +Int -2522 <Int Csstore(_, _, _, _)) => doneLemma(false) ... </k>
 
-    claim <k> runLemma(#gas(G) <Int #gas(G' +Int 700))  => doneLemma(false) ... </k>
-    claim <k> runLemma(#gas(G' +Int 700) <=Int #gas(G)) => doneLemma(true)  ... </k>
+    claim <k> runLemma(#gas(_G) <Int #gas(_G' +Int 700))  => doneLemma(false) ... </k>
+    claim <k> runLemma(#gas(_G' +Int 700) <=Int #gas(_G)) => doneLemma(true)  ... </k>
 
     claim <k> runLemma(#if _:Int ==Int 0 #then #gas(VGas -Int Csstore(_, _, _,_)) #else #gas(VGas +Int -344) #fi <Int 8)  => doneLemma(false) ... </k>
     claim <k> runLemma(8 <=Int #if _:Int ==Int 0 #then #gas(VGas -Int Csstore(_, _, _,_)) #else #gas(VGas +Int -344) #fi) => doneLemma(true)  ... </k>
@@ -82,6 +82,6 @@ module INFINITE-GAS-SPEC
     claim <k> runLemma(#if _:Int ==Int 0 #then #gas(VGas -Int Csstore(_, _, _,_)) #else #gas(VGas +Int -344) #fi <Int minInt(#if _ #then #gas(_) #else #gas(_) #fi, #gas(_)))  => doneLemma(false) ... </k>
     claim <k> runLemma(minInt(#if _ #then #gas(_) #else #gas(_) #fi, #gas(_)) <=Int #if _:Int ==Int 0 #then #gas(VGas -Int Csstore(_, _, _,_)) #else #gas(VGas +Int -344) #fi) => doneLemma(true)  ... </k>
 
-    claim <k> runLemma(#allBut64th(#gas(G)) <Int #gas(G')) => doneLemma(false) ... </k>
+    claim <k> runLemma(#allBut64th(#gas(_G)) <Int #gas(_G')) => doneLemma(false) ... </k>
 
 endmodule

--- a/tests/specs/functional/lemmas-spec.k
+++ b/tests/specs/functional/lemmas-spec.k
@@ -25,9 +25,9 @@ module LEMMAS-SPEC
  // ----------------------
 
     claim <k> runLemma(#rangeUInt(256, #lookup(M, KX) -Int #lookup(M, KY))) => doneLemma(true) ... </k>
-      requires #rangeUInt(256, X) andBool X ==Int #lookup(M, KX)
-       andBool #rangeUInt(256, Y) andBool Y ==Int #lookup(M, KY)
-       andBool #rangeUInt(256, Z) andBool Z ==Int #lookup(M, KZ)
+      requires #rangeUInt(256, X) andBool X ==Int #lookup(M,  KX)
+       andBool #rangeUInt(256, Y) andBool Y ==Int #lookup(M,  KY)
+       andBool #rangeUInt(256, Z) andBool Z ==Int #lookup(M, _KZ)
        andBool #rangeUInt(256, (X -Int Y) -Int Z)
 
  // Buffer write simplifications

--- a/tests/specs/functional/merkle-spec.k
+++ b/tests/specs/functional/merkle-spec.k
@@ -3,20 +3,21 @@ requires "evm.md"
 module VERIFICATION
     imports EVM
 
-    syntax StepSort ::= MerkleTree | String
+    syntax StepSort ::= MerkleTree | String | Int
     syntax    KItem ::= runMerkle ( StepSort )
                       | doneMerkle( StepSort )
  // ------------------------------------------
-    rule runMerkle( T ) => doneMerkle( T )
+    rule <k> runMerkle( T ) => doneMerkle( T ) ... </k>
 
-    syntax MerkleTree ::= "#initTree" [function]
- // --------------------------------------------
+    syntax MerkleTree ::= "#initTree"
+ // ---------------------------------
     rule #initTree => MerkleUpdateMap( .MerkleTree,
-                                       #parseByteStack( "do" )    |-> "verb"
-                                       #parseByteStack( "dog" )   |-> "puppy"
-                                       #parseByteStack( "doge" )  |-> "coin"
-                                       #parseByteStack( "horse" ) |-> "stallion"
+                                       .Map [ #parseByteStack( "de" )    <- "verb"     ]
+                                            [ #parseByteStack( "def" )   <- "puppy"    ]
+                                            [ #parseByteStack( "defe" )  <- "coin"     ]
+                                            [ #parseByteStack( "becfe" ) <- "stallion" ]
                                      )
+      [macro]
 endmodule
 
 module MERKLE-SPEC
@@ -60,36 +61,26 @@ module MERKLE-SPEC
            => doneMerkle( MerkleBranch( M, V ) ) </k>
       requires V =/=String ""
 
-    ////////////////////
-    // Concrete Tests //
-    ////////////////////
-    claim <k> runMerkle( Keccak256( #rlpEncodeMerkleTree( MerkleUpdateMap( .MerkleTree,
-               #parseByteStack( "do" )    |-> "verb"
-               #parseByteStack( "dog" )   |-> "puppy"
-               #parseByteStack( "doge" )  |-> "coin"
-               #parseByteStack( "horse" ) |-> "stallion"
-                                                                        )
-                                                       )
-                                 )
-                      )
-           => doneMerkle( "5991bb8c6514148a29db676a14ac506cd2cd5775ace63c30a4fe457715e9ac84" )
-          </k>
+    claim <k> runMerkle  ( #merkleExtensionBuilder ( #parseByteStack("0e") , #parseByteStack("") , "verb" , #parseByteStack("0f0e") , "coin" ) )
+           => doneMerkle ( MerkleExtension ( #parseByteStack("0e") , MerkleBranch ( 15 |-> MerkleLeaf ( #parseByteStack("0e") , "coin" ) , "verb" ) ) ) </k>
 
     ////////////////////////
     // MerkleDelete Tests //
     ////////////////////////
-    claim <k> runMerkle ( Keccak256( #rlpEncodeMerkleTree( MerkleUpdate( #initTree, "do", "" ) ) ) )
-           => doneMerkle( "72543939c0b0dbc3bb86f81f14b9b7e7ea80eac1613ad59820b6d692ce1764d3" ) </k>
 
-    claim <k> runMerkle ( Keccak256( #rlpEncodeMerkleTree( MerkleUpdate( #initTree, "horse", "" ) ) ) )
-           => doneMerkle( "ef7b2fe20f5d2c30c46ad4d83c39811bcbf1721aef2e805c0e107947320888b6" ) </k>
+    claim <k> runMerkle ( Keccak256( #rlpEncodeMerkleTree( MerkleUpdate( #initTree, "de", "" ) ) ) )
+           => doneMerkle( "4ba393b447e1c78b2f647e10ae687de132f01f49d67e396bcdea4da2de05370f" ) </k>
 
-    claim <k> runMerkle ( Keccak256( #rlpEncodeMerkleTree( MerkleUpdate( #initTree, "dog", "" ) ) ) )
-           => doneMerkle( "2d09ab2a260088a5558f754511c9060bd6cd62ab5d3c10a15a9c0fced52add40" ) </k>
+    claim <k> runMerkle ( Keccak256( #rlpEncodeMerkleTree( MerkleUpdate( #initTree, "becfe", "" ) ) ) )
+           => doneMerkle( "4ba393b447e1c78b2f647e10ae687de132f01f49d67e396bcdea4da2de05370f" ) </k>
 
-    claim <k> runMerkle ( Keccak256( #rlpEncodeMerkleTree( MerkleUpdate( #initTree, "doge", "" ) ) ) )
-           => doneMerkle( "40b4a841a5ed78d2beb33a3dbba6dd38f5b1566db97ae643e073ded3aa77dceb" ) </k>
+    claim <k> runMerkle ( Keccak256( #rlpEncodeMerkleTree( MerkleUpdate( #initTree, "def", "" ) ) ) )
+           => doneMerkle( "4ba393b447e1c78b2f647e10ae687de132f01f49d67e396bcdea4da2de05370f" ) </k>
 
-    claim <k> runMerkle ( Keccak256( #rlpEncodeMerkleTree( MerkleUpdate( MerkleUpdate( #initTree, "doge", "" ), "horse", "" ) ) ) )
-           => doneMerkle( "779db3986dd4f38416bfde49750ef7b13c6ecb3e2221620bcad9267e94604d36" ) </k>
+    claim <k> runMerkle ( Keccak256( #rlpEncodeMerkleTree( MerkleUpdate( #initTree, "defe", "" ) ) ) )
+           => doneMerkle( "4ba393b447e1c78b2f647e10ae687de132f01f49d67e396bcdea4da2de05370f" ) </k>
+
+    claim <k> runMerkle ( Keccak256( #rlpEncodeMerkleTree( MerkleUpdate( MerkleUpdate( #initTree, "defe", "" ), "becfe", "" ) ) ) )
+           => doneMerkle( "4ba393b447e1c78b2f647e10ae687de132f01f49d67e396bcdea4da2de05370f" ) </k>
+
 endmodule

--- a/tests/specs/functional/storageRoot-spec.k
+++ b/tests/specs/functional/storageRoot-spec.k
@@ -4,6 +4,14 @@ requires "edsl.md"
 module VERIFICATION
     imports EVM
     imports EDSL
+
+    syntax KItem ::= runLemma ( Step ) | doneLemma ( Step )
+ // -------------------------------------------------------
+    rule <k> runLemma(S) => doneLemma(S) ... </k>
+
+    syntax Step ::= String
+ // ----------------------
+
 endmodule
 
 module STORAGEROOT-SPEC
@@ -18,16 +26,16 @@ module STORAGEROOT-SPEC
     // uint pos0;
     //
     // pos0 = 1234;
-    claim <k> Keccak256( #rlpEncodeMerkleTree( #storageRoot( #hashedLocation( "Solidity", 0, .IntList ) |-> 1234 ) ) )
-           => "6ff6cfba457bc662332201b53a8bda503e307197962f2c51e5e2dcc3809e19be"
+    claim <k> runLemma  ( Keccak256( #rlpEncodeMerkleTree( #storageRoot( #hashedLocation( "Solidity", 0, .IntList ) |-> 1234 ) ) ) )
+           => doneLemma ( "6ff6cfba457bc662332201b53a8bda503e307197962f2c51e5e2dcc3809e19be" )
           </k>
 
     // mapping (uint => uint) pos0;
     //
     // pos0[0] = 100;
     // pos0[1] = 200;
-    claim <k> Keccak256( #rlpEncodeMerkleTree( #storageRoot( #hashedLocation( "Solidity", 0, 0 ) |-> 100 #hashedLocation( "Solidity", 0, 1 ) |-> 200 ) ) )
-           => "27093708a19995cf73ddd4b27049a7e33fb49e242bde6c1bffbb6596b67b8b3e"
+    claim <k> runLemma  ( Keccak256( #rlpEncodeMerkleTree( #storageRoot( #hashedLocation( "Solidity", 0, 0 ) |-> 100 #hashedLocation( "Solidity", 0, 1 ) |-> 200 ) ) ) )
+           => doneLemma ( "27093708a19995cf73ddd4b27049a7e33fb49e242bde6c1bffbb6596b67b8b3e" )
           </k>
 
     // uint                   pos0;
@@ -36,8 +44,8 @@ module STORAGEROOT-SPEC
     // pos0    = 600;
     // pos1[0] = 200;
     // pos1[5] = 24;
-    claim <k> Keccak256( #rlpEncodeMerkleTree( #storageRoot( #hashedLocation( "Solidity", 0, .IntList ) |-> 600 #hashedLocation( "Solidity", 1, 0 ) |-> 200 #hashedLocation( "Solidity", 1, 5 ) |-> 24 ) ) )
-           => "7df5d7b198240b49434b4e1dbff02fcb0649dd91650ae0fae191b2881cbb009e"
+    claim <k> runLemma  ( Keccak256( #rlpEncodeMerkleTree( #storageRoot( #hashedLocation( "Solidity", 0, .IntList ) |-> 600 #hashedLocation( "Solidity", 1, 0 ) |-> 200 #hashedLocation( "Solidity", 1, 5 ) |-> 24 ) ) ) )
+           => doneLemma ( "7df5d7b198240b49434b4e1dbff02fcb0649dd91650ae0fae191b2881cbb009e" )
           </k>
 
     // mapping (uint => uint) pos0;
@@ -47,8 +55,8 @@ module STORAGEROOT-SPEC
     // pos0[1] = 456;
     // pos1[6] = 56;
     // pos1[9] = 333;
-    claim <k> Keccak256( #rlpEncodeMerkleTree( #storageRoot( #hashedLocation( "Solidity", 0, 0 ) |-> 123 #hashedLocation( "Solidity", 0, 1 ) |-> 456 #hashedLocation( "Solidity", 1, 6 ) |-> 56 #hashedLocation( "Solidity", 1, 9 ) |-> 333 ) ) )
-           => "e3d130ca69a8d33ad2058d86ba26ec414f6e5639930041d6a266ee88b25ea835"
+    claim <k> runLemma  ( Keccak256( #rlpEncodeMerkleTree( #storageRoot( #hashedLocation( "Solidity", 0, 0 ) |-> 123 #hashedLocation( "Solidity", 0, 1 ) |-> 456 #hashedLocation( "Solidity", 1, 6 ) |-> 56 #hashedLocation( "Solidity", 1, 9 ) |-> 333 ) ) ) )
+           => doneLemma ( "e3d130ca69a8d33ad2058d86ba26ec414f6e5639930041d6a266ee88b25ea835" )
           </k>
 
     // uint                                     pos0;
@@ -62,7 +70,7 @@ module STORAGEROOT-SPEC
     // pos2       = 100;
     // pos3[0][0] = 42;
     // pos3[2][1] = 2019;
-    claim <k> Keccak256( #rlpEncodeMerkleTree( #storageRoot( #hashedLocation( "Solidity", 0, .IntList ) |-> 1234 #hashedLocation( "Solidity", 1, 0 ) |-> 0 #hashedLocation( "Solidity", 1, 1 ) |-> 1 #hashedLocation( "Solidity", 2, .IntList ) |-> 100 #hashedLocation( "Solidity", 3, 0 0 ) |-> 42 #hashedLocation( "Solidity", 3, 2 1 ) |-> 2019 ) ) )
-           => "1a40e309e184fb6483112c37def9ed52e5ee36aa4b570a234a962b3a8f186610"
+    claim <k> runLemma  ( Keccak256( #rlpEncodeMerkleTree( #storageRoot( #hashedLocation( "Solidity", 0, .IntList ) |-> 1234 #hashedLocation( "Solidity", 1, 0 ) |-> 0 #hashedLocation( "Solidity", 1, 1 ) |-> 1 #hashedLocation( "Solidity", 2, .IntList ) |-> 100 #hashedLocation( "Solidity", 3, 0 0 ) |-> 42 #hashedLocation( "Solidity", 3, 2 1 ) |-> 2019 ) ) ) )
+           => doneLemma ( "1a40e309e184fb6483112c37def9ed52e5ee36aa4b570a234a962b3a8f186610" )
           </k>
 endmodule

--- a/tests/specs/functional/storageRoot-spec.k
+++ b/tests/specs/functional/storageRoot-spec.k
@@ -9,19 +9,19 @@ module VERIFICATION
  // -------------------------------------------------------
     rule <k> runLemma(S) => doneLemma(S) ... </k>
 
-    syntax Step ::= String
- // ----------------------
+    syntax Step ::= String | MerkleTree
+ // -----------------------------------
 
 endmodule
 
 module STORAGEROOT-SPEC
     imports VERIFICATION
 
-    claim <k> #storageRoot( .Map ) => .MerkleTree </k>
+    claim <k> runLemma ( #storageRoot( .Map ) ) => doneLemma ( .MerkleTree ) </k>
 
-    claim <k> #rlpEncodeString ( "" ) => "\x80" </k>
+    claim <k> runLemma ( #rlpEncodeString ( "" ) ) => doneLemma ( "\x80" ) </k>
 
-    claim <k> #rlpEncodeString ( "\x82\x04\xd2" ) => "\x83\x82\x04\xd2" </k>
+    claim <k> runLemma ( #rlpEncodeString ( "\x82\x04\xd2" ) ) => doneLemma ( "\x83\x82\x04\xd2" ) </k>
 
     // uint pos0;
     //

--- a/tests/specs/infinite-gas.k
+++ b/tests/specs/infinite-gas.k
@@ -158,7 +158,7 @@ module INFINITE-GAS-COMMON
     rule #gas(_) <Int Cmem(_, _)  => false [simplification]
     rule Cmem(_, _) <=Int #gas(_) => true  [simplification]
 
-    rule 0 <=Int #allBut64th(G)       => true                          [simplification]
+    rule 0 <=Int #allBut64th(_G)      => true                          [simplification]
     rule #allBut64th(G) <Int #gas(G') => true requires G <Int #gas(G') [simplification]
 
 endmodule


### PR DESCRIPTION
- Use set-union instead of set-concat for `<touchedAccounts>` cell, to avoid definedness issues when doing symbolic reason about them.
- Clears up some of the unused variable warnings in the lemmas and proofs.
- Adjusts the merkle-spec proofs to not have undefined initial states.
- Sequences the computation of `merkleExtensionBuilder` so that when we're accessing the first byte of a given path we already know it exists.
- Adds `runLemma/doneLemma` wrappers for some other functional proofs.