### PR TITLE
Remove VMTests on Haskell backend stage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,7 +28,7 @@ pipeline {
           failFast true
           options {
             lock("proofs-${env.NODE_NAME}")
-            timeout(time: 120, unit: 'MINUTES')
+            timeout(time: 150, unit: 'MINUTES')
           }
           parallel {
             stage('Conformance (LLVM)')         { steps { sh 'make test-conformance -j8 TEST_CONCRETE_BACKEND=llvm' } }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,23 +24,17 @@ pipeline {
       stages {
         stage('Deps')  { steps { sh 'make plugin-deps'            } }
         stage('Build') { steps { sh 'make build RELEASE=true -j6' } }
-        stage('Test Execution') {
+        stage('Test') {
           failFast true
-          options { timeout(time: 25, unit: 'MINUTES') }
-          parallel {
-            stage('Conformance (LLVM)') { steps { sh 'make test-conformance -j8 TEST_CONCRETE_BACKEND=llvm' } }
-            stage('VM (Haskell)')       { steps { sh 'make test-vm -j8 TEST_CONCRETE_BACKEND=haskell'       } }
-          }
-        }
-        stage('Proofs') {
           options {
             lock("proofs-${env.NODE_NAME}")
             timeout(time: 120, unit: 'MINUTES')
           }
           parallel {
-            stage('Java')              { steps { sh 'make test-prove -j5 TEST_SYMBOLIC_BACKEND=java'    } }
-            stage('Haskell')           { steps { sh 'make test-prove -j4 TEST_SYMBOLIC_BACKEND=haskell' } }
-            stage('Haskell (dry-run)') { steps { sh 'make test-haskell-dry-run -j3'                     } }
+            stage('Conformance (LLVM)')         { steps { sh 'make test-conformance -j8 TEST_CONCRETE_BACKEND=llvm' } }
+            stage('Proofs (Java)')              { steps { sh 'make test-prove -j5 TEST_SYMBOLIC_BACKEND=java'       } }
+            stage('Proofs (Haskell)')           { steps { sh 'make test-prove -j4 TEST_SYMBOLIC_BACKEND=haskell'    } }
+            stage('Proofs (Haskell - dry-run)') { steps { sh 'make test-haskell-dry-run -j3'                        } }
           }
         }
         stage('Test Interactive') {

--- a/Makefile
+++ b/Makefile
@@ -209,9 +209,9 @@ KOMPILE_STANDALONE := kompile --debug --backend llvm --md-selector "$(tangle_con
 # Java
 
 java_dir           := java
-java_main_module   := ETHEREUM-SIMULATION
+java_main_module   := EDSL
 java_syntax_module := $(java_main_module)
-java_main_file     := driver.md
+java_main_file     := edsl.md
 java_main_filename := $(basename $(notdir $(java_main_file)))
 java_kompiled      := $(java_dir)/$(java_main_filename)-kompiled/compiled.bin
 
@@ -224,9 +224,9 @@ $(KEVM_LIB)/$(java_kompiled): $(includes)
 # Haskell
 
 haskell_dir            := haskell
-haskell_main_module    := ETHEREUM-SIMULATION
+haskell_main_module    := EDSL
 haskell_syntax_module  := $(haskell_main_module)
-haskell_main_file      := driver.md
+haskell_main_file      := edsl.md
 haskell_main_filename  := $(basename $(notdir $(haskell_main_file)))
 haskell_kompiled       := $(haskell_dir)/$(haskell_main_filename)-kompiled/definition.kore
 

--- a/Makefile
+++ b/Makefile
@@ -209,9 +209,9 @@ KOMPILE_STANDALONE := kompile --debug --backend llvm --md-selector "$(tangle_con
 # Java
 
 java_dir           := java
-java_main_module   := EDSL
+java_main_module   := ETHEREUM-SIMULATION
 java_syntax_module := $(java_main_module)
-java_main_file     := edsl.md
+java_main_file     := driver.md
 java_main_filename := $(basename $(notdir $(java_main_file)))
 java_kompiled      := $(java_dir)/$(java_main_filename)-kompiled/compiled.bin
 
@@ -224,9 +224,9 @@ $(KEVM_LIB)/$(java_kompiled): $(includes)
 # Haskell
 
 haskell_dir            := haskell
-haskell_main_module    := EDSL
+haskell_main_module    := ETHEREUM-SIMULATION
 haskell_syntax_module  := $(haskell_main_module)
-haskell_main_file      := edsl.md
+haskell_main_file      := driver.md
 haskell_main_filename  := $(basename $(notdir $(haskell_main_file)))
 haskell_kompiled       := $(haskell_dir)/$(haskell_main_filename)-kompiled/definition.kore
 

--- a/Makefile
+++ b/Makefile
@@ -289,9 +289,9 @@ $(KEVM_LIB)/release.md: INSTALL.md
 
 build: $(patsubst %, $(KEVM_BIN)/%, $(install_bins)) $(patsubst %, $(KEVM_LIB)/%, $(install_libs)) $(lemma_includes)
 
-build-haskell: $(KEVM_LIB)/$(haskell_kompiled) $(KEVM_BIN)/$(KEVM)
+build-haskell: $(KEVM_LIB)/$(haskell_kompiled) $(KEVM_BIN)/$(KEVM) $(KEVM_LIB)/kore-json.py
 build-llvm:    $(KEVM_LIB)/$(llvm_kompiled)    $(KEVM_BIN)/$(KEVM) $(KEVM_LIB)/kore-json.py
-build-java:    $(KEVM_LIB)/$(java_kompiled)    $(KEVM_BIN)/$(KEVM)
+build-java:    $(KEVM_LIB)/$(java_kompiled)    $(KEVM_BIN)/$(KEVM) $(KEVM_LIB)/kast-json.py
 build-lemmas:  $(lemma_includes)
 
 all_bin_sources := $(shell find $(KEVM_BIN) -type f                                                                                                                    | sed 's|^$(KEVM_BIN)/||')


### PR DESCRIPTION
- ~Builds both java/haskell backends against EDSL instead of ETHEREUM-SIMULATION. This means that the `--main-module` contains more of the syntax by default, to make parsing/unparsing issues in the kore-repl go away.~
- Stops running the VMTests for haskell backend. The VMTests slowed down on Haskell backend for #1005, which sped up the proofs significantly.

~BLOCKED on kframework/k#2024~