### PR TITLE
Remove hash1/hash2/keccakIntList abstractions

### DIFF
--- a/hashed-locations.md
+++ b/hashed-locations.md
@@ -90,16 +90,6 @@ Specifically, `#hashedLocation` is defined as follows, capturing the storage lay
     rule bytesInNextInt(WS, N) => #sizeByteArray(WS) -Int 32 *Int (N -Int 1)
 ```
 
-Solidity stores values of type `bytes` and `string` in one slot if they are short enough.
-If the data is at most 31 bytes long, it is stored in the higher-order bytes (left aligned) and the lowest-order byte stores `2 * length`.
-
-```k
-    syntax Int ::= #packBytes ( ByteArray ) [function]
- // --------------------------------------------------
-    rule #packBytes( WS ) => #asInteger(#padRightToWidth(31, WS) ++ #asByteStack(2 *Int #sizeByteArray(WS)))
-      requires #sizeByteArray(WS) <=Int 31
-```
-
 ```k
 endmodule
 ```

--- a/hashed-locations.md
+++ b/hashed-locations.md
@@ -54,40 +54,17 @@ More information about how storage locations are defined in Solidity can be foun
 Specifically, `#hashedLocation` is defined as follows, capturing the storage layout schemes of Solidity and Vyper.
 
 ```k
-    syntax IntList ::= List{Int, ""}                             [klabel(intList)]
-    syntax Int     ::= #hashedLocation( String , Int , IntList ) [function]
- // -----------------------------------------------------------------------
-    rule #hashedLocation(_LANG, BASE, .IntList) => BASE
+    syntax Int ::= #hashedLocation( String , Int , IntList ) [function, klabel(hashLoc), smtlib(hashLoc)]
+ // -----------------------------------------------------------------------------------------------------
+    rule #hashedLocation(_LANG, BASE, .IntList      ) => BASE
+    rule #hashedLocation( LANG, BASE, OFFSET OFFSETS) => #hashedLocation(LANG, #hashedLocation(LANG, BASE, OFFSET .IntList), OFFSETS) requires OFFSETS =/=K .IntList
 
-    rule #hashedLocation("Vyper",    BASE, OFFSET OFFSETS) => #hashedLocation("Vyper",    keccakIntList(BASE OFFSET),       OFFSETS)
-    rule #hashedLocation("Solidity", BASE, OFFSET OFFSETS) => #hashedLocation("Solidity", keccakIntList(OFFSET BASE),       OFFSETS)
-    rule #hashedLocation("Array",    BASE, OFFSET OFFSETS) => #hashedLocation("Array",    keccakIntList(BASE) +Word OFFSET, OFFSETS)
+    rule #hashedLocation("Vyper",    BASE, OFFSET .IntList) => keccak(#bufStrict(32, BASE)   ++ #bufStrict(32, OFFSET)) requires #rangeUInt(256, BASE) andBool #rangeUInt(256, OFFSET)
+    rule #hashedLocation("Solidity", BASE, OFFSET .IntList) => keccak(#bufStrict(32, OFFSET) ++ #bufStrict(32, BASE))   requires #rangeUInt(256, BASE) andBool #rangeUInt(256, OFFSET)
+    rule #hashedLocation("Array",    BASE, OFFSET .IntList) => keccak(#bufStrict(32, BASE)) +Word OFFSET                requires #rangeUInt(256, BASE) andBool #rangeUInt(256, OFFSET)
 
-    syntax Int ::= keccakIntList( IntList ) [function]
- // --------------------------------------------------
-    rule [keccakIntList]: keccakIntList(VS) => keccak(intList2ByteArray(VS))
-
-    syntax ByteArray ::= intList2ByteArray( IntList ) [function]
- // ------------------------------------------------------------
-    rule intList2ByteArray(.IntList) => .ByteArray
-    rule intList2ByteArray(V VS)     => #bufStrict(32, V) ++ intList2ByteArray(VS)
-      requires 0 <=Int V andBool V <Int pow256
-
-    syntax IntList ::= byteStack2IntList ( ByteArray )       [function]
-                     | byteStack2IntList ( ByteArray , Int ) [function]
+    syntax IntList ::= List{Int, ""} [klabel(intList), smtlib(intList)]
  // -------------------------------------------------------------------
-    rule byteStack2IntList ( WS ) => byteStack2IntList ( WS , #sizeByteArray(WS) /Int 32 )
-
-    // #sizeWordStack(WS) is not necessarily a multiple of 32.
-    rule byteStack2IntList ( WS , N )
-         => #asWord ( WS [ 0 .. bytesInNextInt(WS, N) ] ) byteStack2IntList ( #drop(bytesInNextInt(WS, N), WS) , N -Int 1 )
-         requires N >Int 0
-
-    rule byteStack2IntList ( _WS , 0 ) => .IntList
-
-    syntax Int ::= bytesInNextInt ( ByteArray , Int ) [function]
- // ------------------------------------------------------------
-    rule bytesInNextInt(WS, N) => #sizeByteArray(WS) -Int 32 *Int (N -Int 1)
 ```
 
 ```k

--- a/tests/specs/bihu/concrete-rules.txt
+++ b/tests/specs/bihu/concrete-rules.txt
@@ -14,7 +14,6 @@ EVM-TYPES.signextend.invalid
 EVM-TYPES.signextend.negative
 EVM-TYPES.signextend.positive
 EVM-TYPES.upDivInt
-HASHED-LOCATIONS.keccakIntList
 SERIALIZATION.keccak
 SERIALIZATION.#newAddr
 SERIALIZATION.#newAddrCreate2

--- a/tests/specs/concrete-rules.txt
+++ b/tests/specs/concrete-rules.txt
@@ -24,7 +24,6 @@ EVM-TYPES.signextend.invalid
 EVM-TYPES.signextend.negative
 EVM-TYPES.signextend.positive
 EVM-TYPES.upDivInt
-HASHED-LOCATIONS.keccakIntList
 SERIALIZATION.keccak
 SERIALIZATION.#newAddr
 SERIALIZATION.#newAddrCreate2

--- a/tests/specs/erc20/concrete-rules.txt
+++ b/tests/specs/erc20/concrete-rules.txt
@@ -21,7 +21,6 @@ EVM-TYPES.signextend.invalid
 EVM-TYPES.signextend.negative
 EVM-TYPES.signextend.positive
 EVM-TYPES.upDivInt
-HASHED-LOCATIONS.keccakIntList
 SERIALIZATION.keccak
 SERIALIZATION.#newAddr
 SERIALIZATION.#newAddrCreate2

--- a/tests/specs/functional/lemmas-spec.k
+++ b/tests/specs/functional/lemmas-spec.k
@@ -21,6 +21,11 @@ module LEMMAS-SPEC
 
     claim <k> runLemma ( bool2Word((UINT8 ==K 0) ==K false) ) => doneLemma ( UINT8 ) ... </k> requires #rangeBool(UINT8)
 
+ // sizeByteArray
+ // -------------
+
+    claim <k> runLemma(#sizeByteArray(#padToWidth(32, #asByteStack(#hashedLocation("Solidity", 2, OWNER .IntList))))) => doneLemma(32) ... </k> requires #rangeUInt(256, OWNER)
+
  // Addresses
  // ---------
 
@@ -46,6 +51,9 @@ module LEMMAS-SPEC
     // claim <k> runLemma ( M:Map [ I1 <- 1 ] [ I2 <- 2 ] ) => doneLemma ( M [ I2 <- 2 ] [ I1 <- 1 ] ) ... </k> requires I1  >Int I2
     // claim <k> runLemma ( M:Map [ I1 <- 1 ] [ I2 <- 2 ] ) => doneLemma ( M [ I1 <- 2 ]             ) ... </k> requires I1 ==Int I2
     // claim <k> runLemma ( M:Map [ I1 <- 1 ] [ I2 <- 2 ] ) => doneLemma ( M [ I2 <- 2 ]             ) ... </k> requires I1 ==Int I2
+
+    claim <k> runLemma(M:Memory [ 32 := BA1 ] [ 32 := BA2                                                                  ]) => doneLemma(M:Memory [ 32 := BA2                                                                  ]) ... </k> requires #sizeByteArray(BA1) <=Int #sizeByteArray(BA2)
+    claim <k> runLemma(M:Memory [ 32 := BA1 ] [ 32 := #padToWidth(32, #asByteStack(#hashedLocation("Solidity", 2, OWNER))) ]) => doneLemma(M:Memory [ 32 := #padToWidth(32, #asByteStack(#hashedLocation("Solidity", 2, OWNER))) ]) ... </k> requires #sizeByteArray(BA1) ==Int 32 andBool #rangeUInt(256, OWNER)
 
  // #lookup simplifications
  // -----------------------
@@ -110,6 +118,9 @@ module LEMMAS-SPEC
     claim <k> runLemma ( #buf( 32 , 1 )                    ==K #buf( 32 , I:Int ) ) => doneLemma( I ==K 1    ) ... </k>
 
     claim <k> runLemma ( #bufStrict( #ceil32(LEN) -Int LEN, 0 ) ) => doneLemma( #buf( #ceil32(LEN) -Int LEN, 0 ) ) ... </k> requires 0 <=Int LEN
+
+    claim <k> runLemma( #padToWidth(32, #asByteStack(#hashedLocation("Solidity", 2, OWNER         .IntList))) ) => doneLemma(#buf(32, #hashedLocation("Solidity", 2, OWNER         .IntList))) ... </k> requires #rangeUInt(256, OWNER)
+    claim <k> runLemma( #padToWidth(32, #asByteStack(#hashedLocation("Solidity", 2, OWNER SPENDER .IntList))) ) => doneLemma(#buf(32, #hashedLocation("Solidity", 2, OWNER SPENDER .IntList))) ... </k> requires #rangeUInt(256, OWNER) andBool #rangeUInt(256, SPENDER)
 
  // chop simplification
  // -------------------

--- a/tests/specs/lemmas.k
+++ b/tests/specs/lemmas.k
@@ -142,7 +142,6 @@ module LEMMAS-JAVA [symbolic, kast]
        andBool L >=Int N +Int #sizeByteArray(BUF)
       [simplification]
 
-    rule keccak(BUF1 ++ BUF2) => hash2(#asWord(BUF1), #asWord(BUF2)) requires #sizeByteArray(BUF1) ==Int 32 andBool #sizeByteArray(BUF2) ==Int 32 [simplification]
 
     // for Solidity
     rule #asWord(WS) /Int D => #asWord(#take(#sizeByteArray(WS) -Int log256Int(D), WS))
@@ -162,28 +161,6 @@ module LEMMAS-JAVA [symbolic, kast]
 
     rule #noOverflowAux(BA        ) => 0 <=Int BA[0] andBool BA[0] <Int 256 andBool #noOverflowAux(#drop(1,BA)) requires #sizeByteArray(BA) >Int 0
     rule #noOverflowAux(.ByteArray) => true
-
-    // TODO: drop hash1 and keccakIntList once new vyper hashed location scheme is captured in edsl.md
-
-    syntax Int ::= hash1(Int) [function, smtlib(smt_hash1)]
- // -------------------------------------------------------
-    rule hash1(V) => keccak(#padToWidth(32, #asByteStack(V)))
-      requires 0 <=Int V andBool V <Int pow256
-      [concrete]
-
-    rule hash2(V1, V2) => keccak(   #padToWidth(32, #asByteStack(V1))
-                                 ++ #padToWidth(32, #asByteStack(V2)))
-      requires 0 <=Int V1 andBool V1 <Int pow256
-       andBool 0 <=Int V2 andBool V2 <Int pow256
-      [concrete]
-
-    rule keccakIntList(V:Int .IntList) => hash1(V)
-    rule keccakIntList(V1:Int V2:Int .IntList) => hash2(V1, V2)
-
-    // for terms came from bytecode not via #hashedLocation
-    rule keccak(WS) => keccakIntList(byteStack2IntList(WS))
-      requires ( notBool #isConcrete(WS) )
-       andBool ( #sizeByteArray(WS) ==Int 32 orBool #sizeByteArray(WS) ==Int 64 )
 
     rule 1 *Int N => N
     rule N *Int 1 => N
@@ -254,15 +231,6 @@ module LEMMAS-JAVA [symbolic, kast]
 
     rule 0 <=Int #asWord(_WS)         => true [simplification]
     rule #asWord(_WS) <Int pow256     => true [simplification]
-
-    rule 0 <=Int hash1(_)             => true [simplification]
-    rule         hash1(_) <Int pow256 => true [simplification]
-
-    rule 0 <=Int hash2(_,_)             => true [simplification]
-    rule         hash2(_,_) <Int pow256 => true [simplification]
-
-    rule 0 <=Int keccakIntList(_)             => true [simplification]
-    rule         keccakIntList(_) <Int pow256 => true [simplification]
 
     rule X <=Int maxUInt256 => X <Int pow256 [simplification]
     rule X <=Int maxUInt160 => X <Int pow160 [simplification]
@@ -352,6 +320,4 @@ endmodule
 module HASH2 [symbolic]
     imports INT
 
-    syntax Int ::= hash2 ( Int , Int ) [function]
- // ---------------------------------------------
 endmodule

--- a/tests/specs/lemmas.k
+++ b/tests/specs/lemmas.k
@@ -96,6 +96,11 @@ module LEMMAS
     rule X in (SetItem(Y) _   ) => true      requires X  ==Int Y [simplification]
     rule X in (SetItem(Y) REST) => X in REST requires X =/=Int Y [simplification]
 
+    rule M:Memory [ K1 := BUF1 ] [ K2 := BUF2 ] => M [ K2 := BUF2 ]
+      requires K2 <=Int K1
+       andBool K1 +Int #sizeByteArray(BUF1) <=Int K2 +Int #sizeByteArray(BUF2)
+      [simplification]
+
 endmodule
 
 module LEMMAS-JAVA [symbolic, kast]
@@ -247,11 +252,6 @@ module LEMMAS-JAVA [symbolic, kast]
     //For #bufStrict simplification in benchmarks
     rule 0 <Int 2 ^Int I  => true      requires 0 <=Int I [simplification]
     rule 0 <=Int I *Int 8 => 0 <=Int I                    [simplification]
-
-    rule M:Memory [ K1 := BUF1 ] [ K2 := BUF2 ] => M [ K2 := BUF2 ]
-      requires K2 <=Int K1
-       andBool K1 +Int #sizeByteArray(BUF1) <=Int K2 +Int #sizeByteArray(BUF2)
-      [simplification]
 
 endmodule
 

--- a/tests/specs/lemmas.k
+++ b/tests/specs/lemmas.k
@@ -280,6 +280,11 @@ module LEMMAS-JAVA [symbolic, kast]
     rule 0 <Int 2 ^Int I  => true      requires 0 <=Int I [simplification]
     rule 0 <=Int I *Int 8 => 0 <=Int I                    [simplification]
 
+    rule M:Memory [ K1 := BUF1 ] [ K2 := BUF2 ] => M [ K2 := BUF2 ]
+      requires K2 <=Int K1
+       andBool K1 +Int #sizeByteArray(BUF1) <=Int K2 +Int #sizeByteArray(BUF2)
+      [simplification]
+
 endmodule
 
 module LEMMAS-HASKELL [symbolic, kore]

--- a/tests/specs/mcd/concrete-rules.txt
+++ b/tests/specs/mcd/concrete-rules.txt
@@ -24,7 +24,6 @@ EVM-TYPES.signextend.invalid
 EVM-TYPES.signextend.negative
 EVM-TYPES.signextend.positive
 EVM-TYPES.upDivInt
-HASHED-LOCATIONS.keccakIntList
 SERIALIZATION.keccak
 SERIALIZATION.#newAddr
 SERIALIZATION.#newAddrCreate2

--- a/tests/specs/mcd/flapper-tend-guy-diff-pass-rough-spec.k
+++ b/tests/specs/mcd/flapper-tend-guy-diff-pass-rough-spec.k
@@ -705,7 +705,7 @@ module FLAPPER-TEND-GUY-DIFF-PASS-ROUGH-SPEC
             <wordStack> .WordStack => ?_ </wordStack>
             <localMem> .Memory => ?_ </localMem>
             <pc> 0 => ?_ </pc>
-            <gas> #gas(VGas) => #if ( #lookup( ACCT_ID_STORAGE , #hashedLocation("Solidity", 2, ABI_src CALLER_ID .IntList) ==Int maxUInt256 andBool ( Allowance ==Int maxUInt256 andBool ( maxUInt256 ==Int maxUInt256 orBool ABI_wad <=Int maxUInt256 ) ) )
+            <gas> #gas(VGas) => #if ( #lookup( ACCT_ID_STORAGE , #hashedLocation("Solidity", 2, ABI_src CALLER_ID .IntList) ) ==Int maxUInt256 andBool ( Allowance ==Int maxUInt256 andBool ( maxUInt256 ==Int maxUInt256 orBool ABI_wad <=Int maxUInt256 ) ) )
               #then   #gas ( ( ( ( VGas -Int Csstore( ISTANBUL , ( Gem_s -Int ABI_wad ) , Gem_s , Junk_1 ) ) -Int Csstore( ISTANBUL , ( Gem_d +Int ABI_wad ) , Gem_d , Junk_2 ) ) +Int -7281 ) )
               #else   #gas ( ( ( ( ( VGas -Int Csstore( ISTANBUL , ( Allowance -Int ABI_wad ) , Allowance , Junk_0 ) ) -Int Csstore( ISTANBUL , ( Gem_s -Int ABI_wad ) , Gem_s , Junk_1 ) ) -Int Csstore( ISTANBUL , ( Gem_d +Int ABI_wad ) , Gem_d , Junk_2 ) ) +Int -9538 ) )
             #fi </gas>

--- a/tests/specs/mcd/flapper-tend-guy-diff-pass-rough-spec.k
+++ b/tests/specs/mcd/flapper-tend-guy-diff-pass-rough-spec.k
@@ -705,7 +705,7 @@ module FLAPPER-TEND-GUY-DIFF-PASS-ROUGH-SPEC
             <wordStack> .WordStack => ?_ </wordStack>
             <localMem> .Memory => ?_ </localMem>
             <pc> 0 => ?_ </pc>
-            <gas> #gas(VGas) => #if ( #lookup( ACCT_ID_STORAGE , hash2 ( CALLER_ID , hash2 ( ABI_src , 2 ) ) ) ==Int maxUInt256 andBool ( Allowance ==Int maxUInt256 andBool ( maxUInt256 ==Int maxUInt256 orBool ABI_wad <=Int maxUInt256 ) ) )
+            <gas> #gas(VGas) => #if ( #lookup( ACCT_ID_STORAGE , #hashedLocation("Solidity", 2, ABI_src CALLER_ID .IntList) ==Int maxUInt256 andBool ( Allowance ==Int maxUInt256 andBool ( maxUInt256 ==Int maxUInt256 orBool ABI_wad <=Int maxUInt256 ) ) )
               #then   #gas ( ( ( ( VGas -Int Csstore( ISTANBUL , ( Gem_s -Int ABI_wad ) , Gem_s , Junk_1 ) ) -Int Csstore( ISTANBUL , ( Gem_d +Int ABI_wad ) , Gem_d , Junk_2 ) ) +Int -7281 ) )
               #else   #gas ( ( ( ( ( VGas -Int Csstore( ISTANBUL , ( Allowance -Int ABI_wad ) , Allowance , Junk_0 ) ) -Int Csstore( ISTANBUL , ( Gem_s -Int ABI_wad ) , Gem_s , Junk_1 ) ) -Int Csstore( ISTANBUL , ( Gem_d +Int ABI_wad ) , Gem_d , Junk_2 ) ) +Int -9538 ) )
             #fi </gas>

--- a/tests/specs/mcd/flapper-yank-pass-rough-spec.k
+++ b/tests/specs/mcd/flapper-yank-pass-rough-spec.k
@@ -279,7 +279,7 @@ module FLAPPER-YANK-PASS-ROUGH-SPEC
             <wordStack> .WordStack => ?_ </wordStack>
             <localMem> .Memory => ?_ </localMem>
             <pc> 0 => ?_ </pc>
-            <gas> #gas(VGas) => #if ( #lookup( ACCT_ID_STORAGE , hash2 ( CALLER_ID , hash2 ( ABI_src , 2 ) ) ) ==Int maxUInt256 andBool ( Allowance ==Int maxUInt256 andBool ( maxUInt256 ==Int maxUInt256 orBool ABI_wad <=Int maxUInt256 ) ) )
+            <gas> #gas(VGas) => #if ( #lookup( ACCT_ID_STORAGE , #hashedLocation("Solidity", 2, ABI_src CALLER_ID .IntList) ==Int maxUInt256 andBool ( Allowance ==Int maxUInt256 andBool ( maxUInt256 ==Int maxUInt256 orBool ABI_wad <=Int maxUInt256 ) ) )
               #then   #gas ( ( ( ( VGas -Int Csstore( ISTANBUL , ( Gem_s -Int ABI_wad ) , Gem_s , Junk_1 ) ) -Int Csstore( ISTANBUL , ( Gem_d +Int ABI_wad ) , Gem_d , Junk_2 ) ) +Int -7281 ) )
               #else   #gas ( ( ( ( ( VGas -Int Csstore( ISTANBUL , ( Allowance -Int ABI_wad ) , Allowance , Junk_0 ) ) -Int Csstore( ISTANBUL , ( Gem_s -Int ABI_wad ) , Gem_s , Junk_1 ) ) -Int Csstore( ISTANBUL , ( Gem_d +Int ABI_wad ) , Gem_d , Junk_2 ) ) +Int -9538 ) )
             #fi </gas>

--- a/tests/specs/mcd/flapper-yank-pass-rough-spec.k
+++ b/tests/specs/mcd/flapper-yank-pass-rough-spec.k
@@ -279,7 +279,7 @@ module FLAPPER-YANK-PASS-ROUGH-SPEC
             <wordStack> .WordStack => ?_ </wordStack>
             <localMem> .Memory => ?_ </localMem>
             <pc> 0 => ?_ </pc>
-            <gas> #gas(VGas) => #if ( #lookup( ACCT_ID_STORAGE , #hashedLocation("Solidity", 2, ABI_src CALLER_ID .IntList) ==Int maxUInt256 andBool ( Allowance ==Int maxUInt256 andBool ( maxUInt256 ==Int maxUInt256 orBool ABI_wad <=Int maxUInt256 ) ) )
+            <gas> #gas(VGas) => #if ( #lookup( ACCT_ID_STORAGE , #hashedLocation("Solidity", 2, ABI_src CALLER_ID .IntList) ) ==Int maxUInt256 andBool ( Allowance ==Int maxUInt256 andBool ( maxUInt256 ==Int maxUInt256 orBool ABI_wad <=Int maxUInt256 ) ) )
               #then   #gas ( ( ( ( VGas -Int Csstore( ISTANBUL , ( Gem_s -Int ABI_wad ) , Gem_s , Junk_1 ) ) -Int Csstore( ISTANBUL , ( Gem_d +Int ABI_wad ) , Gem_d , Junk_2 ) ) +Int -7281 ) )
               #else   #gas ( ( ( ( ( VGas -Int Csstore( ISTANBUL , ( Allowance -Int ABI_wad ) , Allowance , Junk_0 ) ) -Int Csstore( ISTANBUL , ( Gem_s -Int ABI_wad ) , Gem_s , Junk_1 ) ) -Int Csstore( ISTANBUL , ( Gem_d +Int ABI_wad ) , Gem_d , Junk_2 ) ) +Int -9538 ) )
             #fi </gas>

--- a/tests/specs/mcd/verification.k
+++ b/tests/specs/mcd/verification.k
@@ -402,11 +402,6 @@ module LEMMAS-MCD-COMMON
 
     // ### end-cage-ilk-pass-rough
 
-    rule M:Memory [ K1 := BUF1 ] [ K2 := BUF2 ] => M [ K2 := BUF2 ]
-      requires K2 <=Int K1
-       andBool K1 +Int #sizeByteArray(BUF1) <=Int K2 +Int #sizeByteArray(BUF2)
-      [simplification]
-
     rule M:Memory [ K1 := (BUF11 ++ BUF12) ] [ K2 := BUF2 ] => M [ K1 +Int #sizeByteArray(BUF11) := BUF12 ] [ K2 := BUF2 ]
       requires K2 <=Int K1
        andBool K1 +Int #sizeByteArray(BUF11) <=Int K2 +Int #sizeByteArray(BUF2)

--- a/tests/specs/mcd/verification.k
+++ b/tests/specs/mcd/verification.k
@@ -132,7 +132,7 @@ module LEMMAS-MCD-COMMON
 
     // This lemma is considered "safe enough" because `hash2` is a hash function over a large range and is very unlikely to overflow.
     // Note that this case comes from a solidity struct being accessed (hence the integer offsets), so it's an assumption built into the Solidity compiler anyway.
-    rule chop(hash2(I1, I2) +Int N) => hash2(I1, I2) +Int N requires 0 <=Int N andBool N <Int 6 [simplification]
+    rule chop(keccak(BA) +Int N) => keccak(BA) +Int N requires 0 <=Int N andBool N <Int 6 [simplification]
 
     rule ( BA1:ByteArray ++ BA2:ByteArray ) ++ BA3:ByteArray => BA1 ++ ( BA2 ++ BA3 ) [simplification]
 

--- a/tests/specs/mcd/verification.k
+++ b/tests/specs/mcd/verification.k
@@ -130,7 +130,7 @@ module LEMMAS-MCD-COMMON
 
     // ### flipper-bids-pass-rough
 
-    // This lemma is considered "safe enough" because `hash2` is a hash function over a large range and is very unlikely to overflow.
+    // This lemma is considered "safe enough" because `keccak` is a hash function over a large range and is very unlikely to overflow.
     // Note that this case comes from a solidity struct being accessed (hence the integer offsets), so it's an assumption built into the Solidity compiler anyway.
     rule chop(keccak(BA) +Int N) => keccak(BA) +Int N requires 0 <=Int N andBool N <Int 6 [simplification]
 


### PR DESCRIPTION
We instead do our reasoning directly over `keccak`, and use `#hashedLocation` when writing down in "pretty" format.