### PR TITLE
#constructTypedArg prove

### DIFF
--- a/abi.md
+++ b/abi.md
@@ -199,20 +199,20 @@ This is the decoding of the typed arguments.
 ```k
     syntax TypedArg ::= #constructTypedArg ( String , String ) [function]
 //  ---------------------------------------------------------------------
-    rule #constructTypedArg(T, V) => #uint160  (String2Base(V, 16) modInt pow160)                 requires T ==String "uint160"
-    rule #constructTypedArg(T, V) => #address  (String2Base(V, 16) modInt pow160)                 requires T ==String "address"
-    rule #constructTypedArg(T, V) => #uint256  (String2Base(V, 16) modInt pow256)                 requires T ==String "uint256"
-    rule #constructTypedArg(T, V) => #uint48   (String2Base(V, 16) modInt pow48)                  requires T ==String "uint48"
-    rule #constructTypedArg(T, V) => #uint16   (String2Base(V, 16) modInt pow16)                  requires T ==String "uint16"
-    rule #constructTypedArg(T, V) => #uint8    (String2Base(V, 16) modInt 256)                    requires T ==String "uint8"
-    rule #constructTypedArg(T, V) => #int256   ((String2Base(V, 16) modInt pow256) -Int pow256)   requires T ==String "int256" andBool String2Base(V, 16) modInt pow256 >Int maxSInt256
-    rule #constructTypedArg(T, V) => #int256   (String2Base(V, 16) modInt pow256)                 requires T ==String "int256" andBool String2Base(V, 16) modInt pow256 <=Int maxSInt256
-    rule #constructTypedArg(T, V) => #int128   ((String2Base(V, 16) modInt pow128) -Int pow128)   requires T ==String "int128" andBool String2Base(V, 16) modInt pow128 >Int maxSInt128
-    rule #constructTypedArg(T, V) => #int128   (String2Base(V, 16) modInt pow128)                 requires T ==String "int128" andBool String2Base(V, 16) modInt pow128 <=Int maxSInt128
-    rule #constructTypedArg(T, V) => #bytes    (#String2Bytes(V))                                 requires T ==String "bytes"
-    rule #constructTypedArg(T, V) => #bytes32  (#parseHexWord(V))                                 requires T ==String "bytes32"
-    rule #constructTypedArg(T, V) => #bool     (String2Base(V, 16) modInt 2)                      requires T ==String "bool"
-    rule #constructTypedArg(T, V) => #string   (V)                                                requires T ==String "string"
+    rule #constructTypedArg(T, V) => #uint160  (              String2Base(V, 16) modInt pow160) requires T ==String "uint160"
+    rule #constructTypedArg(T, V) => #address  (              String2Base(V, 16) modInt pow160) requires T ==String "address"
+    rule #constructTypedArg(T, V) => #uint256  (              String2Base(V, 16) modInt pow256) requires T ==String "uint256"
+    rule #constructTypedArg(T, V) => #uint48   (               String2Base(V, 16) modInt pow48) requires T ==String "uint48"
+    rule #constructTypedArg(T, V) => #uint16   (               String2Base(V, 16) modInt pow16) requires T ==String "uint16"
+    rule #constructTypedArg(T, V) => #uint8    (                 String2Base(V, 16) modInt 256) requires T ==String "uint8"
+    rule #constructTypedArg(T, V) => #int256   ((String2Base(V, 16) modInt pow256) -Int pow256) requires T ==String "int256" andBool String2Base(V, 16) modInt pow256 >Int maxSInt256
+    rule #constructTypedArg(T, V) => #int256   (              String2Base(V, 16) modInt pow256) requires T ==String "int256" andBool String2Base(V, 16) modInt pow256 <=Int maxSInt256
+    rule #constructTypedArg(T, V) => #int128   ((String2Base(V, 16) modInt pow128) -Int pow128) requires T ==String "int128" andBool String2Base(V, 16) modInt pow128 >Int maxSInt128
+    rule #constructTypedArg(T, V) => #int128   (              String2Base(V, 16) modInt pow128) requires T ==String "int128" andBool String2Base(V, 16) modInt pow128 <=Int maxSInt128
+    rule #constructTypedArg(T, V) => #bytes    (                              #String2Bytes(V)) requires T ==String "bytes"
+    rule #constructTypedArg(T, V) => #bytes32  (                              #parseHexWord(V)) requires T ==String "bytes32"
+    rule #constructTypedArg(T, V) => #bool     (                   String2Base(V, 16) modInt 2) requires T ==String "bool"
+    rule #constructTypedArg(T, V) => #string   (                                             V) requires T ==String "string"
 ```
 
 ### ABI Event Logs

--- a/abi.md
+++ b/abi.md
@@ -178,20 +178,41 @@ where `F1 : F2 : F3 : F4` is the (two's complement) byte-array representation of
 ```k
     syntax Int ::= #getValue ( TypedArg ) [function]
  // ------------------------------------------------
-    rule #getValue(   #bool( X )) => X       requires #rangeBool(X)
-    rule #getValue(#address( X )) => X       requires #rangeAddress(X)
-    rule #getValue(  #uint8( X )) => X       requires #rangeUInt(8, X)
-    rule #getValue( #uint16( X )) => X       requires #rangeUInt(16, X)
-    rule #getValue( #uint48( X )) => X       requires #rangeUInt(48, X)
-    rule #getValue(#uint160( X )) => X       requires #rangeUInt(160, X)
-    rule #getValue(#uint256( X )) => X       requires #rangeUInt(256, X)
-    rule #getValue( #int128( X )) => chop(X) requires #rangeSInt(128, X)
-    rule #getValue( #int256( X )) => chop(X) requires #rangeSInt(256, X)
-    rule #getValue(#bytes32( X )) => X       requires #rangeUInt(256, X)
+    rule #getValue(      #bool( X )) => X        requires #rangeBool(X)
+    rule #getValue(   #address( X )) => #addr(X)
+    rule #getValue(     #uint8( X )) => X        requires #rangeUInt(8, X)
+    rule #getValue(    #uint16( X )) => X        requires #rangeUInt(16, X)
+    rule #getValue(    #uint48( X )) => X        requires #rangeUInt(48, X)
+    rule #getValue(   #uint160( X )) => X        requires #rangeUInt(160, X)
+    rule #getValue(   #uint256( X )) => X        requires #rangeUInt(256, X)
+    rule #getValue(    #int128( X )) => chop(X)  requires #rangeSInt(128, X)
+    rule #getValue(    #int256( X )) => chop(X)  requires #rangeSInt(256, X)
+    rule #getValue(   #bytes32( X )) => X        requires #rangeUInt(256, X)
 
     syntax Int ::= #ceil32 ( Int ) [function, functional, smtlib(smt_ceil32)]
  // -------------------------------------------------------------------------
     rule [#ceil32]: #ceil32(N) => ((N +Int 31) /Int 32) *Int 32
+```
+
+This is the decoding of the typed arguments.
+
+```k
+    syntax TypedArg ::= #constructTypedArg ( String , String ) [function]
+//  ---------------------------------------------------------------------
+    rule #constructTypedArg(T, V) => #uint160  (String2Base(V, 16) modInt pow160)                 requires T ==String "uint160"
+    rule #constructTypedArg(T, V) => #address  (String2Base(V, 16) modInt pow160)                 requires T ==String "address"
+    rule #constructTypedArg(T, V) => #uint256  (String2Base(V, 16) modInt pow256)                 requires T ==String "uint256"
+    rule #constructTypedArg(T, V) => #uint48   (String2Base(V, 16) modInt pow48)                  requires T ==String "uint48"
+    rule #constructTypedArg(T, V) => #uint16   (String2Base(V, 16) modInt pow16)                  requires T ==String "uint16"
+    rule #constructTypedArg(T, V) => #uint8    (String2Base(V, 16) modInt 256)                    requires T ==String "uint8"
+    rule #constructTypedArg(T, V) => #int256   ((String2Base(V, 16) modInt pow256) -Int pow256)   requires T ==String "int256" andBool String2Base(V, 16) modInt pow256 >Int maxSInt256
+    rule #constructTypedArg(T, V) => #int256   (String2Base(V, 16) modInt pow256)                 requires T ==String "int256" andBool String2Base(V, 16) modInt pow256 <=Int maxSInt256
+    rule #constructTypedArg(T, V) => #int128   ((String2Base(V, 16) modInt pow128) -Int pow128)   requires T ==String "int128" andBool String2Base(V, 16) modInt pow128 >Int maxSInt128
+    rule #constructTypedArg(T, V) => #int128   (String2Base(V, 16) modInt pow128)                 requires T ==String "int128" andBool String2Base(V, 16) modInt pow128 <=Int maxSInt128
+    rule #constructTypedArg(T, V) => #bytes    (#String2Bytes(V))                                 requires T ==String "bytes"
+    rule #constructTypedArg(T, V) => #bytes32  (#parseHexWord(V))                                 requires T ==String "bytes32"
+    rule #constructTypedArg(T, V) => #bool     (String2Base(V, 16) modInt 2)                      requires T ==String "bool"
+    rule #constructTypedArg(T, V) => #string   (V)                                                requires T ==String "string"
 ```
 
 ### ABI Event Logs

--- a/abi.md
+++ b/abi.md
@@ -209,7 +209,7 @@ This is the decoding of the typed arguments.
     rule #constructTypedArg(T, V) => #int256   (              String2Base(V, 16) modInt pow256) requires T ==String "int256" andBool String2Base(V, 16) modInt pow256 <=Int maxSInt256
     rule #constructTypedArg(T, V) => #int128   ((String2Base(V, 16) modInt pow128) -Int pow128) requires T ==String "int128" andBool String2Base(V, 16) modInt pow128 >Int maxSInt128
     rule #constructTypedArg(T, V) => #int128   (              String2Base(V, 16) modInt pow128) requires T ==String "int128" andBool String2Base(V, 16) modInt pow128 <=Int maxSInt128
-    rule #constructTypedArg(T, V) => #bytes    (                              #String2Bytes(V)) requires T ==String "bytes"
+    rule #constructTypedArg(T, V) => #bytes    (                               String2Bytes(V)) requires T ==String "bytes"
     rule #constructTypedArg(T, V) => #bytes32  (                              #parseHexWord(V)) requires T ==String "bytes32"
     rule #constructTypedArg(T, V) => #bool     (                   String2Base(V, 16) modInt 2) requires T ==String "bool"
     rule #constructTypedArg(T, V) => #string   (                                             V) requires T ==String "string"

--- a/tests/specs/functional/abi-spec.k
+++ b/tests/specs/functional/abi-spec.k
@@ -1,0 +1,54 @@
+requires "../lemmas.k"
+
+module VERIFICATION
+    imports LEMMAS
+
+    syntax StepSort ::= Int | Bool | String
+ // ---------------------------------------
+
+    syntax KItem ::= runLemma ( StepSort )
+                   | doneLemma( StepSort )
+ // --------------------------------------
+    rule runLemma( T ) => doneLemma( T )
+
+endmodule
+
+module ABI-SPEC
+    imports VERIFICATION
+
+    claim <k> runLemma ( #getValue(#constructTypedArg("bool", "01")) ) => doneLemma ( 1 ) ... </k>
+    claim <k> runLemma ( #typeName(#constructTypedArg("bool", "01")) ) => doneLemma ( "bool" ) ... </k>
+
+    claim <k> runLemma ( #getValue(#constructTypedArg("uint160", "1461501637330902918203684832716283019655932542976")) ) => doneLemma ( 0 ) ... </k>
+    claim <k> runLemma ( #typeName(#constructTypedArg("uint160", "1461501637330902918203684832716283019655932542976")) ) => doneLemma ( "uint160" ) ... </k>
+
+    claim <k> runLemma ( #getValue(#constructTypedArg("address", "1234567890")) ) => doneLemma ( 1234567890 ) ... </k>
+    claim <k> runLemma ( #typeName(#constructTypedArg("address", "1234567890")) ) => doneLemma ( "address" ) ... </k>
+
+    claim <k> runLemma ( #getValue(#constructTypedArg("uint256", "115792089237316195423570985008687907853269984665640564039457584007913129639936")) ) => doneLemma ( 0 ) ... </k>
+    claim <k> runLemma ( #typeName(#constructTypedArg("uint256", "115792089237316195423570985008687907853269984665640564039457584007913129639936")) ) => doneLemma ( "uint256" ) ... </k>
+
+    claim <k> runLemma ( #getValue(#constructTypedArg("uint48", "281474976710656")) ) => doneLemma ( 0 ) ... </k>
+    claim <k> runLemma ( #typeName(#constructTypedArg("uint48", "281474976710656")) ) => doneLemma ( "uint48" ) ... </k>
+
+    claim <k> runLemma ( #getValue(#constructTypedArg("uint16", "65536")) ) => doneLemma ( 0 ) ... </k>
+    claim <k> runLemma ( #typeName(#constructTypedArg("uint16", "65536")) ) => doneLemma ( "uint16" ) ... </k>
+
+    claim <k> runLemma ( #getValue(#constructTypedArg("uint8", "256")) ) => doneLemma ( 0 ) ... </k>
+    claim <k> runLemma ( #typeName(#constructTypedArg("uint8", "256")) ) => doneLemma ( "uint8" ) ... </k>
+
+    claim <k> runLemma ( #getValue(#constructTypedArg("int256", "57896044618658097711785492504343953926634992332820282019728792003956564819967")) ) => doneLemma ( -57896044618658097711785492504343953926634992332820282019728792003956564819967 ) ... </k>
+    claim <k> runLemma ( #getValue(#constructTypedArg("int256", "100")) ) => doneLemma ( 100 ) ... </k>
+    claim <k> runLemma ( #typeName(#constructTypedArg("int256", "100")) ) => doneLemma ( "int256" ) ... </k>
+
+    claim <k> runLemma ( #getValue(#constructTypedArg("int128", "170141183460469231731687303715884105727")) ) => doneLemma ( -170141183460469231731687303715884105727 ) ... </k>
+    claim <k> runLemma ( #getValue(#constructTypedArg("int128", "100")) ) => doneLemma ( 100 ) ... </k>
+    claim <k> runLemma ( #typeName(#constructTypedArg("int128", "100")) ) => doneLemma ( "int128" ) ... </k>
+
+    claim <k> runLemma ( #getValue(#constructTypedArg("bytes", "1234567890")) ) => doneLemma ( "1234567890" ) ... </k>
+    claim <k> runLemma ( #typeName(#constructTypedArg("bytes", "1234567890")) ) => doneLemma ( "bytes" ) ... </k>
+
+    claim <k> runLemma ( #getValue(#constructTypedArg("bytes32", "1234567890")) ) => doneLemma ( "1234567890" ) ... </k>
+    claim <k> runLemma ( #typeName(#constructTypedArg("bytes32", "1234567890")) ) => doneLemma ( "bytes32" ) ... </k>
+endmodule
+


### PR DESCRIPTION
Implemented `#constructTypedArg` and corresponding spec test.