### PR TITLE
Build updates for `kevm kompile`

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,6 @@ pipeline {
         }
       }
       stages {
-        stage('Deps')  { steps { sh 'make plugin-deps'            } }
         stage('Build') { steps { sh 'make build RELEASE=true -j6' } }
         stage('Test Execution') {
           failFast true

--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,20 @@ $(libff_out): $(PLUGIN_SUBMODULE)/deps/libff/CMakeLists.txt
 
 deps: k-deps plugin-deps
 
+K_MVN_ARGS :=
+ifneq ($(SKIP_LLVM),)
+    K_MVN_ARGS += -Dllvm.backend.skip
+endif
+ifneq ($(SKIP_HASKELL),)
+    K_MVN_ARGS += -Dhaskell.backend.skip
+endif
+
+ifneq ($(RELEASE),)
+    K_BUILD_TYPE := FastBuild
+else
+    K_BUILD_TYPE := Debug
+endif
+
 k-deps:
 	cd $(K_SUBMODULE)                                                                                                                                                                            \
 	    && mvn --batch-mode package -DskipTests -Dllvm.backend.prefix=$(INSTALL_LIB)/kframework -Dllvm.backend.destdir=$(CURDIR)/$(BUILD_DIR) -Dproject.build.type=$(K_BUILD_TYPE) $(K_MVN_ARGS) \
@@ -112,9 +126,6 @@ plugin_includes := $(plugin_include)/krypto.md                     \
 
 plugin-deps: $(plugin_includes)
 
-#$(PLUGIN_SOURCE): $(PLUGIN_SUBMODULE)/plugin/krypto.md
-#	cd deps/plugin && make INSTALL_PREFIX=$(CURDIR)/$(KEVM_LIB) install
-
 $(plugin_include)/%: $(PLUGIN_SUBMODULE)/%
 	@mkdir -p $(dir $@)
 	install $< $@
@@ -122,20 +133,6 @@ $(plugin_include)/%: $(PLUGIN_SUBMODULE)/%
 $(plugin_include)/%.md: $(PLUGIN_SUBMODULE)/plugin/%.md
 	@mkdir -p $(dir $@)
 	install $< $@
-
-K_MVN_ARGS :=
-ifneq ($(SKIP_LLVM),)
-    K_MVN_ARGS += -Dllvm.backend.skip
-endif
-ifneq ($(SKIP_HASKELL),)
-    K_MVN_ARGS += -Dhaskell.backend.skip
-endif
-
-ifneq ($(RELEASE),)
-    K_BUILD_TYPE := FastBuild
-else
-    K_BUILD_TYPE := Debug
-endif
 
 # Building
 # --------

--- a/Makefile
+++ b/Makefile
@@ -232,11 +232,11 @@ llvm_main_filename := $(basename $(notdir $(llvm_main_file)))
 llvm_kompiled      := $(llvm_dir)/$(llvm_main_filename)-kompiled/interpreter
 
 $(KEVM_LIB)/$(llvm_kompiled): $(includes) $(libff_out) $(plugin_includes)
-	$(KOMPILE) --backend llvm                           \
-	    $(llvm_main_file)                               \
-	    --directory $(KEVM_LIB)/$(llvm_dir)             \
-	    --main-module $(llvm_main_module)               \
-	    --syntax-module $(llvm_syntax_module)           \
+	$(KOMPILE) --backend llvm                 \
+	    $(llvm_main_file)                     \
+	    --directory $(KEVM_LIB)/$(llvm_dir)   \
+	    --main-module $(llvm_main_module)     \
+	    --syntax-module $(llvm_syntax_module) \
 	    $(KOMPILE_OPTS)
 
 # Installing

--- a/Makefile
+++ b/Makefile
@@ -80,9 +80,7 @@ $(libsecp256k1_out): $(PLUGIN_SUBMODULE)/deps/secp256k1/autogen.sh
 	    && $(MAKE)                                                        \
 	    && $(MAKE) install
 
-LIBFF_PREFIX = $(CURDIR)/
-
-LIBFF_CMAKE_FLAGS = -DPROFILE_OP_COUNTS=OFF
+LIBFF_CMAKE_FLAGS :=
 
 ifeq ($(UNAME_S),Linux)
     LIBFF_CMAKE_FLAGS +=
@@ -92,10 +90,10 @@ endif
 
 $(libff_out): $(PLUGIN_SUBMODULE)/deps/libff/CMakeLists.txt
 	@mkdir -p $(PLUGIN_SUBMODULE)/deps/libff/build
-	cd $(PLUGIN_SUBMODULE)/deps/libff/build                                                                                 \
-	    && cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$(LIBFF_PREFIX)$(KEVM_LIB)/libff $(LIBFF_CMAKE_FLAGS) \
-	    && make -s -j4                                                                                                      \
-	    && make install
+	cd $(PLUGIN_SUBMODULE)/deps/libff/build                                                                     \
+	    && cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$(INSTALL_LIB)/libff $(LIBFF_CMAKE_FLAGS) \
+	    && make -s -j4                                                                                          \
+	    && make install DESTDIR=$(CURDIR)/$(BUILD_DIR)
 
 # K Dependencies
 # --------------

--- a/Makefile
+++ b/Makefile
@@ -286,9 +286,9 @@ $(KEVM_LIB)/release.md: INSTALL.md
 
 build: $(patsubst %, $(KEVM_BIN)/%, $(install_bins)) $(patsubst %, $(KEVM_LIB)/%, $(install_libs)) $(lemma_includes)
 
-build-haskell: $(KEVM_LIB)/$(haskell_kompiled) $(KEVM_BIN)/$(KEVM)
-build-llvm:    $(KEVM_LIB)/$(llvm_kompiled)    $(KEVM_BIN)/$(KEVM) $(KEVM_LIB)/kore-json.py
-build-java:    $(KEVM_LIB)/$(java_kompiled)    $(KEVM_BIN)/$(KEVM)
+build-haskell: $(KEVM_LIB)/$(haskell_kompiled)
+build-llvm:    $(KEVM_LIB)/$(llvm_kompiled)    $(KEVM_LIB)/kore-json.py
+build-java:    $(KEVM_LIB)/$(java_kompiled)
 build-lemmas:  $(lemma_includes)
 
 all_bin_sources := $(shell find $(KEVM_BIN) -type f                                                                                                                    | sed 's|^$(KEVM_BIN)/||')

--- a/Makefile
+++ b/Makefile
@@ -164,9 +164,8 @@ $(KEVM_INCLUDE)/kframework/lemmas/%.k: tests/specs/%.k
 	@mkdir -p $(dir $@)
 	install $< $@
 
-tangle_concrete := k & ( ( !              nobytes   ) | concrete | bytes   )
-tangle_java     := k & ( ( ! ( concrete | bytes   ) )            | nobytes )
-tangle_haskell  := k & ( ( ! ( concrete | nobytes ) )            | bytes   )
+tangle_bytes   := k & ( ! nobytes )
+tangle_nobytes := k & ( ! bytes   )
 
 HOOK_NAMESPACES    = KRYPTO JSON
 KOMPILE_INCLUDES   = $(KEVM_INCLUDE)/kframework $(INSTALL_INCLUDE)/kframework
@@ -179,12 +178,12 @@ endif
 
 JAVA_KOMPILE_OPTS ?=
 
-KOMPILE_JAVA := kompile --debug --backend java --md-selector "$(tangle_java)" \
+KOMPILE_JAVA := kompile --debug --backend java --md-selector "$(tangle_nobytes)" \
                 $(KOMPILE_OPTS) $(JAVA_KOMPILE_OPTS)
 
 HASKELL_KOMPILE_OPTS ?=
 
-KOMPILE_HASKELL := kompile --debug --backend haskell --md-selector "$(tangle_haskell)" \
+KOMPILE_HASKELL := kompile --debug --backend haskell --md-selector "$(tangle_bytes)" \
                    $(KOMPILE_OPTS) $(HASKELL_KOMPILE_OPTS)
 
 STANDALONE_KOMPILE_OPTS := -L$(LOCAL_LIB)                               \
@@ -202,9 +201,8 @@ ifeq ($(UNAME_S),Darwin)
     STANDALONE_KOMPILE_OPTS += -I/usr/local/include -L/usr/local/lib -I$(OPENSSL_ROOT)/include -L$(OPENSSL_ROOT)/lib
 endif
 
-KOMPILE_STANDALONE := kompile --debug --backend llvm --md-selector "$(tangle_concrete)" \
-                      $(KOMPILE_OPTS)                \
-                      $(addprefix -ccopt ,$(STANDALONE_KOMPILE_OPTS))
+KOMPILE_STANDALONE := kompile --debug --backend llvm --md-selector "$(tangle_bytes)"  \
+                      $(KOMPILE_OPTS) $(addprefix -ccopt ,$(STANDALONE_KOMPILE_OPTS))
 
 # Java
 

--- a/Makefile
+++ b/Makefile
@@ -88,15 +88,15 @@ endif
 
 $(libff_out): $(PLUGIN_SUBMODULE)/deps/libff/CMakeLists.txt
 	@mkdir -p $(PLUGIN_SUBMODULE)/deps/libff/build
-	cd $(PLUGIN_SUBMODULE)/deps/libff/build                                                                  \
-	    && cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$(KEVM_LIB)/libff $(LIBFF_CMAKE_FLAGS) \
-	    && make -s -j4                                                                                       \
+	cd $(PLUGIN_SUBMODULE)/deps/libff/build                                                                            \
+	    && cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$(CURDIR)/$(KEVM_LIB)/libff $(LIBFF_CMAKE_FLAGS) \
+	    && make -s -j4                                                                                                 \
 	    && make install
 
 # K Dependencies
 # --------------
 
-deps: k-deps plugin-deps
+deps: k-deps
 
 K_MVN_ARGS :=
 ifneq ($(SKIP_LLVM),)

--- a/Makefile
+++ b/Makefile
@@ -164,9 +164,9 @@ $(KEVM_INCLUDE)/kframework/lemmas/%.k: tests/specs/%.k
 	@mkdir -p $(dir $@)
 	install $< $@
 
-tangle_concrete := k & ( ( ! ( symbolic | nobytes ) ) | concrete | bytes   )
-tangle_java     := k & ( ( ! ( concrete | bytes   ) ) | symbolic | nobytes )
-tangle_haskell  := k & ( ( ! ( concrete | nobytes ) ) | symbolic | bytes   )
+tangle_concrete := k & ( ( !              nobytes   ) | concrete | bytes   )
+tangle_java     := k & ( ( ! ( concrete | bytes   ) )            | nobytes )
+tangle_haskell  := k & ( ( ! ( concrete | nobytes ) )            | bytes   )
 
 HOOK_NAMESPACES    = KRYPTO JSON
 KOMPILE_INCLUDES   = $(KEVM_INCLUDE)/kframework $(INSTALL_INCLUDE)/kframework

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ export PLUGIN_SUBMODULE
 
 .PHONY: all clean distclean                                                                                                      \
         deps all-deps llvm-deps haskell-deps k-deps plugin-deps libsecp256k1 libff                                               \
-        build build-java build-haskell build-llvm build-lemmas                                                                   \
+        build build-java build-haskell build-llvm                                                                                \
         test test-all test-conformance test-rest-conformance test-all-conformance test-slow-conformance test-failing-conformance \
         test-vm test-rest-vm test-all-vm test-bchain test-rest-bchain test-all-bchain                                            \
         test-prove test-failing-prove                                                                                            \
@@ -157,8 +157,6 @@ SOURCE_FILES       := abi                        \
 EXTRA_SOURCE_FILES :=
 ALL_FILES          := $(patsubst %, %.md, $(SOURCE_FILES) $(EXTRA_SOURCE_FILES))
 
-includes := $(patsubst %, $(KEVM_INCLUDE)/kframework/%, $(ALL_FILES)) $(plugin_includes)
-
 LEMMA_FILES := infinite-gas.k                           \
                lemmas.k                                 \
                erc20/abstract-semantics-segmented-gas.k \
@@ -169,6 +167,8 @@ LEMMA_FILES := infinite-gas.k                           \
                mcd/word-pack.k
 
 lemma_includes := $(patsubst %, $(KEVM_INCLUDE)/kframework/lemmas/%, $(LEMMA_FILES))
+
+includes := $(patsubst %, $(KEVM_INCLUDE)/kframework/%, $(ALL_FILES)) $(plugin_includes) $(lemma_includes)
 
 $(includes): $(KEVM_BIN)/$(KEVM)
 
@@ -278,7 +278,6 @@ build: $(patsubst %, $(KEVM_BIN)/%, $(install_bins)) $(patsubst %, $(KEVM_LIB)/%
 build-haskell: $(KEVM_LIB)/$(haskell_kompiled)
 build-llvm:    $(KEVM_LIB)/$(llvm_kompiled)    $(KEVM_LIB)/kore-json.py
 build-java:    $(KEVM_LIB)/$(java_kompiled)
-build-lemmas:  $(lemma_includes)
 
 all_bin_sources := $(shell find $(KEVM_BIN) -type f | sed 's|^$(KEVM_BIN)/||')
 all_lib_sources := $(shell find $(KEVM_LIB) -type f                                            \

--- a/Makefile
+++ b/Makefile
@@ -103,10 +103,25 @@ k-deps:
 	    && mvn --batch-mode package -DskipTests -Dllvm.backend.prefix=$(INSTALL_LIB)/kframework -Dllvm.backend.destdir=$(CURDIR)/$(BUILD_DIR) -Dproject.build.type=$(K_BUILD_TYPE) $(K_MVN_ARGS) \
 	    && DESTDIR=$(CURDIR)/$(BUILD_DIR) PREFIX=$(INSTALL_LIB)/kframework package/package
 
-plugin-deps: $(PLUGIN_SOURCE)
+plugin_include  := $(KEVM_INCLUDE)/blockchain-k-plugin
+plugin_cpp      := $(patsubst %, blockchain-k-plugin/plugin-c/%.cpp, plugin_util crypto blake2)
+plugin_h        := $(patsubst %, blockchain-k-plugin/plugin-c/%.h,   plugin_util        blake2)
+plugin_includes := $(plugin_include)/krypto.md                     \
+                   $(patsubst %, $(KEVM_INCLUDE)/%, $(plugin_cpp)) \
+                   $(patsubst %, $(KEVM_INCLUDE)/%, $(plugin_h))
 
-$(PLUGIN_SOURCE): $(PLUGIN_SUBMODULE)/plugin/krypto.md
-	cd deps/plugin && make INSTALL_PREFIX=$(CURDIR)/$(KEVM_LIB) install
+plugin-deps: $(plugin_includes)
+
+#$(PLUGIN_SOURCE): $(PLUGIN_SUBMODULE)/plugin/krypto.md
+#	cd deps/plugin && make INSTALL_PREFIX=$(CURDIR)/$(KEVM_LIB) install
+
+$(plugin_include)/%: $(PLUGIN_SUBMODULE)/%
+	@mkdir -p $(dir $@)
+	install $< $@
+
+$(plugin_include)/%.md: $(PLUGIN_SUBMODULE)/plugin/%.md
+	@mkdir -p $(dir $@)
+	install $< $@
 
 K_MVN_ARGS :=
 ifneq ($(SKIP_LLVM),)

--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,8 @@ $(libsecp256k1_out): $(PLUGIN_SUBMODULE)/deps/secp256k1/autogen.sh
 	    && $(MAKE)                                                        \
 	    && $(MAKE) install
 
+LIBFF_PREFIX = $(CURDIR)/
+
 ifeq ($(UNAME_S),Linux)
     LIBFF_CMAKE_FLAGS=
 else
@@ -88,9 +90,9 @@ endif
 
 $(libff_out): $(PLUGIN_SUBMODULE)/deps/libff/CMakeLists.txt
 	@mkdir -p $(PLUGIN_SUBMODULE)/deps/libff/build
-	cd $(PLUGIN_SUBMODULE)/deps/libff/build                                                                            \
-	    && cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$(CURDIR)/$(KEVM_LIB)/libff $(LIBFF_CMAKE_FLAGS) \
-	    && make -s -j4                                                                                                 \
+	cd $(PLUGIN_SUBMODULE)/deps/libff/build                                                                                 \
+	    && cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$(LIBFF_PREFIX)$(KEVM_LIB)/libff $(LIBFF_CMAKE_FLAGS) \
+	    && make -s -j4                                                                                                      \
 	    && make install
 
 # K Dependencies

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ distclean:
 # ------------------
 
 libsecp256k1_out := $(LOCAL_LIB)/pkgconfig/libsecp256k1.pc
-libff_out        := $(LOCAL_LIB)/libff.a
+libff_out        := $(KEVM_LIB)/libff/lib/libff.a
 
 libsecp256k1: $(libsecp256k1_out)
 libff:        $(libff_out)
@@ -88,9 +88,9 @@ endif
 
 $(libff_out): $(PLUGIN_SUBMODULE)/deps/libff/CMakeLists.txt
 	@mkdir -p $(PLUGIN_SUBMODULE)/deps/libff/build
-	cd $(PLUGIN_SUBMODULE)/deps/libff/build                                                               \
-	    && cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$(BUILD_LOCAL) $(LIBFF_CMAKE_FLAGS) \
-	    && make -s -j4                                                                                    \
+	cd $(PLUGIN_SUBMODULE)/deps/libff/build                                                                  \
+	    && cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$(KEVM_LIB)/libff $(LIBFF_CMAKE_FLAGS) \
+	    && make -s -j4                                                                                       \
 	    && make install
 
 # K Dependencies

--- a/Makefile
+++ b/Makefile
@@ -282,8 +282,12 @@ build-llvm:    $(KEVM_LIB)/$(llvm_kompiled)    $(KEVM_LIB)/kore-json.py
 build-java:    $(KEVM_LIB)/$(java_kompiled)
 build-lemmas:  $(lemma_includes)
 
-all_bin_sources := $(shell find $(KEVM_BIN) -type f                                                                                                                    | sed 's|^$(KEVM_BIN)/||')
-all_lib_sources := $(shell find $(KEVM_LIB) -type f -not -path "$(KEVM_LIB)/llvm/driver-kompiled/dt/*" -not -path "$(KEVM_LIB)/kframework/share/kframework/pl-tutorial/*" | sed 's|^$(KEVM_LIB)/||')
+all_bin_sources := $(shell find $(KEVM_BIN) -type f | sed 's|^$(KEVM_BIN)/||')
+all_lib_sources := $(shell find $(KEVM_LIB) -type f                                            \
+                            -not -path "$(KEVM_LIB)/llvm/driver-kompiled/dt/*"                 \
+                            -not -path "$(KEVM_LIB)/kframework/share/kframework/pl-tutorial/*" \
+                            -not -path "$(KEVM_LIB)/kframework/share/kframework/k-tutorial/*"  \
+                        | sed 's|^$(KEVM_LIB)/||')
 
 install: $(patsubst %, $(DESTDIR)$(INSTALL_BIN)/%, $(all_bin_sources)) \
          $(patsubst %, $(DESTDIR)$(INSTALL_LIB)/%, $(all_lib_sources))

--- a/Makefile
+++ b/Makefile
@@ -137,6 +137,8 @@ $(plugin_include)/%.md: $(PLUGIN_SUBMODULE)/plugin/%.md
 # Building
 # --------
 
+KOMPILE := $(KEVM) kompile
+
 SOURCE_FILES       := abi                        \
                       asm                        \
                       buf                        \
@@ -204,7 +206,7 @@ java_main_filename := $(basename $(notdir $(java_main_file)))
 java_kompiled      := $(java_dir)/$(java_main_filename)-kompiled/compiled.bin
 
 $(KEVM_LIB)/$(java_kompiled): $(includes)
-	kevm kompile --backend java                \
+	$(KOMPILE) --backend java                  \
 	    $(java_main_file) $(JAVA_KOMPILE_OPTS) \
 	    --directory $(KEVM_LIB)/$(java_dir)    \
 	    --main-module $(java_main_module)      \
@@ -221,7 +223,7 @@ haskell_main_filename  := $(basename $(notdir $(haskell_main_file)))
 haskell_kompiled       := $(haskell_dir)/$(haskell_main_filename)-kompiled/definition.kore
 
 $(KEVM_LIB)/$(haskell_kompiled): $(includes)
-	kevm kompile --backend haskell                   \
+	$(KOMPILE) --backend haskell                     \
 	    $(haskell_main_file) $(HASKELL_KOMPILE_OPTS) \
 	    --directory $(KEVM_LIB)/$(haskell_dir)       \
 	    --main-module $(haskell_main_module)         \
@@ -238,7 +240,7 @@ llvm_main_filename := $(basename $(notdir $(llvm_main_file)))
 llvm_kompiled      := $(llvm_dir)/$(llvm_main_filename)-kompiled/interpreter
 
 $(KEVM_LIB)/$(llvm_kompiled): $(includes) $(libff_out) $(plugin_includes)
-	kevm kompile --backend llvm                         \
+	$(KOMPILE) --backend llvm                           \
 	    $(llvm_main_file)                               \
 	    --directory $(KEVM_LIB)/$(llvm_dir)             \
 	    --main-module $(llvm_main_module)               \

--- a/Makefile
+++ b/Makefile
@@ -82,10 +82,12 @@ $(libsecp256k1_out): $(PLUGIN_SUBMODULE)/deps/secp256k1/autogen.sh
 
 LIBFF_PREFIX = $(CURDIR)/
 
+LIBFF_CMAKE_FLAGS = -DPROFILE_OP_COUNTS=OFF
+
 ifeq ($(UNAME_S),Linux)
-    LIBFF_CMAKE_FLAGS=
+    LIBFF_CMAKE_FLAGS +=
 else
-    LIBFF_CMAKE_FLAGS=-DWITH_PROCPS=OFF
+    LIBFF_CMAKE_FLAGS += -DWITH_PROCPS=OFF
 endif
 
 $(libff_out): $(PLUGIN_SUBMODULE)/deps/libff/CMakeLists.txt
@@ -188,16 +190,6 @@ ifneq (,$(RELEASE))
     KOMPILE_OPTS += -O2
 endif
 
-STANDALONE_KOMPILE_OPTS :=
-
-ifeq ($(UNAME_S),Linux)
-    STANDALONE_KOMPILE_OPTS += -lprocps
-endif
-ifeq ($(UNAME_S),Darwin)
-    OPENSSL_ROOT := $(shell brew --prefix openssl)
-    STANDALONE_KOMPILE_OPTS += -I/usr/local/include -L/usr/local/lib -I$(OPENSSL_ROOT)/include -L$(OPENSSL_ROOT)/lib
-endif
-
 # Java
 
 java_dir           := java
@@ -247,8 +239,7 @@ $(KEVM_LIB)/$(llvm_kompiled): $(includes) $(libff_out) $(plugin_includes)
 	    --directory $(KEVM_LIB)/$(llvm_dir)             \
 	    --main-module $(llvm_main_module)               \
 	    --syntax-module $(llvm_syntax_module)           \
-	    $(KOMPILE_OPTS)                                 \
-	    $(addprefix -ccopt ,$(STANDALONE_KOMPILE_OPTS))
+	    $(KOMPILE_OPTS)
 
 # Installing
 # ----------

--- a/Makefile
+++ b/Makefile
@@ -140,24 +140,22 @@ plugin-deps: $(plugin_includes) $(plugin_c_includes)
 
 KOMPILE := $(KEVM) kompile
 
-SOURCE_FILES       := abi                        \
-                      asm                        \
-                      buf                        \
-                      data                       \
-                      driver                     \
-                      edsl                       \
-                      evm                        \
-                      evm-types                  \
-                      hashed-locations           \
-                      json-rpc                   \
-                      network                    \
-                      optimizations              \
-                      serialization              \
-                      state-loader
-EXTRA_SOURCE_FILES :=
-ALL_FILES          := $(patsubst %, %.md, $(SOURCE_FILES) $(EXTRA_SOURCE_FILES))
+kevm_includes := abi.md              \
+                 asm.md              \
+                 buf.md              \
+                 data.md             \
+                 driver.md           \
+                 edsl.md             \
+                 evm.md              \
+                 evm-types.md        \
+                 hashed-locations.md \
+                 json-rpc.md         \
+                 network.md          \
+                 optimizations.md    \
+                 serialization.md    \
+                 state-loader.md
 
-LEMMA_FILES := infinite-gas.k                           \
+kevm_lemmas := infinite-gas.k                           \
                lemmas.k                                 \
                erc20/abstract-semantics-segmented-gas.k \
                erc20/evm-symbolic.k                     \
@@ -166,9 +164,9 @@ LEMMA_FILES := infinite-gas.k                           \
                mcd/verification.k                       \
                mcd/word-pack.k
 
-lemma_includes := $(patsubst %, $(KEVM_INCLUDE)/kframework/lemmas/%, $(LEMMA_FILES))
+lemma_includes := $(patsubst %, $(KEVM_INCLUDE)/kframework/lemmas/%, $(kevm_lemmas))
 
-includes := $(patsubst %, $(KEVM_INCLUDE)/kframework/%, $(ALL_FILES)) $(plugin_includes) $(lemma_includes)
+includes := $(patsubst %, $(KEVM_INCLUDE)/kframework/%, $(kevm_includes)) $(plugin_includes) $(lemma_includes)
 
 $(includes): $(KEVM_BIN)/$(KEVM)
 

--- a/data.md
+++ b/data.md
@@ -2,7 +2,6 @@ EVM Words
 =========
 
 ```k
-requires "blockchain-k-plugin/krypto.md"
 requires "evm-types.md"
 requires "json-rpc.md"
 requires "serialization.md"
@@ -10,7 +9,6 @@ requires "serialization.md"
 
 ```k
 module EVM-DATA
-    imports KRYPTO
     imports EVM-TYPES
     imports SERIALIZATION
     imports STRING-BUFFER

--- a/data.md
+++ b/data.md
@@ -19,10 +19,6 @@ module EVM-DATA
     imports JSON-EXT
 ```
 
-```{.k .concrete .bytes}
-    imports BYTES
-```
-
 ```k
 endmodule
 ```

--- a/evm-types.md
+++ b/evm-types.md
@@ -12,7 +12,7 @@ module EVM-TYPES
     imports COLLECTIONS
 ```
 
-```{.k .concrete .bytes}
+```{.k .bytes}
     imports BYTES
 ```
 

--- a/kevm
+++ b/kevm
@@ -13,11 +13,14 @@ check_k_install() {
         || fatal "Must have K installed! See https://github.com/kframework/k/releases."
 }
 
-INSTALL_BIN="$(dirname $0)"
-INSTALL_LIB=${INSTALL_BIN}/../lib/kevm
-INSTALL_K_BIN=${INSTALL_LIB}/kframework/bin
+INSTALL_BIN="$(cd $(dirname $0) && pwd)"
+INSTALL_LIB="$(dirname ${INSTALL_BIN})/lib/kevm"
+INSTALL_INCLUDE=${INSTALL_LIB}/include
 
-export PATH="$INSTALL_K_BIN:$INSTALL_BIN:$INSTALL_LIB:$PATH"
+install_k_bin=${INSTALL_LIB}/kframework/bin
+plugin_include=${INSTALL_INCLUDE}/blockchain-k-plugin
+
+export PATH="$install_k_bin:$INSTALL_BIN:$INSTALL_LIB:$PATH"
 export LD_LIBRARY_PATH=${LD_LIBRARY_PATH:-}:/usr/local/lib
 
 export K_OPTS="${K_OPTS:--Xmx16G -Xss512m}"
@@ -30,18 +33,28 @@ export KLAB_OUT="${KLAB_OUT:-~/.klab}"
 # User Commands
 
 run_kompile() {
-    local tangle_tag
+    local kompile_opts
 
+    kompile_opts=(  --backend "${backend}" "${run_file}"                       )
+    kompile_opts+=( -I "${INSTALL_INCLUDE}/kframework" -I "${INSTALL_INCLUDE}" )
+    kompile_opts+=( --hook-namespaces "JSON KRYPTO"                            )
+    kompile_opts+=( --emit-json                                                )
     case "${backend}" in
-        haskell|llvm) tangle_tag='k & ! nobytes'                      ;;
-        java)         tangle_tag='k & ! bytes'                        ;;
-        *)            fatal "Unknown backend for kompile: ${backend}" ;;
+        haskell) kompile_opts+=( --md-selector 'k & ! nobytes' )
+                 ;;
+        java)    kompile_opts+=( --md-selector 'k & ! bytes' )
+                 ;;
+        llvm)    kompile_opts+=( --md-selector 'k & ! nobytes'                                                 )
+                 kompile_opts+=( -ccopt -L${plugin_include}/lib                                                )
+                 kompile_opts+=( -ccopt ${plugin_include}/plugin-c/plugin_util.cpp                             )
+                 kompile_opts+=( -ccopt ${plugin_include}/plugin-c/crypto.cpp                                  )
+                 kompile_opts+=( -ccopt ${plugin_include}/plugin-c/blake2.cpp                                  )
+                 kompile_opts+=( -ccopt -g -ccopt -std=c++14                                                   )
+                 kompile_opts+=( -ccopt -lff -ccopt -lcryptopp -ccopt -lsecp256k1 -ccopt -lssl -ccopt -lcrypto )
+                 ;;
+        *)       fatal "Unknown backend for kompile: ${backend}" ;;
     esac
-    kompile --backend "$backend" "$run_file"    \
-         -I "${INSTALL_LIB}/include/kframework" \
-         --hook-namespaces "JSON KRYPTO"        \
-         --md-selector "${tangle_tag}"          \
-         "$@"
+    kompile "${kompile_opts[@]}" "$@"
 }
 
 run_krun() {

--- a/kevm
+++ b/kevm
@@ -18,7 +18,7 @@ INSTALL_LIB="$(dirname ${INSTALL_BIN})/lib/kevm"
 INSTALL_INCLUDE=${INSTALL_LIB}/include
 
 install_k_bin=${INSTALL_LIB}/kframework/bin
-plugin_include=${INSTALL_INCLUDE}/blockchain-k-plugin
+plugin_include=${INSTALL_LIB}/blockchain-k-plugin/include
 libff_dir=${INSTALL_LIB}/libff
 
 export PATH="$install_k_bin:$INSTALL_BIN:$INSTALL_LIB:$PATH"
@@ -36,10 +36,10 @@ export KLAB_OUT="${KLAB_OUT:-~/.klab}"
 run_kompile() {
     local kompile_opts openssl_root
 
-    kompile_opts=(  --backend "${backend}" "${run_file}"                       )
-    kompile_opts+=( -I "${INSTALL_INCLUDE}/kframework" -I "${INSTALL_INCLUDE}" )
-    kompile_opts+=( --hook-namespaces "JSON KRYPTO"                            )
-    kompile_opts+=( --emit-json                                                )
+    kompile_opts=(  --backend "${backend}" "${run_file}"                                 )
+    kompile_opts+=( -I "${INSTALL_INCLUDE}/kframework" -I "${plugin_include}/kframework" )
+    kompile_opts+=( --hook-namespaces "JSON KRYPTO"                                      )
+    kompile_opts+=( --emit-json                                                          )
     case "${backend}" in
         haskell)    kompile_opts+=( --md-selector 'k & ! nobytes' )
                     ;;
@@ -47,9 +47,9 @@ run_kompile() {
                     ;;
         llvm)       kompile_opts+=( --md-selector 'k & ! nobytes'                                                 )
                     kompile_opts+=( -ccopt -L${libff_dir}/lib -ccopt -I${libff_dir}/include                       )
-                    kompile_opts+=( -ccopt ${plugin_include}/plugin-c/plugin_util.cpp                             )
-                    kompile_opts+=( -ccopt ${plugin_include}/plugin-c/crypto.cpp                                  )
-                    kompile_opts+=( -ccopt ${plugin_include}/plugin-c/blake2.cpp                                  )
+                    kompile_opts+=( -ccopt ${plugin_include}/c/plugin_util.cpp                                    )
+                    kompile_opts+=( -ccopt ${plugin_include}/c/crypto.cpp                                         )
+                    kompile_opts+=( -ccopt ${plugin_include}/c/blake2.cpp                                         )
                     kompile_opts+=( -ccopt -g -ccopt -std=c++14                                                   )
                     kompile_opts+=( -ccopt -lff -ccopt -lcryptopp -ccopt -lsecp256k1 -ccopt -lssl -ccopt -lcrypto )
                     if [[ "$(uname -s)" == 'Linux' ]]; then

--- a/kevm
+++ b/kevm
@@ -47,7 +47,6 @@ run_kompile() {
                  ;;
         llvm)    kompile_opts+=( --md-selector 'k & ! nobytes'                                                 )
                  kompile_opts+=( -ccopt -L${libff_dir}/lib -ccopt -I${libff_dir}/include                       )
-                 kompile_opts+=( -ccopt -L${plugin_include}/lib                                                )
                  kompile_opts+=( -ccopt ${plugin_include}/plugin-c/plugin_util.cpp                             )
                  kompile_opts+=( -ccopt ${plugin_include}/plugin-c/crypto.cpp                                  )
                  kompile_opts+=( -ccopt ${plugin_include}/plugin-c/blake2.cpp                                  )

--- a/kevm
+++ b/kevm
@@ -19,6 +19,7 @@ INSTALL_INCLUDE=${INSTALL_LIB}/include
 
 install_k_bin=${INSTALL_LIB}/kframework/bin
 plugin_include=${INSTALL_INCLUDE}/blockchain-k-plugin
+libff_dir=${INSTALL_LIB}/libff
 
 export PATH="$install_k_bin:$INSTALL_BIN:$INSTALL_LIB:$PATH"
 export LD_LIBRARY_PATH=${LD_LIBRARY_PATH:-}:/usr/local/lib
@@ -46,6 +47,7 @@ run_kompile() {
                  ;;
         llvm)    kompile_opts+=( --md-selector 'k & ! nobytes'                                                 )
                  kompile_opts+=( -ccopt -L${plugin_include}/lib                                                )
+                 kompile_opts+=( -ccopt -I${libff_dir}/include                                                 )
                  kompile_opts+=( -ccopt ${plugin_include}/plugin-c/plugin_util.cpp                             )
                  kompile_opts+=( -ccopt ${plugin_include}/plugin-c/crypto.cpp                                  )
                  kompile_opts+=( -ccopt ${plugin_include}/plugin-c/blake2.cpp                                  )

--- a/kevm
+++ b/kevm
@@ -34,24 +34,30 @@ export KLAB_OUT="${KLAB_OUT:-~/.klab}"
 # User Commands
 
 run_kompile() {
-    local kompile_opts
+    local kompile_opts openssl_root
 
     kompile_opts=(  --backend "${backend}" "${run_file}"                       )
     kompile_opts+=( -I "${INSTALL_INCLUDE}/kframework" -I "${INSTALL_INCLUDE}" )
     kompile_opts+=( --hook-namespaces "JSON KRYPTO"                            )
     kompile_opts+=( --emit-json                                                )
     case "${backend}" in
-        haskell) kompile_opts+=( --md-selector 'k & ! nobytes' )
-                 ;;
-        java)    kompile_opts+=( --md-selector 'k & ! bytes' )
-                 ;;
-        llvm)    kompile_opts+=( --md-selector 'k & ! nobytes'                                                 )
-                 kompile_opts+=( -ccopt -L${libff_dir}/lib -ccopt -I${libff_dir}/include                       )
-                 kompile_opts+=( -ccopt ${plugin_include}/plugin-c/plugin_util.cpp                             )
-                 kompile_opts+=( -ccopt ${plugin_include}/plugin-c/crypto.cpp                                  )
-                 kompile_opts+=( -ccopt ${plugin_include}/plugin-c/blake2.cpp                                  )
-                 kompile_opts+=( -ccopt -g -ccopt -std=c++14                                                   )
-                 kompile_opts+=( -ccopt -lff -ccopt -lcryptopp -ccopt -lsecp256k1 -ccopt -lssl -ccopt -lcrypto )
+        haskell)    kompile_opts+=( --md-selector 'k & ! nobytes' )
+                    ;;
+        java)       kompile_opts+=( --md-selector 'k & ! bytes' )
+                    ;;
+        llvm)       kompile_opts+=( --md-selector 'k & ! nobytes'                                                 )
+                    kompile_opts+=( -ccopt -L${libff_dir}/lib -ccopt -I${libff_dir}/include                       )
+                    kompile_opts+=( -ccopt ${plugin_include}/plugin-c/plugin_util.cpp                             )
+                    kompile_opts+=( -ccopt ${plugin_include}/plugin-c/crypto.cpp                                  )
+                    kompile_opts+=( -ccopt ${plugin_include}/plugin-c/blake2.cpp                                  )
+                    kompile_opts+=( -ccopt -g -ccopt -std=c++14                                                   )
+                    kompile_opts+=( -ccopt -lff -ccopt -lcryptopp -ccopt -lsecp256k1 -ccopt -lssl -ccopt -lcrypto )
+                    if [[ "$(uname -s)" == 'Linux' ]]; then
+                        kompile_opts+=( -ccopt -lprocps )
+                    elif [[ "$(uname -s)" == 'Darwin' ]]; then
+                        openssl_root="$(brew --prefix openssl)"
+                        kompile_opts+=( -I/usr/local/include -L/usr/local/lib -I${openssl_root}/include -L${openssl_root}/lib )
+                    fi
                  ;;
         *)       fatal "Unknown backend for kompile: ${backend}" ;;
     esac

--- a/kevm
+++ b/kevm
@@ -30,10 +30,18 @@ export KLAB_OUT="${KLAB_OUT:-~/.klab}"
 # User Commands
 
 run_kompile() {
-   kompile --backend "$backend" "$run_file"    \
-        -I "${INSTALL_LIB}/include/kframework" \
-        --hook-namespaces "JSON KRYPTO"        \
-        "$@"
+    local tangle_tag
+
+    case "${backend}" in
+        haskell|llvm) tangle_tag='k & ! nobytes'                      ;;
+        java)         tangle_tag='k & ! bytes'                        ;;
+        *)            fatal "Unknown backend for kompile: ${backend}" ;;
+    esac
+    kompile --backend "$backend" "$run_file"    \
+         -I "${INSTALL_LIB}/include/kframework" \
+         --hook-namespaces "JSON KRYPTO"        \
+         --md-selector "${tangle_tag}"          \
+         "$@"
 }
 
 run_krun() {

--- a/kevm
+++ b/kevm
@@ -46,8 +46,8 @@ run_kompile() {
         java)    kompile_opts+=( --md-selector 'k & ! bytes' )
                  ;;
         llvm)    kompile_opts+=( --md-selector 'k & ! nobytes'                                                 )
+                 kompile_opts+=( -ccopt -L${libff_dir}/lib -ccopt -I${libff_dir}/include                       )
                  kompile_opts+=( -ccopt -L${plugin_include}/lib                                                )
-                 kompile_opts+=( -ccopt -I${libff_dir}/include                                                 )
                  kompile_opts+=( -ccopt ${plugin_include}/plugin-c/plugin_util.cpp                             )
                  kompile_opts+=( -ccopt ${plugin_include}/plugin-c/crypto.cpp                                  )
                  kompile_opts+=( -ccopt ${plugin_include}/plugin-c/blake2.cpp                                  )

--- a/serialization.md
+++ b/serialization.md
@@ -2,7 +2,7 @@ Parsing/Unparsing
 =================
 
 ```k
-requires "blockchain-k-plugin/krypto.md"
+requires "krypto.md"
 requires "evm-types.md"
 requires "json-rpc.md"
 ```


### PR DESCRIPTION
This PR updates several things, so that `kevm kompile` is more useful for projects that depend on KEVM.

- The `deps/plugin` build products are included in the `kevm` library build too now, so that projects that depend on KEVM have access to them.
- `kevm kompile` now does most of the heavy lifting of deciding which options to send to each backend. This ends up simplifying the `Makefile` quite a bit. It also handles the options relating to plugins which means that users of KEVM can call `kevm kompile` without knowing about the plugin dependencies.
- The `tangle_*` tags are simplified to just `bytes` backends, and `nobytes` backends. We used to need tags `symbolic` and `concrete` as well, but that distinction is mostly handled with module comments anymore.
- The installation of plugin dependencies happens in `$(KEVM_LIB)/blockchain-k-plugin` now instead of mixing those files into KEVM source files. This follows the pattern of other dependencies of installing them into `$(KEVM_LIB)/DEPENDENCY` rather than mixing the files into KEVM source files.

This PR enables building KEVM into mkr-mcd-spec for doing refinement proofs: https://github.com/makerdao/mkr-mcd-spec/pull/243. It works (and passes tests) locally, but the docker image for this branch is not deployed yet so it's not working on CI yet.