### PR TITLE
Reduce ceil32 to up/Int

### DIFF
--- a/abi.md
+++ b/abi.md
@@ -189,9 +189,9 @@ where `F1 : F2 : F3 : F4` is the (two's complement) byte-array representation of
     rule #getValue( #int256( X )) => chop(X) requires #rangeSInt(256, X)
     rule #getValue(#bytes32( X )) => X       requires #rangeUInt(256, X)
 
-    syntax Int ::= #ceil32 ( Int ) [function, functional, smtlib(smt_ceil32)]
- // -------------------------------------------------------------------------
-    rule [#ceil32]: #ceil32(N) => ((N +Int 31) /Int 32) *Int 32
+    syntax Int ::= #ceil32 ( Int )
+ // ------------------------------
+    rule #ceil32(N) => (N up/Int 32) *Int 32 [macro]
 ```
 
 ### ABI Event Logs

--- a/evm-types.md
+++ b/evm-types.md
@@ -198,11 +198,12 @@ NOTE: Here, we choose to add `I2 -Int 1` to the numerator beforing doing the div
 You could alternatively calculate `I1 modInt I2`, then add one to the normal integer division afterward depending on the result.
 
 ```k
-    syntax Int ::= Int "up/Int" Int [function]
- // ------------------------------------------
-    rule _I1 up/Int 0  => 0
-    rule  I1 up/Int 1  => I1
-    rule  I1 up/Int I2 => (I1 +Int (I2 -Int 1)) /Int I2 requires I2 >Int 1
+    syntax Int ::= Int "up/Int" Int [function, functional, smtlib(upDivInt)]
+ // ------------------------------------------------------------------------
+    rule              _I1 up/Int 0  => 0
+    rule              _I1 up/Int I2 => 0                             requires I2 <Int 0
+    rule               I1 up/Int 1  => I1
+    rule [upDivInt] :  I1 up/Int I2 => (I1 +Int (I2 -Int 1)) /Int I2 requires I2 >Int 1
 ```
 
 -   `log256Int` returns the log base 256 (floored) of an integer.

--- a/tests/specs/benchmarks/verification.k
+++ b/tests/specs/benchmarks/verification.k
@@ -251,8 +251,6 @@ module VERIFICATION
 
     rule X <=Int #ceil32(X) => true requires X >=Int 0 [simplification]
 
-    rule #ceil32(N) => ((N +Int 31) /Int 32) *Int 32 [smt-lemma]
-
   // ########################
   // Gnosis
   // ########################

--- a/tests/specs/bihu/concrete-rules.txt
+++ b/tests/specs/bihu/concrete-rules.txt
@@ -1,4 +1,3 @@
-EVM-ABI.#ceil32
 EVM.Cextra
 EVM.Cgascap
 EVM.Cmem
@@ -14,6 +13,7 @@ EVM-TYPES.powmod.zero
 EVM-TYPES.signextend.invalid
 EVM-TYPES.signextend.negative
 EVM-TYPES.signextend.positive
+EVM-TYPES.upDivInt
 HASHED-LOCATIONS.keccakIntList
 SERIALIZATION.keccak
 SERIALIZATION.#newAddr

--- a/tests/specs/concrete-rules.txt
+++ b/tests/specs/concrete-rules.txt
@@ -1,4 +1,3 @@
-EVM-ABI.#ceil32
 EVM.allBut64th.pos
 EVM.Cextra
 EVM.Cgascap
@@ -24,6 +23,7 @@ EVM-TYPES.#range
 EVM-TYPES.signextend.invalid
 EVM-TYPES.signextend.negative
 EVM-TYPES.signextend.positive
+EVM-TYPES.upDivInt
 HASHED-LOCATIONS.keccakIntList
 SERIALIZATION.keccak
 SERIALIZATION.#newAddr

--- a/tests/specs/erc20/concrete-rules.txt
+++ b/tests/specs/erc20/concrete-rules.txt
@@ -1,4 +1,3 @@
-EVM-ABI.#ceil32
 EVM.Cextra
 EVM.Cgascap
 EVM.Cmem
@@ -21,6 +20,7 @@ EVM-TYPES.#range
 EVM-TYPES.signextend.invalid
 EVM-TYPES.signextend.negative
 EVM-TYPES.signextend.positive
+EVM-TYPES.upDivInt
 HASHED-LOCATIONS.keccakIntList
 SERIALIZATION.keccak
 SERIALIZATION.#newAddr

--- a/tests/specs/functional/infinite-gas-spec.k
+++ b/tests/specs/functional/infinite-gas-spec.k
@@ -61,6 +61,9 @@ module INFINITE-GAS-SPEC
            => doneLemma(#gas(-271 -Int Cmem(ISTANBUL, #memoryUsageUpdate(5, 160, DATA_LEN)) -Int 3 *Int (DATA_LEN up/Int 32) +Int -3)) ... </k>
       requires 0 <=Int DATA_LEN andBool DATA_LEN <Int pow16
 
+    claim <k> runLemma(  #gas( -271 -Int CMEM -Int 3 *Int ( DATA_LEN up/Int 32 ) -Int CMEM' +Int CMEM -Int Cmem ( ISTANBUL , #memoryUsageUpdate ( 5 , ( DATA_LEN +Int 31 ) /Int 32 *Int 32 +Int 160 , 32 ) ) +Int CMEM' +Int -122))
+           => doneLemma( #gas( -271           -Int 3 *Int ( DATA_LEN up/Int 32 )                      -Int Cmem ( ISTANBUL , #memoryUsageUpdate ( 5 , ( DATA_LEN +Int 31 ) /Int 32 *Int 32 +Int 160 , 32 ) )            +Int -122)) ... </k>
+
  // Infinite Gas comparisons
  // ------------------------
 

--- a/tests/specs/functional/infinite-gas-spec.k
+++ b/tests/specs/functional/infinite-gas-spec.k
@@ -92,4 +92,6 @@ module INFINITE-GAS-SPEC
     claim <k> runLemma(Gexp < SCHED > +Int Gexpbyte < SCHED > *Int ( log2Int ( W1 ) /Int 8 +Int 1 ) <=Int #gas(GAVAIL)) => doneLemma(true)  ... </k>
     claim <k> runLemma(#gas(GAVAIL) <Int Gexp < SCHED > +Int Gexpbyte < SCHED > *Int ( log2Int ( W1 ) /Int 8 +Int 1 ))  => doneLemma(false) ... </k>
 
+    claim <k> runLemma(#gas ( -271 -Int Cmem ( ISTANBUL , #memoryUsageUpdate ( 5 , 160 , DATA_LEN ) ) ) <Int 3 *Int ( DATA_LEN up/Int 32 ) +Int 3) => doneLemma(false) ... </k> requires 0 <=Int DATA_LEN andBool DATA_LEN <Int pow16
+
 endmodule

--- a/tests/specs/functional/infinite-gas-spec.k
+++ b/tests/specs/functional/infinite-gas-spec.k
@@ -105,7 +105,7 @@ module INFINITE-GAS-SPEC
     claim <k> runLemma(#gas(G) <Int         DATA_LEN up/Int 32        ) => doneLemma(false) ... </k> requires 0 <=Int DATA_LEN andBool DATA_LEN <Int pow16
     claim <k> runLemma(#gas(G) <Int         DATA_LEN                  ) => doneLemma(false) ... </k> requires 0 <=Int DATA_LEN andBool DATA_LEN <Int pow16
 
-    claim <k> runLemma(0 <=Int 3 *Int (DATA_LEN up/Int 32)) => doneLemma(true) ... </k> requires 0 <=Int DATA_LEN andBool DATA_LEN <Int pow16
+    claim <k> runLemma(0 <=Int 3 *Int (DATA_LEN up/Int 32))      => doneLemma(true) ... </k> requires 0 <=Int DATA_LEN andBool DATA_LEN <Int pow16
     claim <k> runLemma(3 *Int (DATA_LEN up/Int 32) <Int #gas(_)) => doneLemma(true) ... </k> requires 0 <=Int DATA_LEN andBool DATA_LEN <Int pow16
 
 endmodule

--- a/tests/specs/functional/infinite-gas-spec.k
+++ b/tests/specs/functional/infinite-gas-spec.k
@@ -55,6 +55,12 @@ module INFINITE-GAS-SPEC
     claim <k> runLemma(#gas(G) -Int Cmem(SCHED, #memoryUsageUpdate(MU, W0, 32))) => doneLemma(#gas(G -Int Cmem(SCHED, #memoryUsageUpdate(MU, W0, 32)))) ... </k>
     claim <k> runLemma(#gas(G) -Int Gverylow < SCHED >) => doneLemma(#gas(G -Int Gverylow < SCHED >)) ... </k>
 
+    claim <k> runLemma(#gas(G) -Int 3 *Int (DATA_LEN up/Int 32)) => doneLemma(#gas(G -Int 3 *Int (DATA_LEN up/Int 32))) ... </k> requires 0 <=Int DATA_LEN andBool DATA_LEN <Int pow16
+
+    claim <k> runLemma (#gas(-271 -Int Cmem(ISTANBUL, #memoryUsageUpdate(5, 160, DATA_LEN))) -Int 3 *Int (DATA_LEN up/Int 32) +Int -3)
+           => doneLemma(#gas(-271 -Int Cmem(ISTANBUL, #memoryUsageUpdate(5, 160, DATA_LEN)) -Int 3 *Int (DATA_LEN up/Int 32) +Int -3)) ... </k>
+      requires 0 <=Int DATA_LEN andBool DATA_LEN <Int pow16
+
  // Infinite Gas comparisons
  // ------------------------
 
@@ -92,6 +98,11 @@ module INFINITE-GAS-SPEC
     claim <k> runLemma(Gexp < SCHED > +Int Gexpbyte < SCHED > *Int ( log2Int ( W1 ) /Int 8 +Int 1 ) <=Int #gas(GAVAIL)) => doneLemma(true)  ... </k>
     claim <k> runLemma(#gas(GAVAIL) <Int Gexp < SCHED > +Int Gexpbyte < SCHED > *Int ( log2Int ( W1 ) /Int 8 +Int 1 ))  => doneLemma(false) ... </k>
 
-    claim <k> runLemma(#gas ( -271 -Int Cmem ( ISTANBUL , #memoryUsageUpdate ( 5 , 160 , DATA_LEN ) ) ) <Int 3 *Int ( DATA_LEN up/Int 32 ) +Int 3) => doneLemma(false) ... </k> requires 0 <=Int DATA_LEN andBool DATA_LEN <Int pow16
+    claim <k> runLemma(#gas(G) <Int 3 *Int (DATA_LEN up/Int 32) +Int 3) => doneLemma(false) ... </k> requires 0 <=Int DATA_LEN andBool DATA_LEN <Int pow16
+    claim <k> runLemma(#gas(G) <Int         DATA_LEN up/Int 32        ) => doneLemma(false) ... </k> requires 0 <=Int DATA_LEN andBool DATA_LEN <Int pow16
+    claim <k> runLemma(#gas(G) <Int         DATA_LEN                  ) => doneLemma(false) ... </k> requires 0 <=Int DATA_LEN andBool DATA_LEN <Int pow16
+
+    claim <k> runLemma(0 <=Int 3 *Int (DATA_LEN up/Int 32)) => doneLemma(true) ... </k> requires 0 <=Int DATA_LEN andBool DATA_LEN <Int pow16
+    claim <k> runLemma(3 *Int (DATA_LEN up/Int 32) <Int #gas(_)) => doneLemma(true) ... </k> requires 0 <=Int DATA_LEN andBool DATA_LEN <Int pow16
 
 endmodule

--- a/tests/specs/infinite-gas.k
+++ b/tests/specs/infinite-gas.k
@@ -173,4 +173,7 @@ module INFINITE-GAS-COMMON
     rule log2Int(_) <=Int #gas(_) => true  [simplification]
     rule #gas(_) <Int log2Int(_)  => false [simplification]
 
+    rule _ up/Int _ <=Int #gas(_) => true  [simplification]
+    rule #gas(_) <Int _ up/Int _  => false [simplification]
+
 endmodule

--- a/tests/specs/infinite-gas.k
+++ b/tests/specs/infinite-gas.k
@@ -89,8 +89,10 @@ module INFINITE-GAS-COMMON
     rule (notBool (A andBool B)) andBool A => (notBool B) andBool A                      [simplification]
     rule #if B #then C +Int C1 #else C +Int C2 #fi => C +Int #if B #then C1 #else C2 #fi [simplification]
 
-    rule I -Int I => 0              [simplification]
-    rule (I1 -Int I2) +Int I2 => I1 [simplification]
+    rule I -Int I => 0                                                    [simplification]
+    rule   (I1 -Int I2)                   +Int I2 =>  I1                  [simplification]
+    rule  ((I1 -Int I2) -Int I3)          +Int I2 =>  I1 -Int I3          [simplification]
+    rule (((I1 -Int I2) -Int I3) -Int I4) +Int I2 => (I1 -Int I3) -Int I4 [simplification]
 
     rule X -Int Y +Int Z <=Int A => false requires A <Int X -Int Y andBool 0 <=Int Z [simplification]
 

--- a/tests/specs/infinite-gas.k
+++ b/tests/specs/infinite-gas.k
@@ -138,6 +138,8 @@ module INFINITE-GAS-COMMON
     rule I *Int I' <=Int #gas(G) => true requires                     I <=Int #gas(G) andBool I' <=Int #gas(G) [simplification]
     rule I /Int I' <=Int #gas(G) => true requires I' =/=Int 0 andBool I <=Int #gas(G) andBool I' <=Int #gas(G) [simplification]
 
+    rule I *Int I' <Int #gas(G) => true requires I <Int #gas(G) andBool I' <Int #gas(G) [simplification]
+
     rule #gas(G) <Int I +Int I' => false requires                     notBool (#gas(G) <Int I orBool #gas(G) <Int I') [simplification]
     rule #gas(G) <Int I -Int I' => false requires                     notBool (#gas(G) <Int I orBool #gas(G) <Int I') [simplification]
     rule #gas(G) <Int I *Int I' => false requires                     notBool (#gas(G) <Int I orBool #gas(G) <Int I') [simplification]
@@ -166,14 +168,18 @@ module INFINITE-GAS-COMMON
     rule #allBut64th(G) <Int #gas(G') => true requires G <Int #gas(G') [simplification]
 
     rule 0 <=Int _:ScheduleConst < _:Schedule >       => true  [simplification]
-    rule _:ScheduleConst < _:Schedule > <Int #gas(_)  => true  [simplification]
+    rule _:ScheduleConst < _:Schedule >  <Int #gas(_) => true  [simplification]
     rule _:ScheduleConst < _:Schedule > <=Int #gas(_) => true  [simplification]
     rule #gas(_) <Int _:ScheduleConst < _:Schedule >  => false [simplification]
 
     rule log2Int(_) <=Int #gas(_) => true  [simplification]
     rule #gas(_) <Int log2Int(_)  => false [simplification]
 
-    rule _ up/Int _ <=Int #gas(_) => true  [simplification]
-    rule #gas(_) <Int _ up/Int _  => false [simplification]
+    rule 0 <=Int G up/Int _        => true  requires         0 <=Int G        [simplification]
+    rule G up/Int _  <Int #gas(G') => true  requires         G  <Int #gas(G') [simplification]
+    rule G up/Int _ <=Int #gas(G') => true  requires         G <=Int #gas(G') [simplification]
+    rule #gas(G') <Int G up/Int _  => false requires notBool #gas(G') <Int G  [simplification]
+
+    rule 0 <=Int X *Int Y => true requires 0 <=Int X andBool 0 <=Int Y [simplification]
 
 endmodule

--- a/tests/specs/mcd/concrete-rules.txt
+++ b/tests/specs/mcd/concrete-rules.txt
@@ -1,4 +1,3 @@
-EVM-ABI.#ceil32
 EVM.allBut64th.pos
 EVM.Cextra
 EVM.Cmem
@@ -24,6 +23,7 @@ EVM-TYPES.#rangeAux.rec
 EVM-TYPES.signextend.invalid
 EVM-TYPES.signextend.negative
 EVM-TYPES.signextend.positive
+EVM-TYPES.upDivInt
 HASHED-LOCATIONS.keccakIntList
 SERIALIZATION.keccak
 SERIALIZATION.#newAddr


### PR DESCRIPTION
Currently we have several places which use ceil32, and several places which use up/Int, but no common lemmas because they're used in different contexts. This PR:

- Reduces `ceil32` to `up/Int` via a `macro`.
- Adds gas simplification lemmas for `up/Int` and some other gas expressions.
- Switches over the concrete-rules files to using `up/Int` instead of `ceil32`.
- Adds functional tests of the new lemmas.