### PR TITLE
Add KEEP_OUTPUTS flag to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -337,7 +337,7 @@ tests/%.run: tests/%
 	    --mode $(KEVM_MODE) --schedule $(KEVM_SCHEDULE) --chainid $(KEVM_CHAINID)                                      \
 	    > tests/$*.$(TEST_CONCRETE_BACKEND)-out                                                                        \
 	    || $(CHECK) tests/$*.$(TEST_CONCRETE_BACKEND)-out tests/templates/output-success-$(TEST_CONCRETE_BACKEND).json
-	rm -rf tests/$*.$(TEST_CONCRETE_BACKEND)-out
+	$(KEEP_OUTPUTS) || rm -rf tests/$*.$(TEST_CONCRETE_BACKEND)-out
 
 tests/%.run-interactive: tests/%
 	$(KEVM) run $< $(TEST_OPTIONS) --backend $(TEST_CONCRETE_BACKEND)                                                  \
@@ -351,12 +351,12 @@ tests/%.run-expected: tests/% tests/%.expected
 	    --mode $(KEVM_MODE) --schedule $(KEVM_SCHEDULE) --chainid $(KEVM_CHAINID) \
 	    > tests/$*.$(TEST_CONCRETE_BACKEND)-out                                   \
 	    || $(CHECK) tests/$*.$(TEST_CONCRETE_BACKEND)-out tests/$*.expected
-	rm -rf tests/$*.$(TEST_CONCRETE_BACKEND)-out
+	$(KEEP_OUTPUTS) || rm -rf tests/$*.$(TEST_CONCRETE_BACKEND)-out
 
 tests/%.parse: tests/%
 	$(KEVM) kast $< kast $(TEST_OPTIONS) --backend $(TEST_CONCRETE_BACKEND) > $@-out
 	$(CHECK) $@-out $@-expected
-	rm -rf $@-out
+	$(KEEP_OUTPUTS) || rm -rf $@-out
 
 tests/specs/functional/lemmas-no-smt-spec.k.prove: KPROVE_OPTS += --haskell-backend-command "kore-exec --smt=none"
 

--- a/Makefile
+++ b/Makefile
@@ -320,6 +320,8 @@ KEVM_CHAINID  := 1
 KPROVE_MODULE  := VERIFICATION
 KPROVE_OPTS    ?=
 
+KEEP_OUTPUTS := false
+
 test-all: test-all-conformance test-prove test-interactive test-parse
 test: test-conformance test-prove test-interactive test-parse
 
@@ -342,7 +344,7 @@ tests/%.run-interactive: tests/%
 	    --mode $(KEVM_MODE) --schedule $(KEVM_SCHEDULE) --chainid $(KEVM_CHAINID)                                      \
 	    > tests/$*.$(TEST_CONCRETE_BACKEND)-out                                                                        \
 	    || $(CHECK) tests/$*.$(TEST_CONCRETE_BACKEND)-out tests/templates/output-success-$(TEST_CONCRETE_BACKEND).json
-	rm -rf tests/$*.$(TEST_CONCRETE_BACKEND)-out
+	$(KEEP_OUTPUTS) || rm -rf tests/$*.$(TEST_CONCRETE_BACKEND)-out
 
 tests/%.run-expected: tests/% tests/%.expected
 	$(KEVM) run $< $(TEST_OPTIONS) --backend $(TEST_CONCRETE_BACKEND)             \
@@ -369,7 +371,7 @@ tests/%.prove-dry-run: tests/%
 tests/%.search: tests/%
 	$(KEVM) search $< "<statusCode> EVMC_INVALID_INSTRUCTION </statusCode>" $(TEST_OPTIONS) --backend $(TEST_SYMBOLIC_BACKEND) > $@-out
 	$(CHECK) $@-out $@-expected
-	rm -rf $@-out
+	$(KEEP_OUTPUTS) || rm -rf $@-out
 
 tests/%.klab-prove: tests/%
 	$(KEVM) klab-prove $< $(KPROVE_MODULE) $(TEST_OPTIONS) --backend $(TEST_SYMBOLIC_BACKEND) --format-failures $(KPROVE_OPTS) \


### PR DESCRIPTION
This is needed for the Haskell backend's regression tests. We want to be able to access the output command when just running the frontend for these tests.