### PR TITLE
Fixes `Could not find module: INFINITE-GAS-JAVA`

### DIFF
--- a/infinite-gas.md
+++ b/infinite-gas.md
@@ -87,7 +87,6 @@ In particular, this means that `#gas(_) <Int #gas(_) => false`, and `#gas(_) <=I
     rule log2Int(_) <=Int #gas(_) => true  [simplification]
     rule #gas(_) <Int log2Int(_)  => false [simplification]
 endmodule
-```
 
 module INFINITE-GAS-HASKELL [kore]
     imports INFINITE-GAS-COMMON


### PR DESCRIPTION
Previously, `make build -j8` yielded `[Error] Compiler: Could not find module: INFINITE-GAS-JAVA`. This was because of an extra triple-backtick.