### PR TITLE
Enable Haskell Backend Tests Passing in <20m

### DIFF
--- a/tests/failing-symbolic.haskell
+++ b/tests/failing-symbolic.haskell
@@ -9,8 +9,6 @@ tests/specs/benchmarks/ecrecoverloop02-sig1-invalid-spec.k
 tests/specs/benchmarks/ecrecoverloop02-sigs-valid-spec.k
 tests/specs/benchmarks/encodepacked-keccak01-spec.k
 tests/specs/benchmarks/keccak00-spec.k
-tests/specs/benchmarks/requires01-a0gt0-spec.k
-tests/specs/benchmarks/staticarray00-spec.k
 tests/specs/benchmarks/staticloop00-a0lt10-spec.k
 tests/specs/bihu/collectToken-spec.k
 tests/specs/bihu/forwardToHotWallet-failure-1-spec.k
@@ -38,7 +36,6 @@ tests/specs/erc20/ds/transferFrom-success-1-spec.k
 tests/specs/erc20/ds/transferFrom-success-2-spec.k
 tests/specs/erc20/ds/transfer-success-1-spec.k
 tests/specs/erc20/ds/transfer-success-2-spec.k
-tests/specs/erc20/hkg/allowance-spec.k
 tests/specs/erc20/hkg/approve-spec.k
 tests/specs/erc20/hkg/balanceOf-spec.k
 tests/specs/erc20/hkg/transfer-failure-1-spec.k


### PR DESCRIPTION
I ran the test suite locally, pulled out the new tests that pass in under 20 minutes, and enabled them.

There was some uncertainty if my local build was clean, since there was at least one test that should have been passing but failed. However that should only mean that this PR might miss passing tests, and not that it enables failing ones.