### PR TITLE
evm: skip #addr if we know it wont be used

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,7 +35,7 @@ pipeline {
         stage('Proofs') {
           options {
             lock("proofs-${env.NODE_NAME}")
-            timeout(time: 145, unit: 'MINUTES')
+            timeout(time: 120, unit: 'MINUTES')
           }
           parallel {
             stage('Java')              { steps { sh 'make test-prove -j5 TEST_SYMBOLIC_BACKEND=java'    } }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,7 +35,7 @@ pipeline {
         stage('Proofs') {
           options {
             lock("proofs-${env.NODE_NAME}")
-            timeout(time: 120, unit: 'MINUTES')
+            timeout(time: 145, unit: 'MINUTES')
           }
           parallel {
             stage('Java')              { steps { sh 'make test-prove -j5 TEST_SYMBOLIC_BACKEND=java'    } }

--- a/evm.md
+++ b/evm.md
@@ -301,7 +301,7 @@ The `#next [_]` operator initiates execution by:
     syntax InternalOp ::= "#next" "[" OpCode "]"
  // --------------------------------------------
     rule <k> #next [ OP ]
-          => #addr [ OP ]
+          => #if isAddr1Op(OP) orBool isAddr2Op(OP) #then #addr [ OP ] #else . #fi
           ~> #exec [ OP ]
           ~> #pc   [ OP ]
          ...


### PR DESCRIPTION
This is inspired by the data here: https://github.com/kframework/evm-semantics/issues/1048#issuecomment-862711135

I noticed that one of the really-high frequency rules was for `#addr[_]`, and also noticed that this rule wasn't particularly fast (or slow). This rule only needs to be fired on a very small fraction of opcodes, so if we inline the condition about whether we should run this check or not using an `#if_#then_#else_#fi`, we can skip an entire rewrite rule per EVM opcode step in many cases!

I ran an initial test using `tests/specs/benchmarks/storagevar00-spec.k`, results are:

```
* 906ef670 - evm: skip #addr if we know it wont be used                                       - Everett Hildenbrandt (HEAD, upstream/addr-optimizations, addr-optimizations)
| testset: single-profile - Thu Jun 17 00:03:34 UTC 2021
| pre: rm -rf .build
| pre: git submodule update --init --recursive
| pre: make deps RELEASE=true
| 0  60.69s   761.92s  20.39s  2729392KB  make  build                                             -j8                            RELEASE=true
| 0  260.02s  462.54s  8.90s   3356184KB  make  tests/specs/benchmarks/storagevar00-spec.k.prove  TEST_SYMBOLIC_BACKEND=haskell
| 0  246.05s  285.20s  3.99s   1937556KB  make  tests/specs/benchmarks/storagevar00-spec.k.prove  TEST_SYMBOLIC_BACKEND=haskell
| 0  238.03s  277.13s  5.33s   1937300KB  make  tests/specs/benchmarks/storagevar00-spec.k.prove  TEST_SYMBOLIC_BACKEND=haskell
| 
* 64ae85bf - uppercase variables in tests/specs/mcd (#1051)                                   - 0xVerif (upstream/master)
| testset: single-profile - Wed Jun 16 23:49:53 UTC 2021
| pre: rm -rf .build
| pre: git submodule update --init --recursive
| pre: make deps RELEASE=true
| 0  311.92s  1046.14s  22.53s  2570444KB  make  build                                             -j8                            RELEASE=true
| 0  281.90s  471.91s   7.58s   2962644KB  make  tests/specs/benchmarks/storagevar00-spec.k.prove  TEST_SYMBOLIC_BACKEND=haskell
| 0  263.16s  301.48s   3.88s   1938472KB  make  tests/specs/benchmarks/storagevar00-spec.k.prove  TEST_SYMBOLIC_BACKEND=haskell
| 0  268.46s  309.28s   3.79s   1937592KB  make  tests/specs/benchmarks/storagevar00-spec.k.prove  TEST_SYMBOLIC_BACKEND=haskell
```

Three runs on `master`: 282s, 263s, 269s
Three runs on this PR: 260s, 246s, 238s - roughly 9% speedup consistently (somewhat consistent with the fact that we're skipping a little fewer than 1/10 steps).

I'll get data on the entirety of the test-suite before marking this as ready.