### PR TITLE
Run functional spec for MCD proofs on Haskell backend

### DIFF
--- a/tests/failing-symbolic.haskell
+++ b/tests/failing-symbolic.haskell
@@ -73,7 +73,6 @@ tests/specs/mcd/flopper-dent-guy-same-pass-rough-spec.k
 tests/specs/mcd/flopper-file-pass-rough-spec.k
 tests/specs/mcd/flopper-kick-pass-rough-spec.k
 tests/specs/mcd/flopper-tick-pass-rough-spec.k
-tests/specs/mcd/functional-spec.k
 tests/specs/mcd/gemjoin-exit-pass-rough-spec.k
 tests/specs/mcd/pot-join-pass-rough-spec.k
 tests/specs/mcd/vat-addui-fail-rough-spec.k

--- a/tests/specs/mcd/functional-spec.k
+++ b/tests/specs/mcd/functional-spec.k
@@ -63,9 +63,6 @@ module FUNCTIONAL-SPEC
 
     claim <k> runLemma(#range(M:Memory [ 0 := #buf(4, X) ] [ 0 <- 10 ] [ 1 <- 11 ] [ 2 <- 12 ] [ 3 <- 13 ], 0, 4)) => doneLemma(10 : 11 : 12 : 13 : .ByteArray) ... </k>
 
-    claim <k> runLemma(M:Memory [ 128 := (B1 : B2 : B3 : B4 : _     : .ByteArray) ] [ 132 := BA':ByteArray ]) => doneLemma(M [ 128 := (B1 : B2 : B3 : B4 : .ByteArray) ] [ 132 := BA' ]) ... </k> requires #sizeByteArray(BA') ==Int 32
-    claim <k> runLemma(M:Memory [ 128 := (B1 : B2 : B3 : B4 : _ : _ : .ByteArray) ] [ 132 := BA':ByteArray ]) => doneLemma(M [ 128 := (B1 : B2 : B3 : B4 : .ByteArray) ] [ 132 := BA' ]) ... </k> requires #sizeByteArray(BA') ==Int 32
-
     claim <k> runLemma( M:Memory [ 132 := #buf(32, B11) ] [ 128 := (#buf(32, B21) ++ #buf(32, B22)) ] ) => doneLemma( M [ 128 := (#buf(32, B21) ++ #buf(32, B22)) ] ) ... </k>
       requires #rangeUInt(256, B11) andBool #rangeUInt(256, B21) andBool #rangeUInt(256, B22)
 

--- a/tests/specs/mcd/verification.k
+++ b/tests/specs/mcd/verification.k
@@ -54,6 +54,10 @@ endmodule
 module LEMMAS-MCD-HASKELL [symbolic, kore]
     imports LEMMAS-MCD-COMMON
 
+    // ### functional
+
+    rule chop(Y) => Y +Int pow256 requires #rangeSInt(256, Y) andBool Y <Int 0 [simplification]
+
     // ### flapper-yank-pass-rough
 
     rule #range(M:Memory [ K <- V ], START, WIDTH) => #range(M [ K := (V : .ByteArray) ], START, WIDTH)

--- a/tests/specs/mcd/verification.k
+++ b/tests/specs/mcd/verification.k
@@ -397,10 +397,10 @@ module LEMMAS-MCD-COMMON
     rule <acctID> ACCTID </acctID>  ==K <acctID> ACCTID' </acctID> => ACCTID  ==Int ACCTID' [simplification]
     rule <acctID> ACCTID </acctID> =/=K <acctID> ACCTID' </acctID> => ACCTID =/=Int ACCTID' [simplification]
 
-    rule ((K |-> V) REST) [ K' <- undef ] => REST                             requires K  ==K K' [simplification]
+    rule ((K |-> _) REST) [ K' <- undef ] => REST                             requires K  ==K K' [simplification]
     rule ((K |-> V) REST) [ K' <- undef ] => (K |-> V) (REST [ K' <- undef ]) requires K =/=K K' [simplification]
 
-    rule M:Map [ K1 <- V1 ] [ K2 <- V2 ] [ K1 <- V1' ] => M [ K1 <- V1' ] [ K2 <- V2 ] requires K1 =/=Int K2 [simplification]
+    rule M:Map [ K1 <- _ ] [ K2 <- V2 ] [ K1 <- V1' ] => M [ K1 <- V1' ] [ K2 <- V2 ] requires K1 =/=Int K2 [simplification]
 
     // ### end-cage-ilk-pass-rough
 
@@ -427,7 +427,7 @@ module LEMMAS-MCD-COMMON
 
     rule ((I1 -Int I2) -Int I3) +Int I2 => I1 -Int I3 [simplification]
 
-    rule M:Map [ K1 <- V1 ] [ K2 <- V2 ] [ K3 <- V3 ] [ K1 <- V4 ] => M [ K1 <- V4 ] [ K2 <- V2 ] [ K3 <- V3 ] requires K1 =/=Int K2 andBool K1 =/=Int K3 [simplification]
+    rule M:Map [ K1 <- _ ] [ K2 <- V2 ] [ K3 <- V3 ] [ K1 <- V4 ] => M [ K1 <- V4 ] [ K2 <- V2 ] [ K3 <- V3 ] requires K1 =/=Int K2 andBool K1 =/=Int K3 [simplification]
 
     // ### vat-fold-pass-rough
 

--- a/tests/specs/mcd/word-pack.k
+++ b/tests/specs/mcd/word-pack.k
@@ -21,22 +21,6 @@ endmodule
 
 module WORD-PACK-JAVA [kast]
     imports WORD-PACK-COMMON
-endmodule
-
-module WORD-PACK-HASKELL [kore]
-    imports WORD-PACK-COMMON
-endmodule
-
-module WORD-PACK-COMMON
-    imports EVM-TYPES
-
-    syntax Int ::= #WordPackUInt48UInt48     (       Int , Int ) [function, no-evaluators, smtlib(WordPackUInt48UInt48)]
-                 | #WordPackAddrUInt48UInt48 ( Int , Int , Int ) [function, no-evaluators, smtlib(WordPackAddrUInt48UInt48)]
-                 | #WordPackAddrUInt8        (       Int , Int ) [function, no-evaluators, smtlib(WordPackAddrUInt8)]
- // -----------------------------------------------------------------------------------------------------------------
-    // rule #WordPackUInt48UInt48     (            UINT48_1 , UINT48_2 ) => UINT48_2 *Int pow48 +Int UINT48_1                        requires #rangeUInt(48, UINT48_1) andBool #rangeUInt(48, UINT48_2)
-    // rule #WordPackAddrUInt48UInt48 (     ADDR , UINT48_1 , UINT48_2 ) => UINT48_2 *Int pow208 +Int UINT48_1 *Int pow160 +Int ADDR requires #rangeAddress(ADDR) andBool #rangeUInt(48, UINT48_1) andBool #rangeUInt(48, UINT48_2)
-    // rule #WordPackAddrUInt8        (     ADDR , UINT8               ) => UINT8 *Int pow160 +Int ADDR                              requires #rangeAddress(ADDR) andBool #rangeUInt(8, UINT_8)
 
     rule    ADDR_UINT48_UINT48 ==K #WordPackAddrUInt48UInt48(ADDR, UINT48_1, UINT48_2)
          => ADDR     ==Int maxUInt160 &Int  ADDR_UINT48_UINT48
@@ -56,6 +40,43 @@ module WORD-PACK-COMMON
     andBool UINT8 ==Int maxUInt8   &Int (ADDR_UINT8 /Int pow160)
     andBool #rangeUInt(168, ADDR_UINT8)
       [simplification]
+
+endmodule
+
+module WORD-PACK-HASKELL [kore]
+    imports WORD-PACK-COMMON
+
+    rule    ADDR_UINT48_UINT48 ==Int #WordPackAddrUInt48UInt48(ADDR, UINT48_1, UINT48_2)
+         => ADDR     ==Int maxUInt160 &Int  ADDR_UINT48_UINT48
+    andBool UINT48_1 ==Int maxUInt48  &Int (ADDR_UINT48_UINT48 /Int pow160)
+    andBool UINT48_2 ==Int maxUInt48  &Int (ADDR_UINT48_UINT48 /Int pow208)
+    andBool #rangeUInt(256, ADDR_UINT48_UINT48)
+      [simplification]
+
+    rule    UINT48_UINT48 ==Int #WordPackUInt48UInt48(UINT48_1, UINT48_2)
+         => UINT48_1 ==Int maxUInt48 &Int  UINT48_UINT48
+    andBool UINT48_2 ==Int maxUInt48 &Int (UINT48_UINT48 /Int pow48)
+    andBool #rangeUInt(96, UINT48_UINT48)
+      [simplification]
+
+    rule    ADDR_UINT8 ==Int #WordPackAddrUInt8(ADDR, UINT8)
+         => ADDR  ==Int maxUInt160 &Int  ADDR_UINT8
+    andBool UINT8 ==Int maxUInt8   &Int (ADDR_UINT8 /Int pow160)
+    andBool #rangeUInt(168, ADDR_UINT8)
+      [simplification]
+
+endmodule
+
+module WORD-PACK-COMMON
+    imports EVM-TYPES
+
+    syntax Int ::= #WordPackUInt48UInt48     (       Int , Int ) [function, no-evaluators, smtlib(WordPackUInt48UInt48)]
+                 | #WordPackAddrUInt48UInt48 ( Int , Int , Int ) [function, no-evaluators, smtlib(WordPackAddrUInt48UInt48)]
+                 | #WordPackAddrUInt8        (       Int , Int ) [function, no-evaluators, smtlib(WordPackAddrUInt8)]
+ // -----------------------------------------------------------------------------------------------------------------
+    // rule #WordPackUInt48UInt48     (            UINT48_1 , UINT48_2 ) => UINT48_2 *Int pow48 +Int UINT48_1                        requires #rangeUInt(48, UINT48_1) andBool #rangeUInt(48, UINT48_2)
+    // rule #WordPackAddrUInt48UInt48 (     ADDR , UINT48_1 , UINT48_2 ) => UINT48_2 *Int pow208 +Int UINT48_1 *Int pow160 +Int ADDR requires #rangeAddress(ADDR) andBool #rangeUInt(48, UINT48_1) andBool #rangeUInt(48, UINT48_2)
+    // rule #WordPackAddrUInt8        (     ADDR , UINT8               ) => UINT8 *Int pow160 +Int ADDR                              requires #rangeAddress(ADDR) andBool #rangeUInt(8, UINT_8)
 
     syntax Int ::= "maskWordPackUInt48UInt48_1" // 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF000000000000FFFFFFFFFFFF
                  | "maskWordPackUInt48UInt48_2" // 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF000000000000

--- a/tests/specs/mcd/word-pack.k
+++ b/tests/specs/mcd/word-pack.k
@@ -15,6 +15,19 @@ requires "evm-types.md"
     //
 
 module WORD-PACK
+    imports WORD-PACK-HASKELL
+    imports WORD-PACK-JAVA
+endmodule
+
+module WORD-PACK-JAVA [kast]
+    imports WORD-PACK-COMMON
+endmodule
+
+module WORD-PACK-HASKELL [kore]
+    imports WORD-PACK-COMMON
+endmodule
+
+module WORD-PACK-COMMON
     imports EVM-TYPES
 
     syntax Int ::= #WordPackUInt48UInt48     (       Int , Int ) [function, no-evaluators, smtlib(WordPackUInt48UInt48)]

--- a/tests/specs/mcd/word-pack.k
+++ b/tests/specs/mcd/word-pack.k
@@ -65,6 +65,11 @@ module WORD-PACK-HASKELL [kore]
     andBool #rangeUInt(168, ADDR_UINT8)
       [simplification]
 
+    rule maxUInt48 &Int (X /Int pow48) => X /Int pow48 requires #rangeUInt(96, X) [simplification]
+
+    rule X |Int 0 => X requires 0 <=Int X [simplification]
+    rule 0 &Int X => 0 requires 0 <=Int X [simplification]
+
 endmodule
 
 module WORD-PACK-COMMON


### PR DESCRIPTION
This PR:

- Separates out the `WordStack` axiomatization into haskell/java specific ones.
- Adds some simple arithmetic simplification lemmas needed to make the functional proofs go through.
- Removes two problematic tests which actually are invalid (they do not make sure the input bytes are valid width, so they should not pass).
- Enables the MCD functional tests on haskell backend on CI.