### PR TITLE
Simplify Concrete ByteArrays on Haskell Backend

### DIFF
--- a/tests/specs/benchmarks/functional-spec.k
+++ b/tests/specs/benchmarks/functional-spec.k
@@ -27,4 +27,6 @@ module FUNCTIONAL-SPEC
 
     claim <k> runLemma(#ceil32(DATA_LEN) +Int 292 <Int DATA_LEN +Int 292) => doneLemma(false) ... </k> requires #range(0 <= DATA_LEN < pow16)
 
+    claim <k> runLemma(#buf(4, 0) ++ (#buf(32, 6) ++ BA:ByteArray)) => doneLemma(#buf(36, 6) ++ BA:ByteArray) ... </k>
+
 endmodule

--- a/tests/specs/benchmarks/verification.k
+++ b/tests/specs/benchmarks/verification.k
@@ -353,6 +353,8 @@ module VERIFICATION-HASKELL [symbolic, kore]
 
     rule X +Int Y <Int Z => X <Int Z -Int Y [concrete(Y), simplification]
 
+    rule BA1 ++ (BA2 ++ BA3) => (BA1 ++ BA2) ++ BA3 [concrete(BA1, BA2), simplification]
+
 endmodule
 
 module VERIFICATION-JAVA [symbolic, kast]


### PR DESCRIPTION
Left-associates concrete byte arrays on the haskell backend so that they can get simplified.