### PR TITLE
Update build instructions for Arch Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,6 @@ sudo pacman -S                                               \
     mpfr python stack yaml-cpp z3 zlib
 ```
 
-In addition, you'll need the `glog-git` AUR package: <https://aur.archlinux.org/packages/glog-git/>.
-
 #### MacOS
 
 On OSX, using [Homebrew](https://brew.sh/), after installing the command line tools package:


### PR DESCRIPTION
Remove the note on needing to install `glog-git`, since the project builds
successfully without it, and nothing in the repo mentions it.