### PR TITLE
Port tests/spec/benchmarks/encode-keccak00-spec.k to Haskell backend

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,7 +35,7 @@ pipeline {
         stage('Proofs') {
           options {
             lock("proofs-${env.NODE_NAME}")
-            timeout(time: 100, unit: 'MINUTES')
+            timeout(time: 120, unit: 'MINUTES')
           }
           parallel {
             stage('Java')              { steps { sh 'make test-prove -j5 TEST_SYMBOLIC_BACKEND=java'    } }

--- a/tests/failing-symbolic.haskell
+++ b/tests/failing-symbolic.haskell
@@ -8,6 +8,7 @@ tests/specs/benchmarks/ecrecoverloop00-sigs-valid-spec.k
 tests/specs/benchmarks/ecrecoverloop02-sig0-invalid-spec.k
 tests/specs/benchmarks/ecrecoverloop02-sig1-invalid-spec.k
 tests/specs/benchmarks/ecrecoverloop02-sigs-valid-spec.k
+tests/specs/benchmarks/encode-keccak00-spec.k
 tests/specs/benchmarks/encodepacked-keccak01-spec.k
 tests/specs/benchmarks/keccak00-spec.k
 tests/specs/benchmarks/overflow00-nooverflow-spec.k

--- a/tests/failing-symbolic.haskell
+++ b/tests/failing-symbolic.haskell
@@ -8,7 +8,6 @@ tests/specs/benchmarks/ecrecoverloop00-sigs-valid-spec.k
 tests/specs/benchmarks/ecrecoverloop02-sig0-invalid-spec.k
 tests/specs/benchmarks/ecrecoverloop02-sig1-invalid-spec.k
 tests/specs/benchmarks/ecrecoverloop02-sigs-valid-spec.k
-tests/specs/benchmarks/encode-keccak00-spec.k
 tests/specs/benchmarks/encodepacked-keccak01-spec.k
 tests/specs/benchmarks/keccak00-spec.k
 tests/specs/benchmarks/overflow00-nooverflow-spec.k

--- a/tests/specs/benchmarks/functional-spec.k
+++ b/tests/specs/benchmarks/functional-spec.k
@@ -18,8 +18,7 @@ module FUNCTIONAL-SPEC
     claim <k> runLemma(#encodeArgs(#bytes32(keccak(1 : #encodeArgs(#uint256(A0)))))) => doneLemma(#buf(32, keccak(#buf(1,1) ++ #buf(32, A0)))) ... </k> requires #rangeUInt(256, A0)
 
     claim <k> runLemma(#buf(32, maxUInt256 &Int keccak(#buf(32, maxUInt256 &Int A0) ++ #buf(32, maxUInt256 &Int A1))))
-           => doneLemma(#buf(32, keccak(#buf(32,A0) ++ #buf(32,A1))))
-          </k>
+           => doneLemma(#buf(32, keccak(#buf(32,A0) ++ #buf(32,A1)))) ... </k>
       requires #rangeUInt(256, A0)
        andBool #rangeUInt(256, A1)
 endmodule

--- a/tests/specs/benchmarks/functional-spec.k
+++ b/tests/specs/benchmarks/functional-spec.k
@@ -17,4 +17,9 @@ module FUNCTIONAL-SPEC
 
     claim <k> runLemma(#encodeArgs(#bytes32(keccak(1 : #encodeArgs(#uint256(A0)))))) => doneLemma(#buf(32, keccak(#buf(1,1) ++ #buf(32, A0)))) ... </k> requires #rangeUInt(256, A0)
 
+    claim <k> runLemma(#buf(32, maxUInt256 &Int keccak(#buf(32, maxUInt256 &Int A0) ++ #buf(32, maxUInt256 &Int A1))))
+           => doneLemma(#buf(32, keccak(#buf(32,A0) ++ #buf(32,A1))))
+          </k>
+      requires #rangeUInt(256, A0)
+       andBool #rangeUInt(256, A1)
 endmodule

--- a/tests/specs/benchmarks/verification.k
+++ b/tests/specs/benchmarks/verification.k
@@ -162,6 +162,9 @@ module VERIFICATION
 
     rule #asWord(WS) &Int maxUInt256 => #asWord(WS)
       [simplification]
+    
+    rule maxUInt256 &Int X => X requires #rangeUInt(256, X)
+      [simplification]
 
     // 2^256 - 2^160 = 0xff..ff00..00 (96 1's followed by 160 0's)
     rule 115792089237316195423570985007226406215939081747436879206741300988257197096960 &Int ADDR => 0


### PR DESCRIPTION
~~I tentatively removed this test from `tests/failing-symbolic.haskell` as well.~~

fixes #1011