### PR TITLE
Updates to Build system for symbolic backends

### DIFF
--- a/package/debian/control.focal
+++ b/package/debian/control.focal
@@ -2,7 +2,7 @@ Source: kevm
 Section: devel
 Priority: optional
 Maintainer: Everett Hildenbrandt <everett.hildenbrandt@runtimeverification.com>
-Build-Depends: clang-10 , cmake , debhelper , flex , libboost-test-dev , libcrypto++-dev , libgmp-dev , libjemalloc-dev , libmpfr-dev , libprocps-dev , libsecp256k1-dev , libssl-dev , libyaml-dev , maven , openjdk-11-jdk , pkg-config , zlib1g-dev
+Build-Depends: cmake , debhelper , default-jdk-headless , libboost-test-dev , maven , pkg-config , zlib1g-dev
 Standards-Version: 3.9.6
 Homepage: https://github.com/kframework/evm-semantics
 
@@ -10,7 +10,7 @@ Package: kevm
 Architecture: any
 Section: devel
 Priority: optional
-Depends: clang-10 , default-jre-headless , flex , gcc , libcrypto++-dev , libgmp-dev , libjemalloc-dev , libmpfr-dev , libprocps-dev , libsecp256k1-dev , lld-10 , python3 , z3
+Depends: clang-10 , default-jre-headless , flex , gcc , libcrypto++-dev , libgmp-dev , libjemalloc-dev , libmpfr-dev , libprocps-dev , libsecp256k1-dev , libssl-dev , libyaml-dev , lld-10 , python3 , z3
 Description: K Semantics of EVM
  Implementation of Ethereum Virtual Machine (EVM) in K.
  kevm-vm executable communicates over protobuf to run EVM transactions.


### PR DESCRIPTION
- Symbolic backends now use EDSL as main module.
- All backends will not rebuild (unnecessarily) if some of the lemmas files in `tests/specs` changes.

Blocked on: https://github.com/kframework/k/issues/2024