### PR TITLE
Generalized lemma in `tests/specs/lemmas.k`

### DIFF
--- a/tests/specs/lemmas.k
+++ b/tests/specs/lemmas.k
@@ -41,14 +41,12 @@ module LEMMAS
     rule (BUF1 ++ BUF2)[START .. WIDTH] => BUF2 [START -Int #sizeByteArray(BUF1) .. WIDTH]
       requires START >=Int #sizeByteArray(BUF1) [simplification]
 
-    rule #sizeByteArray(BUF1 ++ BUF2)                  => #sizeByteArray(BUF1) +Int #sizeByteArray(BUF2)  [simplification]
-    rule #sizeByteArray(#buf(SIZE, _))                 => SIZE                                            [simplification]
-    rule #sizeByteArray(#buf(SIZE, _)[START .. WIDTH]) => WIDTH
-      requires #range(0 <= START < SIZE)
-       andBool #range(0 < WIDTH <= SIZE -Int START)                                                       [simplification]
-
-    rule #sizeByteArray(#range(_, START, WIDTH)) => WIDTH
-      requires WIDTH >=Int 0 andBool START >=Int 0                                                        [simplification]
+    rule #sizeByteArray(BUF1 ++ BUF2)                  => #sizeByteArray(BUF1) +Int #sizeByteArray(BUF2)     [simplification]
+    rule #sizeByteArray(#buf(SIZE, _))                 => SIZE                                               [simplification]
+    rule #sizeByteArray(_BUF [ START .. WIDTH ])       => WIDTH
+        requires 0 <=Int START andBool 0 <=Int WIDTH                                                         [simplification]
+    rule #sizeByteArray(#range(_, START, WIDTH))       => WIDTH
+      requires WIDTH >=Int 0 andBool START >=Int 0                                                           [simplification]
 
     //Todo custom ==K unification doesn't work in Haskell yet
     //++ unification

--- a/tests/specs/lemmas.k
+++ b/tests/specs/lemmas.k
@@ -41,12 +41,10 @@ module LEMMAS
     rule (BUF1 ++ BUF2)[START .. WIDTH] => BUF2 [START -Int #sizeByteArray(BUF1) .. WIDTH]
       requires START >=Int #sizeByteArray(BUF1) [simplification]
 
-    rule #sizeByteArray(BUF1 ++ BUF2)                  => #sizeByteArray(BUF1) +Int #sizeByteArray(BUF2)     [simplification]
-    rule #sizeByteArray(#buf(SIZE, _))                 => SIZE                                               [simplification]
-    rule #sizeByteArray(_BUF [ START .. WIDTH ])       => WIDTH
-        requires 0 <=Int START andBool 0 <=Int WIDTH                                                         [simplification]
-    rule #sizeByteArray(#range(_, START, WIDTH))       => WIDTH
-      requires 0 <=Int START andBool 0 <=Int WIDTH                                                           [simplification]
+    rule #sizeByteArray(BUF1 ++ BUF2)            => #sizeByteArray(BUF1) +Int #sizeByteArray(BUF2)     [simplification]
+    rule #sizeByteArray(#buf(SIZE, _))           => SIZE                                               [simplification]
+    rule #sizeByteArray(_BUF [ START .. WIDTH ]) => WIDTH requires 0 <=Int START andBool 0 <=Int WIDTH [simplification]
+    rule #sizeByteArray(#range(_, START, WIDTH)) => WIDTH requires 0 <=Int START andBool 0 <=Int WIDTH [simplification]
 
     //Todo custom ==K unification doesn't work in Haskell yet
     //++ unification

--- a/tests/specs/lemmas.k
+++ b/tests/specs/lemmas.k
@@ -46,7 +46,7 @@ module LEMMAS
     rule #sizeByteArray(_BUF [ START .. WIDTH ])       => WIDTH
         requires 0 <=Int START andBool 0 <=Int WIDTH                                                         [simplification]
     rule #sizeByteArray(#range(_, START, WIDTH))       => WIDTH
-      requires WIDTH >=Int 0 andBool START >=Int 0                                                           [simplification]
+      requires 0 <=Int START andBool 0 <=Int WIDTH                                                           [simplification]
 
     //Todo custom ==K unification doesn't work in Haskell yet
     //++ unification

--- a/tests/specs/mcd/verification.k
+++ b/tests/specs/mcd/verification.k
@@ -101,8 +101,6 @@ module LEMMAS-MCD-COMMON
 
     // ### cat-exhaustiveness
 
-    rule #sizeByteArray(_WS [ START .. WIDTH ]) => WIDTH requires 0 <=Int START andBool 0 <=Int WIDTH [simplification]
-
     rule WS [ START .. WIDTH ] [ 0 .. WIDTH' ]  => WS [ START .. WIDTH' ] requires WIDTH' <=Int WIDTH [simplification]
 
     // ### cat-file-addr-pass-rough


### PR DESCRIPTION
In `tests/specs/mcd/verification.k` the lemma
```
rule #sizeByteArray(_WS [ START .. WIDTH ]) => WIDTH requires 0 <=Int START andBool 0 <=Int WIDTH [simplification]
```
is strictly more general that the following lemma from `tests/specs/lemmas.k`
```
rule #sizeByteArray(#buf(SIZE, _)[START .. WIDTH]) => WIDTH
  requires #range(0 <= START < SIZE)
   andBool #range(0 < WIDTH <= SIZE -Int START)
```
So, the more general lemma has been moved from `tests/specs/lemmas.k` to `tests/specs/mcd/verification.k`, and the less general lemma in `tests/specs/mcd/verification` has been removed. This works because the module in `tests/specs/mcd/verification.k` that used the less general lemma already imports the module in `tests/specs/lemmas.k` that now has the more general lemma.