### PR TITLE
Organize lemmas

### DIFF
--- a/tests/specs/benchmarks/verification.k
+++ b/tests/specs/benchmarks/verification.k
@@ -22,7 +22,7 @@ module VERIFICATION
     imports VERIFICATION-HASKELL
 
   // ########################
-  // Map
+  // Map Reasoning
   // ########################
 
     rule M:Map [ K1 <- _  ] [ K2 <- V2 ] => M [ K1 <- V2 ]               requires K1 ==Int K2 [simplification]

--- a/tests/specs/benchmarks/verification.k
+++ b/tests/specs/benchmarks/verification.k
@@ -8,7 +8,7 @@ module VERIFICATION-COMMON
   // Ecrecover
   // ########################
 
-    //Symbolic wrapper over the argument of #ecrec, no implementation.
+    //Symbolic wrapper over the argument of #ecrec. No implementation.
     syntax Int ::= #symEcrec ( ByteArray )   [function]
 
     //Symbolic predicate representing whether output of #ecrec is empty. No implementation.
@@ -20,10 +20,18 @@ module VERIFICATION
     imports VERIFICATION-JAVA
     imports VERIFICATION-HASKELL
 
+  // ########################
+  // Map
+  // ########################
+
     rule M:Map [ K1 <- _  ] [ K2 <- V2 ] => M [ K1 <- V2 ]              requires K1 ==Int K2
       [simplification]
     rule M:Map [ K1 <- V1 ] [ K2 <- V2 ] => M [ K2 <- V2 ] [ K1 <- V1 ] requires K2  <Int K1
       [simplification]
+
+  // ########################
+  // Gas Calculation
+  // ########################
 
     rule Rsstore(BYZANTIUM, NEW, _CURR, _ORIG) => 0 requires NEW =/=Int 0
       [simplification]
@@ -35,19 +43,15 @@ module VERIFICATION
     // Range for #symEcrec
 
     //case 0 is never wrapped into #symEcrec(), corresponds to #ecrecEmpty(DATA) == true
-    rule 0 <Int   #symEcrec(_DATA)             => true
-      [simplification]
+    rule 0 <Int   #symEcrec(_DATA)             => true [simplification]
 
     //that's because the result in concrete semantics is trimmed to Address range.
-    rule          #symEcrec(_DATA) <Int pow160 => true
-      [simplification]
+    rule          #symEcrec(_DATA) <Int pow160 => true [simplification]
 
     // Lemmas implied by the above, but still required to match side conditions of #padToWidth rule in lemmas.md
     // General range conversion lemmas like below are not an option, dramatic performance decrease:
-    rule 0 <=Int  #symEcrec(_DATA)             => true
-      [simplification]
-    rule          #symEcrec(_DATA) <Int pow256 => true
-      [simplification]
+    rule 0 <=Int  #symEcrec(_DATA)             => true [simplification]
+    rule          #symEcrec(_DATA) <Int pow256 => true [simplification]
 
   // ########################
   // Symbolic Call
@@ -72,8 +76,7 @@ module VERIFICATION
       => #parseByteStack(substrString(Keccak256(FSIG), 0, 8))
       ++ #encodeArgs(ARGS)
 
-    rule chop(I) => 0 requires I ==Int pow256
-      [simplification]
+    rule chop(I) => 0 requires I ==Int pow256 [simplification]
 
   // ########################
   // Memory Usage
@@ -81,14 +84,14 @@ module VERIFICATION
 
     rule #memoryUsageUpdate(#memoryUsageUpdate(MU, START0, WIDTH0), START1, WIDTH1) => #memoryUsageUpdate(MU, START0, WIDTH0)
       requires START1 +Int WIDTH1 <=Int START0 +Int WIDTH0
-        andBool 0 <Int WIDTH0
-        andBool 0 <=Int WIDTH1
+       andBool 0 <Int WIDTH0
+       andBool 0 <=Int WIDTH1
       [simplification]
 
     rule #memoryUsageUpdate(#memoryUsageUpdate(MU, START0, WIDTH0), START1, WIDTH1) => #memoryUsageUpdate(MU, START1, WIDTH1)
       requires START0 +Int WIDTH0 <Int START1 +Int WIDTH1
-        andBool 0 <=Int WIDTH0
-        andBool 0 <Int WIDTH1
+       andBool 0 <=Int WIDTH0
+       andBool 0 <Int WIDTH1
       [simplification]
 
     rule 0 <=Int #memoryUsageUpdate(_MU, _START, _WIDTH) => true
@@ -98,70 +101,50 @@ module VERIFICATION
   // Buffer Reasoning
   // ########################
 
-    rule WS ++ .ByteArray => WS
-      [simplification]
-    rule ( WS1 ++ WS2 ) ++ WS3 => WS1 ++ ( WS2 ++ WS3 )
-      [simplification]
+    rule WS ++ .ByteArray => WS [simplification]
+    
+    rule ( WS1 ++ WS2 ) ++ WS3 => WS1 ++ ( WS2 ++ WS3 ) [simplification]
 
-    rule #sizeWordStack(WS, N) <Int SIZE => #sizeWordStack(WS, 0) +Int N <Int SIZE  requires N =/=Int 0
-      [simplification]
-    rule SIZELIMIT <Int #sizeWordStack(WS, N) +Int DELTA  => SIZELIMIT <Int (#sizeWordStack(WS, 0) +Int N) +Int DELTA  requires N =/=Int 0
-      [simplification]
-    rule SIZELIMIT <Int #sizeWordStack(WS, N)             => SIZELIMIT <Int #sizeWordStack(WS, 0) +Int N               requires N =/=Int 0
-      [simplification]
+    rule #sizeWordStack(WS, N) <Int SIZE => #sizeWordStack(WS, 0) +Int N <Int SIZE  requires N =/=Int 0 [simplification]
+    
+    rule SIZELIMIT <Int #sizeWordStack(WS, N) +Int DELTA  => SIZELIMIT <Int (#sizeWordStack(WS, 0) +Int N) +Int DELTA  requires N =/=Int 0 [simplification]
+    rule SIZELIMIT <Int #sizeWordStack(WS, N)             => SIZELIMIT <Int #sizeWordStack(WS, 0) +Int N               requires N =/=Int 0 [simplification]
 
-    rule #sizeWordStack(WS, N) <=Int SIZE => #sizeWordStack(WS, 0) +Int N <=Int SIZE requires N =/=Int 0
-      [simplification]
+    rule #sizeWordStack(WS, N) <=Int SIZE => #sizeWordStack(WS, 0) +Int N <=Int SIZE  requires N =/=Int 0 [simplification]
 
   // ########################
   // Range
   // ########################
 
-    rule 0 <=Int (_X modInt _Y)         => true
-      [simplification]
-    rule         (_X modInt  Y) <Int Y  => true  requires Y >Int 0
-      [simplification]
+    rule 0 <=Int (_X modInt _Y)         => true                    [simplification]
+    rule         (_X modInt  Y) <Int Y  => true  requires Y >Int 0 [simplification]
 
-    rule 0 <=Int 2 ^Int _X             => true
-      [simplification]
-    rule         2 ^Int  X <Int pow256 => true  requires X <Int 256
-      [simplification]
+    rule 0 <=Int 2 ^Int _X             => true                      [simplification]
+    rule         2 ^Int  X <Int pow256 => true  requires X <Int 256 [simplification]
 
-    rule 0 <=Int X &Int Y             => true  requires #rangeUInt(256, X) andBool #rangeUInt(256, Y)
-      [simplification]
-    rule         X &Int Y <Int pow256 => true  requires #rangeUInt(256, X) andBool #rangeUInt(256, Y)
-      [simplification]
+    rule 0 <=Int X &Int Y             => true  requires #rangeUInt(256, X) andBool #rangeUInt(256, Y) [simplification]
+    rule         X &Int Y <Int pow256 => true  requires #rangeUInt(256, X) andBool #rangeUInt(256, Y) [simplification]
 
-    rule 0 <=Int X |Int Y             => true  requires #rangeUInt(256, X) andBool #rangeUInt(256, Y)
-      [simplification]
-    rule         X |Int Y <Int pow256 => true  requires #rangeUInt(256, X) andBool #rangeUInt(256, Y)
-      [simplification]
+    rule 0 <=Int X |Int Y             => true  requires #rangeUInt(256, X) andBool #rangeUInt(256, Y) [simplification]
+    rule         X |Int Y <Int pow256 => true  requires #rangeUInt(256, X) andBool #rangeUInt(256, Y) [simplification]
 
-    rule 0 <=Int #blockhash(_, _, _, _)             => true
-      [simplification]
-    rule         #blockhash(_, _, _, _) <Int pow256 => true
-      [simplification]
+    rule 0 <=Int #blockhash(_, _, _, _)             => true [simplification]
+    rule         #blockhash(_, _, _, _) <Int pow256 => true [simplification]
 
-    rule 0 <=Int X xorInt maxUInt256             => true  requires #rangeUInt(256, X)
-      [simplification]
-    rule         X xorInt maxUInt256 <Int pow256 => true  requires #rangeUInt(256, X)
-      [simplification]
+    rule 0 <=Int X xorInt maxUInt256             => true  requires #rangeUInt(256, X) [simplification]
+    rule         X xorInt maxUInt256 <Int pow256 => true  requires #rangeUInt(256, X) [simplification]
 
   // ########################
   // Simplification
   // ########################
 
-    rule #asWord(#buf(32, DATA)) => DATA  requires #rangeUInt(256, DATA)
-      [simplification]
+    rule #asWord(#buf(32, DATA)) => DATA  requires #rangeUInt(256, DATA) [simplification]
 
-    rule #range(_M [ N := #buf(WIDTH, DATA) ], N, WIDTH) => #buf(WIDTH, DATA)
-      [simplification]
+    rule #range(_M [ N := #buf(WIDTH, DATA) ], N, WIDTH) => #buf(WIDTH, DATA) [simplification]
 
-    rule #asWord(WS) &Int maxUInt256 => #asWord(WS)
-      [simplification]
+    rule #asWord(WS) &Int maxUInt256 => #asWord(WS) [simplification]
 
-    rule maxUInt256 &Int X => X requires #rangeUInt(256, X)
-      [simplification]
+    rule maxUInt256 &Int X => X requires #rangeUInt(256, X) [simplification]
 
     // 2^256 - 2^160 = 0xff..ff00..00 (96 1's followed by 160 0's)
     rule 115792089237316195423570985007226406215939081747436879206741300988257197096960 &Int ADDR => 0
@@ -176,81 +159,56 @@ module VERIFICATION
   // Arithmetic
   // ########################
 
-    rule (A +Int I2) +Int (I3 -Int A) => I2 +Int I3
-      [simplification]
-    rule (A +Int I2) -Int (A +Int I3) => I2 -Int I3
-      [simplification]
-    rule (A +Int I2) -Int (I3 +Int A) => I2 -Int I3
-      [simplification]
+    rule (A +Int I2) +Int (I3 -Int A) => I2 +Int I3 [simplification]
+    rule (A +Int I2) -Int (A +Int I3) => I2 -Int I3 [simplification]
+    rule (A +Int I2) -Int (I3 +Int A) => I2 -Int I3 [simplification]
 
-    rule (I1 +Int I2) -Int (I3 +Int I1) => I2 -Int I3
-      [simplification]
+    rule (I1 +Int I2) -Int (I3 +Int I1) => I2 -Int I3 [simplification]
 
-    rule A -Int (A -Int I1) => I1
-      [simplification]
+    rule A -Int (A -Int I1) => I1 [simplification]
 
-    rule (A +Int I1) -Int A => I1
-      [simplification]
+    rule (A +Int I1) -Int A => I1 [simplification]
 
-    rule (A +Int B) +Int (C -Int B) => A +Int C
-      [simplification]
+    rule (A +Int B) +Int (C -Int B) => A +Int C [simplification]
 
-    rule (A +Int B +Int C) -Int (A +Int D) => B +Int (C -Int D)
-      [simplification]
+    rule (A +Int B +Int C) -Int (A +Int D) => B +Int (C -Int D) [simplification]
 
-    rule (A +Int B +Int C +Int D +Int E) -Int (A +Int C +Int F) => B +Int D +Int E -Int F
-      [simplification]
+    rule (A +Int B +Int C +Int D +Int E) -Int (A +Int C +Int F) => B +Int D +Int E -Int F [simplification]
 
     // Simplify Cmem(_,_) - Cmem(_, _)
-    rule A +Int (I1 -Int A) => I1
-      [simplification]
-    rule (I1 +Int (A -Int I0)) +Int (I2 -Int A) => I1 +Int (I2 -Int I0)
-      [simplification]
+    rule A +Int (I1 -Int A) => I1 [simplification]
+    rule (I1 +Int (A -Int I0)) +Int (I2 -Int A) => I1 +Int (I2 -Int I0) [simplification]
 
     // safeMath mul check c / a == b where c == a * b
-    rule (X *Int Y) /Int X => Y  requires X =/=Int 0
-      [simplification]
-    rule chop(X *Int Y) /Int X ==K Y => false  requires X =/=Int 0 andBool pow256 <=Int X *Int Y
-      [simplification]
+    rule (X *Int Y) /Int X => Y  requires X =/=Int 0 [simplification]
+    rule chop(X *Int Y) /Int X ==K Y => false  requires X =/=Int 0 andBool pow256 <=Int X *Int Y [simplification]
 
-    rule I1 *Int A +Int I2 *Int A => (I1 +Int I2) *Int A
-      [simplification]
+    rule I1 *Int A +Int I2 *Int A => (I1 +Int I2) *Int A [simplification]
 
-    rule I1 *Int A +Int B +Int C +Int D +Int I2 *Int A => (I1 +Int I2) *Int A +Int B +Int C +Int D
-      [simplification]
+    rule I1 *Int A +Int B +Int C +Int D +Int I2 *Int A => (I1 +Int I2) *Int A +Int B +Int C +Int D [simplification]
 
-    rule N -Int N => 0
-      [simplification]
+    rule N -Int N => 0 [simplification]
 
-    rule 2 ^%Int X pow256 => 2 ^Int X
-      requires 0 <=Int X andBool X <Int 256
-      [simplification]
+    rule 2 ^%Int X pow256 => 2 ^Int X  requires 0 <=Int X andBool X <Int 256 [simplification]
 
-    rule X modInt Y => X
-      requires 0 <=Int X andBool X <Int Y
-      [simplification]
+    rule X modInt Y => X  requires 0 <=Int X andBool X <Int Y [simplification]
 
-    rule ((X *Int Y) /Int Z) /Int Y => X /Int Z
-      requires Y =/=Int 0
-      [simplification]
+    rule ((X *Int Y) /Int Z) /Int Y => X /Int Z  requires Y =/=Int 0 [simplification]
 
     // x &Int (NOT 31)
-    rule X &Int 115792089237316195423570985008687907853269984665640564039457584007913129639904 => (X /Int 32) *Int 32  requires 0 <=Int X
-      [simplification]
+    rule X &Int 115792089237316195423570985008687907853269984665640564039457584007913129639904 => (X /Int 32) *Int 32  requires 0 <=Int X [simplification]
 
-    rule (X /Int 32) *Int 32 => X  requires X modInt 32 ==Int 0
-      [simplification]
+    rule (X /Int 32) *Int 32 => X  requires X modInt 32 ==Int 0 [simplification]
 
-    rule #ceil32(X) => X requires X modInt 32 ==Int 0
-      [simplification]
+    rule #ceil32(X) => X  requires X modInt 32 ==Int 0 [simplification]
 
-    rule 0 <Int 1 <<Int N => true requires 0 <=Int N [simplification]
+    rule 0 <Int 1 <<Int N => true  requires 0 <=Int N [simplification]
 
-    rule X +Int Y <Int pow256 => true requires X <=Int pow16 andBool Y <Int pow16 [simplification]
+    rule X +Int Y <Int pow256 => true  requires X <=Int pow16 andBool Y <Int pow16 [simplification]
 
-    rule X <=Int #ceil32(X)     => true  requires 0 <=Int X                       [simplification]
-    rule #ceil32(X) <Int X      => false requires 0 <=Int X                       [simplification]
-    rule #ceil32(X) <=Int pow16 => true  requires 0 <=Int X andBool X <=Int pow16 [simplification]
+    rule X <=Int #ceil32(X)     => true   requires 0 <=Int X                       [simplification]
+    rule #ceil32(X) <Int X      => false  requires 0 <=Int X                       [simplification]
+    rule #ceil32(X) <=Int pow16 => true   requires 0 <=Int X andBool X <=Int pow16 [simplification]
 
   // ########################
   // Gnosis
@@ -259,7 +217,7 @@ module VERIFICATION
    // checkSignatures is only called once in the executeTransaction, we implicitly assumed the arguments of the following functions
    // have additional arguments of checkSignatures.
     syntax Bool ::= "#enoughValidSigs"  [function]
- // ---------------------------------------------
+ // ----------------------------------------------
 
     syntax Bool ::= "#checkSignaturesException" [function]
  // ------------------------------------------------------
@@ -281,66 +239,58 @@ module VERIFICATION
     syntax KItem ::= "#handlePaymentSpecApplied"
  // --------------------------------------------
 
-syntax Int  ::= #fii        ( ByteArray ,       Int , ByteArray , Map , Int ) [function, smtlib(fii)] // first-invalid-signature-index
-syntax Bool ::= #isValid    ( ByteArray , Int , Int , ByteArray , Map , Int , Bool ) [function, smtlib(isValid)]
-syntax Bool ::= #isValidSig ( ByteArray , Int , Int , ByteArray , Map , Int ) [function, smtlib(isValidSig)]
-syntax Bool ::= #isValidSignature ( Int , ByteArray , ByteArray ) [function, smtlib(isValidSignature)] // ISignatureValidator(currentOwner).isValidSignature(data, contractSignature)
-syntax Int  ::= #signer ( ByteArray , Int , Int ) [function]
-syntax Int  ::= #sigR   ( ByteArray , Int ) [function]
-syntax Int  ::= #sigS   ( ByteArray , Int ) [function]
-syntax Int  ::= #sigV   ( ByteArray , Int ) [function]
+    syntax ByteArray ::= #ecrecData ( ByteArray , Int , Int ) [function]
+ // --------------------------------------------------------------------
+    rule #ecrecData(SIGS, I, DATA_HASH) => #encodeArgs(#bytes32(DATA_HASH), #uint8(#sigV(SIGS,I)), #bytes32(#sigR(SIGS,I)), #bytes32(#sigS(SIGS,I)))
 
-rule 0 <=Int #fii(_,_,_,_,_)             => true
-      [simplification]
-rule         #fii(_,_,_,_,_) <Int pow256 => true
-      [simplification]
+    syntax Int  ::= #fii        ( ByteArray ,       Int , ByteArray , Map , Int )        [function, smtlib(fii)             ] // first-invalid-signature-index
+    syntax Bool ::= #isValid    ( ByteArray , Int , Int , ByteArray , Map , Int , Bool ) [function, smtlib(isValid)         ]
+    syntax Bool ::= #isValidSig ( ByteArray , Int , Int , ByteArray , Map , Int )        [function, smtlib(isValidSig)      ]
+    syntax Bool ::= #isValidSignature ( Int , ByteArray , ByteArray )                    [function, smtlib(isValidSignature)] // ISignatureValidator(currentOwner).isValidSignature(data, contractSignature)
+    
+    syntax Int  ::= #signer ( ByteArray , Int , Int ) [function]
+    syntax Int  ::= #sigR   ( ByteArray , Int )       [function]
+    syntax Int  ::= #sigS   ( ByteArray , Int )       [function]
+    syntax Int  ::= #sigV   ( ByteArray , Int )       [function]
 
-// axiomatization of #fii
+    // axiomatization of #fii
 
-rule #isValid(SIGS, I, DATA_HASH, DATA_BUF, STORAGE, MSG_SENDER, _) => true  requires I  <Int #fii(SIGS, DATA_HASH, DATA_BUF, STORAGE, MSG_SENDER)
-rule #isValid(SIGS, I, DATA_HASH, DATA_BUF, STORAGE, MSG_SENDER, _) => false requires I ==Int #fii(SIGS, DATA_HASH, DATA_BUF, STORAGE, MSG_SENDER)
+    rule 0 <=Int #fii(_,_,_,_,_)             => true [simplification]
+    rule         #fii(_,_,_,_,_) <Int pow256 => true [simplification]
 
-// axiomatization of #isValid
+    // axiomatization of #isValid
 
-rule #signer(_, I, _) => 0 requires I <Int 0  // address lastOwner = address(0);
+    rule #isValid(SIGS, I, DATA_HASH, DATA_BUF, STORAGE, MSG_SENDER, _) => true   requires I  <Int #fii(SIGS, DATA_HASH, DATA_BUF, STORAGE, MSG_SENDER)
+    rule #isValid(SIGS, I, DATA_HASH, DATA_BUF, STORAGE, MSG_SENDER, _) => false  requires I ==Int #fii(SIGS, DATA_HASH, DATA_BUF, STORAGE, MSG_SENDER)
 
-// axiomatization of #isValidSig for each signature type
+    // axiomatization of #isValidSig for each signature type
 
-rule #isValidSig(SIGS, I, DATA_HASH, _DATA_BUF, _STORAGE, _MSG_SENDER)
-  => notBool #ecrecEmpty(#ecrecData(SIGS, I, DATA_HASH))
-  requires #sigV(SIGS, I) =/=Int 0
-   andBool #sigV(SIGS, I) =/=Int 1
+    rule #isValidSig(SIGS, I, DATA_HASH, _DATA_BUF, _STORAGE, _MSG_SENDER) => notBool #ecrecEmpty(#ecrecData(SIGS, I, DATA_HASH))
+      requires #sigV(SIGS, I) =/=Int 0
+       andBool #sigV(SIGS, I) =/=Int 1
 
-// definition of #signer
+    // definition of #signer
 
-rule #signer(SIGS, I,  DATA_HASH) => #symEcrec(#ecrecData(SIGS, I, DATA_HASH)) requires I >=Int 0 andBool   #sigV(SIGS, I) =/=Int 0 andBool #sigV(SIGS, I) =/=Int 1   andBool notBool #ecrecEmpty(#ecrecData(SIGS, I, DATA_HASH))
-rule #signer(SIGS, I,  DATA_HASH) => 0                                         requires I >=Int 0 andBool   #sigV(SIGS, I) =/=Int 0 andBool #sigV(SIGS, I) =/=Int 1   andBool         #ecrecEmpty(#ecrecData(SIGS, I, DATA_HASH))
-rule #signer(SIGS, I, _DATA_HASH) => #sigR(SIGS, I)                            requires I >=Int 0 andBool ( #sigV(SIGS, I)  ==Int 0  orBool #sigV(SIGS, I)  ==Int 1 )
-
-syntax ByteArray ::= #ecrecData ( ByteArray , Int , Int ) [function]
-rule #ecrecData(SIGS, I, DATA_HASH) => #encodeArgs(#bytes32(DATA_HASH), #uint8(#sigV(SIGS,I)), #bytes32(#sigR(SIGS,I)), #bytes32(#sigS(SIGS,I)))
+    rule #signer(_   , I, _         ) => 0                                          requires I  <Int 0 // address lastOwner = address(0);
+    rule #signer(SIGS, I,  DATA_HASH) => #symEcrec(#ecrecData(SIGS, I, DATA_HASH))  requires I >=Int 0 andBool   #sigV(SIGS, I) =/=Int 0 andBool #sigV(SIGS, I) =/=Int 1   andBool notBool #ecrecEmpty(#ecrecData(SIGS, I, DATA_HASH))
+    rule #signer(SIGS, I,  DATA_HASH) => 0                                          requires I >=Int 0 andBool   #sigV(SIGS, I) =/=Int 0 andBool #sigV(SIGS, I) =/=Int 1   andBool         #ecrecEmpty(#ecrecData(SIGS, I, DATA_HASH))
+    rule #signer(SIGS, I, _DATA_HASH) => #sigR(SIGS, I)                             requires I >=Int 0 andBool ( #sigV(SIGS, I)  ==Int 0  orBool #sigV(SIGS, I)  ==Int 1 )
 
   // ########################
   // Account Map
   // ########################
 
     syntax Int ::= "#CONTRACT_ID"   [function]
+ // ------------------------------------------
+    rule 0 <=Int #CONTRACT_ID               => true [simplification]
+    rule         #CONTRACT_ID   <Int pow160 => true [simplification]
+    rule         #CONTRACT_ID   <Int pow256 => true [simplification]
 
-    rule 0 <=Int #CONTRACT_ID               => true
-      [simplification]
-    rule         #CONTRACT_ID   <Int pow160 => true
-      [simplification]
-    rule         #CONTRACT_ID   <Int pow256 => true
-      [simplification]
-
-    syntax Int ::= "#CALLEE_ID"   [function]
-
-    rule 0 <=Int #CALLEE_ID               => true
-      [simplification]
-    rule         #CALLEE_ID   <Int pow160 => true
-      [simplification]
-    rule         #CALLEE_ID   <Int pow256 => true
-      [simplification]
+    syntax Int ::= "#CALLEE_ID"    [function]
+ // ------------------------------------------
+    rule 0 <=Int #CALLEE_ID                 => true [simplification]
+    rule         #CALLEE_ID     <Int pow160 => true [simplification]
+    rule         #CALLEE_ID     <Int pow256 => true [simplification]
 
 endmodule
 
@@ -348,7 +298,15 @@ module VERIFICATION-HASKELL [symbolic, kore]
     imports VERIFICATION-COMMON
     imports INFINITE-GAS
 
+  // ########################
+  // Arithmetic
+  // ########################
+
     rule X +Int Y <Int Z => X <Int Z -Int Y [concrete(Y), simplification]
+
+  // ########################
+  // Buffer Reasoning
+  // ########################
 
     rule BA1 ++ (BA2 ++ BA3) => (BA1 ++ BA2) ++ BA3 [concrete(BA1, BA2), simplification]
 
@@ -364,7 +322,7 @@ module VERIFICATION-JAVA [symbolic, kast]
 
     syntax Int ::= #gas ( Int , Int , Int )  [function]  // startGas, nonMemory, memory
  // -----------------------------------------------------------------------------------
-    rule #gas(_, _, _) <=Int I => false requires #isConcrete(I) [simplification]
+    rule #gas(_, _, _) <=Int I => false  requires #isConcrete(I) [simplification]
 
   // ########################
   // Rule Replacement
@@ -385,13 +343,17 @@ module VERIFICATION-JAVA [symbolic, kast]
     claim <k> ECREC => #end EVMC_SUCCESS ... </k>
          <callData> DATA </callData>
          <output> _ => #ecrec(#symEcrec(DATA)) </output>
-      requires notBool #isConcrete(DATA) andBool #sizeByteArray(DATA) ==Int 128 andBool notBool #ecrecEmpty(DATA)
+      requires notBool #isConcrete(DATA)
+       andBool #sizeByteArray(DATA) ==Int 128
+       andBool notBool #ecrecEmpty(DATA)
       [trusted]
 
     claim <k> ECREC => #end EVMC_SUCCESS ... </k>
          <callData> DATA </callData>
          <output> _ => #ecrec(.Account) </output>
-      requires notBool #isConcrete(DATA) andBool #sizeByteArray(DATA) ==Int 128 andBool #ecrecEmpty(DATA)
+      requires notBool #isConcrete(DATA)
+       andBool #sizeByteArray(DATA) ==Int 128
+       andBool #ecrecEmpty(DATA)
       [trusted]
 
   // ########################
@@ -399,12 +361,25 @@ module VERIFICATION-JAVA [symbolic, kast]
   // ########################
 
     rule ((A +Int I1) +Int B) +Int I2 => (A +Int B) +Int (I1 +Int I2)
-      requires notBool #isConcrete(A) andBool notBool #isConcrete(B) andBool #isConcrete(I1) andBool #isConcrete(I2) [simplification]
+      requires notBool #isConcrete(A)
+       andBool notBool #isConcrete(B)
+       andBool #isConcrete(I1)
+       andBool #isConcrete(I2)
+      [simplification]
 
     rule (A +Int I1) +Int (B +Int I2) => (A +Int B) +Int (I1 +Int I2)
-      requires notBool #isConcrete(A) andBool notBool #isConcrete(B) andBool #isConcrete(I1) andBool #isConcrete(I2) [simplification]
+      requires notBool #isConcrete(A)
+       andBool notBool #isConcrete(B)
+       andBool #isConcrete(I1)
+       andBool #isConcrete(I2)
+      [simplification]
 
-    rule chop(X +Int Y) => X +Int Y requires 0 <=Int X andBool X <=Int pow16 andBool 0 <=Int Y andBool Y <Int pow16 [simplification]
+    rule chop(X +Int Y) => X +Int Y
+      requires 0 <=Int X
+       andBool X <=Int pow16
+       andBool 0 <=Int Y
+       andBool Y <Int pow16
+      [simplification]
 
     rule X +Int Y <Int Z => X <Int Z -Int Y requires #isConcrete(Y) [simplification]
 

--- a/tests/specs/benchmarks/verification.k
+++ b/tests/specs/benchmarks/verification.k
@@ -13,6 +13,7 @@ module VERIFICATION-COMMON
 
     //Symbolic predicate representing whether output of #ecrec is empty. No implementation.
     syntax Bool ::= #ecrecEmpty( ByteArray ) [function]
+
 endmodule
 
 module VERIFICATION
@@ -24,17 +25,14 @@ module VERIFICATION
   // Map
   // ########################
 
-    rule M:Map [ K1 <- _  ] [ K2 <- V2 ] => M [ K1 <- V2 ]              requires K1 ==Int K2
-      [simplification]
-    rule M:Map [ K1 <- V1 ] [ K2 <- V2 ] => M [ K2 <- V2 ] [ K1 <- V1 ] requires K2  <Int K1
-      [simplification]
+    rule M:Map [ K1 <- _  ] [ K2 <- V2 ] => M [ K1 <- V2 ]               requires K1 ==Int K2 [simplification]
+    rule M:Map [ K1 <- V1 ] [ K2 <- V2 ] => M [ K2 <- V2 ] [ K1 <- V1 ]  requires K2  <Int K1 [simplification]
 
   // ########################
   // Gas Calculation
   // ########################
 
-    rule Rsstore(BYZANTIUM, NEW, _CURR, _ORIG) => 0 requires NEW =/=Int 0
-      [simplification]
+    rule Rsstore(BYZANTIUM, NEW, _CURR, _ORIG) => 0  requires NEW =/=Int 0 [simplification]
 
   // ########################
   // Ecrecover

--- a/tests/specs/benchmarks/verification.k
+++ b/tests/specs/benchmarks/verification.k
@@ -178,7 +178,6 @@ module VERIFICATION
 
     // safeMath mul check c / a == b where c == a * b
     rule (X *Int Y) /Int X => Y  requires X =/=Int 0 [simplification]
-    rule chop(X *Int Y) /Int X ==K Y => false  requires X =/=Int 0 andBool pow256 <=Int X *Int Y [simplification]
 
     rule I1 *Int A +Int I2 *Int A => (I1 +Int I2) *Int A [simplification]
 

--- a/tests/specs/benchmarks/verification.k
+++ b/tests/specs/benchmarks/verification.k
@@ -207,47 +207,6 @@ module VERIFICATION
     rule #ceil32(X) <Int X      => false  requires 0 <=Int X                       [simplification]
     rule #ceil32(X) <=Int pow16 => true   requires 0 <=Int X andBool X <=Int pow16 [simplification]
 
-  // ########################
-  // Gnosis
-  // ########################
-
-    syntax ByteArray ::= #ecrecData ( ByteArray , Int , Int ) [function]
- // --------------------------------------------------------------------
-    rule #ecrecData(SIGS, I, DATA_HASH) => #encodeArgs(#bytes32(DATA_HASH), #uint8(#sigV(SIGS,I)), #bytes32(#sigR(SIGS,I)), #bytes32(#sigS(SIGS,I)))
-
-    syntax Int  ::= #fii        ( ByteArray ,       Int , ByteArray , Map , Int )        [function, smtlib(fii)             ] // first-invalid-signature-index
-    syntax Bool ::= #isValid    ( ByteArray , Int , Int , ByteArray , Map , Int , Bool ) [function, smtlib(isValid)         ]
-    syntax Bool ::= #isValidSig ( ByteArray , Int , Int , ByteArray , Map , Int )        [function, smtlib(isValidSig)      ]
-    syntax Bool ::= #isValidSignature ( Int , ByteArray , ByteArray )                    [function, smtlib(isValidSignature)] // ISignatureValidator(currentOwner).isValidSignature(data, contractSignature)
-
-    syntax Int  ::= #signer ( ByteArray , Int , Int ) [function]
-    syntax Int  ::= #sigR   ( ByteArray , Int )       [function]
-    syntax Int  ::= #sigS   ( ByteArray , Int )       [function]
-    syntax Int  ::= #sigV   ( ByteArray , Int )       [function]
-
-    // axiomatization of #fii
-
-    rule 0 <=Int #fii(_,_,_,_,_)             => true [simplification]
-    rule         #fii(_,_,_,_,_) <Int pow256 => true [simplification]
-
-    // axiomatization of #isValid
-
-    rule #isValid(SIGS, I, DATA_HASH, DATA_BUF, STORAGE, MSG_SENDER, _) => true   requires I  <Int #fii(SIGS, DATA_HASH, DATA_BUF, STORAGE, MSG_SENDER)
-    rule #isValid(SIGS, I, DATA_HASH, DATA_BUF, STORAGE, MSG_SENDER, _) => false  requires I ==Int #fii(SIGS, DATA_HASH, DATA_BUF, STORAGE, MSG_SENDER)
-
-    // axiomatization of #isValidSig for each signature type
-
-    rule #isValidSig(SIGS, I, DATA_HASH, _DATA_BUF, _STORAGE, _MSG_SENDER) => notBool #ecrecEmpty(#ecrecData(SIGS, I, DATA_HASH))
-      requires #sigV(SIGS, I) =/=Int 0
-       andBool #sigV(SIGS, I) =/=Int 1
-
-    // definition of #signer
-
-    rule #signer(_   , I, _         ) => 0                                          requires I  <Int 0 // address lastOwner = address(0);
-    rule #signer(SIGS, I,  DATA_HASH) => 0                                          requires I >=Int 0 andBool   #sigV(SIGS, I) =/=Int 0 andBool #sigV(SIGS, I) =/=Int 1   andBool         #ecrecEmpty(#ecrecData(SIGS, I, DATA_HASH))
-    rule #signer(SIGS, I,  DATA_HASH) => #symEcrec(#ecrecData(SIGS, I, DATA_HASH))  requires I >=Int 0 andBool   #sigV(SIGS, I) =/=Int 0 andBool #sigV(SIGS, I) =/=Int 1   andBool notBool #ecrecEmpty(#ecrecData(SIGS, I, DATA_HASH))
-    rule #signer(SIGS, I, _DATA_HASH) => #sigR(SIGS, I)                             requires I >=Int 0 andBool ( #sigV(SIGS, I)  ==Int 0  orBool #sigV(SIGS, I)  ==Int 1 )
-
 endmodule
 
 module VERIFICATION-HASKELL [symbolic, kore]

--- a/tests/specs/benchmarks/verification.k
+++ b/tests/specs/benchmarks/verification.k
@@ -273,22 +273,6 @@ module VERIFICATION
     rule #signer(SIGS, I,  DATA_HASH) => #symEcrec(#ecrecData(SIGS, I, DATA_HASH))  requires I >=Int 0 andBool   #sigV(SIGS, I) =/=Int 0 andBool #sigV(SIGS, I) =/=Int 1   andBool notBool #ecrecEmpty(#ecrecData(SIGS, I, DATA_HASH))
     rule #signer(SIGS, I, _DATA_HASH) => #sigR(SIGS, I)                             requires I >=Int 0 andBool ( #sigV(SIGS, I)  ==Int 0  orBool #sigV(SIGS, I)  ==Int 1 )
 
-  // ########################
-  // Account Map
-  // ########################
-
-    syntax Int ::= "#CONTRACT_ID"   [function]
- // ------------------------------------------
-    rule 0 <=Int #CONTRACT_ID               => true [simplification]
-    rule         #CONTRACT_ID   <Int pow160 => true [simplification]
-    rule         #CONTRACT_ID   <Int pow256 => true [simplification]
-
-    syntax Int ::= "#CALLEE_ID"    [function]
- // ------------------------------------------
-    rule 0 <=Int #CALLEE_ID                 => true [simplification]
-    rule         #CALLEE_ID     <Int pow160 => true [simplification]
-    rule         #CALLEE_ID     <Int pow256 => true [simplification]
-
 endmodule
 
 module VERIFICATION-HASKELL [symbolic, kore]

--- a/tests/specs/benchmarks/verification.k
+++ b/tests/specs/benchmarks/verification.k
@@ -70,7 +70,7 @@ module VERIFICATION
 
     syntax ByteArray ::= #abiCallData2 ( String , TypedArgs ) [function]
 
-    rule #abiCallData2( FSIG , ARGS )
+    rule #abiCallData2(FSIG, ARGS)
       => #parseByteStack(substrString(Keccak256(FSIG), 0, 8))
       ++ #encodeArgs(ARGS)
 
@@ -82,18 +82,17 @@ module VERIFICATION
 
     rule #memoryUsageUpdate(#memoryUsageUpdate(MU, START0, WIDTH0), START1, WIDTH1) => #memoryUsageUpdate(MU, START0, WIDTH0)
       requires START1 +Int WIDTH1 <=Int START0 +Int WIDTH0
-       andBool 0 <Int WIDTH0
+       andBool 0  <Int WIDTH0
        andBool 0 <=Int WIDTH1
       [simplification]
 
     rule #memoryUsageUpdate(#memoryUsageUpdate(MU, START0, WIDTH0), START1, WIDTH1) => #memoryUsageUpdate(MU, START1, WIDTH1)
       requires START0 +Int WIDTH0 <Int START1 +Int WIDTH1
        andBool 0 <=Int WIDTH0
-       andBool 0 <Int WIDTH1
+       andBool 0  <Int WIDTH1
       [simplification]
 
-    rule 0 <=Int #memoryUsageUpdate(_MU, _START, _WIDTH) => true
-      [simplification]
+    rule 0 <=Int #memoryUsageUpdate(_MU, _START, _WIDTH) => true [simplification]
 
   // ########################
   // Buffer Reasoning
@@ -270,8 +269,8 @@ module VERIFICATION
     // definition of #signer
 
     rule #signer(_   , I, _         ) => 0                                          requires I  <Int 0 // address lastOwner = address(0);
-    rule #signer(SIGS, I,  DATA_HASH) => #symEcrec(#ecrecData(SIGS, I, DATA_HASH))  requires I >=Int 0 andBool   #sigV(SIGS, I) =/=Int 0 andBool #sigV(SIGS, I) =/=Int 1   andBool notBool #ecrecEmpty(#ecrecData(SIGS, I, DATA_HASH))
     rule #signer(SIGS, I,  DATA_HASH) => 0                                          requires I >=Int 0 andBool   #sigV(SIGS, I) =/=Int 0 andBool #sigV(SIGS, I) =/=Int 1   andBool         #ecrecEmpty(#ecrecData(SIGS, I, DATA_HASH))
+    rule #signer(SIGS, I,  DATA_HASH) => #symEcrec(#ecrecData(SIGS, I, DATA_HASH))  requires I >=Int 0 andBool   #sigV(SIGS, I) =/=Int 0 andBool #sigV(SIGS, I) =/=Int 1   andBool notBool #ecrecEmpty(#ecrecData(SIGS, I, DATA_HASH))
     rule #signer(SIGS, I, _DATA_HASH) => #sigR(SIGS, I)                             requires I >=Int 0 andBool ( #sigV(SIGS, I)  ==Int 0  orBool #sigV(SIGS, I)  ==Int 1 )
 
   // ########################
@@ -373,10 +372,8 @@ module VERIFICATION-JAVA [symbolic, kast]
       [simplification]
 
     rule chop(X +Int Y) => X +Int Y
-      requires 0 <=Int X
-       andBool X <=Int pow16
-       andBool 0 <=Int Y
-       andBool Y <Int pow16
+      requires #range(0 <= X <= pow16)
+       andBool #range(0 <= Y <  pow16)
       [simplification]
 
     rule X +Int Y <Int Z => X <Int Z -Int Y requires #isConcrete(Y) [simplification]

--- a/tests/specs/benchmarks/verification.k
+++ b/tests/specs/benchmarks/verification.k
@@ -99,11 +99,11 @@ module VERIFICATION
   // ########################
 
     rule WS ++ .ByteArray => WS [simplification]
-    
+
     rule ( WS1 ++ WS2 ) ++ WS3 => WS1 ++ ( WS2 ++ WS3 ) [simplification]
 
     rule #sizeWordStack(WS, N) <Int SIZE => #sizeWordStack(WS, 0) +Int N <Int SIZE  requires N =/=Int 0 [simplification]
-    
+
     rule SIZELIMIT <Int #sizeWordStack(WS, N) +Int DELTA  => SIZELIMIT <Int (#sizeWordStack(WS, 0) +Int N) +Int DELTA  requires N =/=Int 0 [simplification]
     rule SIZELIMIT <Int #sizeWordStack(WS, N)             => SIZELIMIT <Int #sizeWordStack(WS, 0) +Int N               requires N =/=Int 0 [simplification]
 
@@ -211,31 +211,6 @@ module VERIFICATION
   // Gnosis
   // ########################
 
-   // checkSignatures is only called once in the executeTransaction, we implicitly assumed the arguments of the following functions
-   // have additional arguments of checkSignatures.
-    syntax Bool ::= "#enoughValidSigs"  [function]
- // ----------------------------------------------
-
-    syntax Bool ::= "#checkSignaturesException" [function]
- // ------------------------------------------------------
-
-    syntax Int ::= "#checkSigsGasNonMem"  [function]
- // ------------------------------------------------
-
-    syntax Int ::= #checkSigsFinalMemUsed ( Int )  [function]  // previous memory used
- // ----------------------------------------------------------------------------------
-
-   // Constant functions are ground terms in kprover. Constraints on the ground terms will not be considered when evaluating conditions only consisting of ground terms.
-   // Thus, #checkSigsNextLoc has to take an argument and this argument should not be a constant.
-    syntax Int ::= #checkSigsNextLoc ( Int )  [function]  // previous memory used
- // -----------------------------------------------------------------------------
-
-    syntax Int ::= #loopGas ( Int , Int )  [function]  // startPC, endPC
- // --------------------------------------------------------------------
-
-    syntax KItem ::= "#handlePaymentSpecApplied"
- // --------------------------------------------
-
     syntax ByteArray ::= #ecrecData ( ByteArray , Int , Int ) [function]
  // --------------------------------------------------------------------
     rule #ecrecData(SIGS, I, DATA_HASH) => #encodeArgs(#bytes32(DATA_HASH), #uint8(#sigV(SIGS,I)), #bytes32(#sigR(SIGS,I)), #bytes32(#sigS(SIGS,I)))
@@ -244,7 +219,7 @@ module VERIFICATION
     syntax Bool ::= #isValid    ( ByteArray , Int , Int , ByteArray , Map , Int , Bool ) [function, smtlib(isValid)         ]
     syntax Bool ::= #isValidSig ( ByteArray , Int , Int , ByteArray , Map , Int )        [function, smtlib(isValidSig)      ]
     syntax Bool ::= #isValidSignature ( Int , ByteArray , ByteArray )                    [function, smtlib(isValidSignature)] // ISignatureValidator(currentOwner).isValidSignature(data, contractSignature)
-    
+
     syntax Int  ::= #signer ( ByteArray , Int , Int ) [function]
     syntax Int  ::= #sigR   ( ByteArray , Int )       [function]
     syntax Int  ::= #sigS   ( ByteArray , Int )       [function]

--- a/tests/specs/bihu/verification.k
+++ b/tests/specs/bihu/verification.k
@@ -15,6 +15,10 @@ module VERIFICATION
       requires 0 <=Int V andBool V <Int pow256
       [simplification]
 
+  // ########################
+  // Arithmetic
+  // ########################
+
     rule N -Int N => 0 [simplification]
 
     rule (I1 *Int I2) /Int I3 <=Int I4 => true
@@ -25,17 +29,14 @@ module VERIFICATION
        andBool  I2 <=Int I3
       [simplification]
 
-    rule 0 <=Int X /Int Y             => true requires 0 <=Int X andBool X <Int pow256 andBool 0 <Int  Y andBool Y <Int pow256
-      [simplification]
-    rule         X /Int Y <Int pow256 => true requires 0 <=Int X andBool X <Int pow256 andBool 0 <Int  Y andBool Y <Int pow256
-      [simplification]
+    rule 0 <=Int X /Int Y             => true requires 0 <=Int X andBool X <Int pow256 andBool 0 <Int  Y andBool Y <Int pow256 [simplification]
+    rule         X /Int Y <Int pow256 => true requires 0 <=Int X andBool X <Int pow256 andBool 0 <Int  Y andBool Y <Int pow256 [simplification]
 
     rule I1 +Int I2 <Int I1 => false requires 0 <=Int I2 [simplification]
 
     rule I1 <Int I1 -Int I2 => false requires 0 <=Int I2 [simplification]
 
-    rule chop(I1 -Int I2) => I1 -Int I2 requires 0 <=Int I1 andBool I2 <Int pow256 andBool I1 >=Int I2
-      [simplification]
+    rule chop(I1 -Int I2) => I1 -Int I2 requires 0 <=Int I1 andBool I2 <Int pow256 andBool I1 >=Int I2 [simplification]
 
     rule chop(I1 +Int (I2 -Int I3)) => I1 +Int (I2 -Int I3)
       requires  0 <=Int I2
@@ -47,58 +48,24 @@ module VERIFICATION
 
     syntax Int ::= "#roundpower" "(" Int "," Int "," Int "," Int ")"  [function, smtlib(smt_roundpower)]
  // ----------------------------------------------------------------------------------------------------
-    rule #roundpower(0, BASEN, BASED, EXPONENT) => 0
-      requires BASEN >Int 0 andBool BASED >=Int BASEN andBool EXPONENT >=Int 0
+    rule #roundpower(0,                           BASEN, BASED, EXPONENT) => 0                                                requires BASEN >Int 0 andBool BASED >=Int BASEN andBool EXPONENT >=Int 0
+    rule #roundpower(ACC,                         BASEN, BASED, 0       ) => ACC                                              requires BASEN >Int 0 andBool BASED >=Int BASEN
+    rule #roundpower((ACC *Int BASEN) /Int BASED, BASEN, BASED, EXPONENT) => #roundpower(ACC, BASEN, BASED, EXPONENT +Int 1)  requires BASEN >Int 0 andBool BASED >=Int BASEN andBool EXPONENT >=Int 0 [simplification]
 
-    rule #roundpower(ACC, BASEN, BASED, 0) => ACC
-      requires BASEN >Int 0 andBool BASED >=Int BASEN
+    rule 0 <=Int #roundpower(ACC, BASEN, BASED, EXPONENT)              => true  requires ACC >=Int 0 andBool BASEN >Int 0 andBool BASED >=Int BASEN andBool EXPONENT >=Int 0                             [simplification]
+    rule         #roundpower(ACC, BASEN, BASED, EXPONENT) <=Int ACC    => true  requires ACC >=Int 0 andBool BASEN >Int 0 andBool BASED >=Int BASEN andBool EXPONENT >=Int 0                             [simplification]
+    rule         #roundpower(ACC, BASEN, BASED, EXPONENT)  <Int pow256 => true  requires ACC >=Int 0 andBool BASEN >Int 0 andBool BASED >=Int BASEN andBool EXPONENT >=Int 0 andBool ACC <Int 2 ^Int 256 [simplification]
 
-    rule #roundpower((ACC *Int BASEN) /Int BASED, BASEN, BASED, EXPONENT) => #roundpower(ACC, BASEN, BASED, EXPONENT +Int 1)
-      requires BASEN >Int 0 andBool BASED >=Int BASEN andBool EXPONENT >=Int 0
-      [simplification]
+    rule 0 <=Int (#roundpower(ACC, BASEN, BASED, EXPONENT) *Int 10)             => true  requires  ACC >=Int 0 andBool BASEN >Int 0 andBool BASED >=Int BASEN andBool EXPONENT >=Int 0                                     [simplification]
+    rule         (#roundpower(ACC, BASEN, BASED, EXPONENT) *Int 10) <Int pow256 => true  requires  ACC >=Int 0 andBool BASEN >Int 0 andBool BASED >=Int BASEN andBool EXPONENT >=Int 0 andBool ACC *Int 10 <Int 2 ^Int 256 [simplification]
 
-    rule 0 <=Int #roundpower(ACC, BASEN, BASED, EXPONENT) => true
-      requires  ACC >=Int 0
-        andBool BASEN >Int 0 andBool BASED >=Int BASEN andBool EXPONENT >=Int 0
-      [simplification]
-
-    rule #roundpower(ACC, BASEN, BASED, EXPONENT) <Int pow256 => true
-      requires  ACC >=Int 0 andBool ACC <Int 2 ^Int 256
-        andBool BASEN >Int 0 andBool BASED >=Int BASEN andBool EXPONENT >=Int 0
-      [simplification]
-
-    rule #roundpower(ACC, BASEN, BASED, EXPONENT) <=Int ACC => true
-      requires  ACC >=Int 0
-        andBool BASEN >Int 0 andBool BASED >=Int BASEN andBool EXPONENT >=Int 0
-      [simplification]
-
-    rule 0 <=Int (#roundpower(ACC, BASEN, BASED, EXPONENT) *Int 10) => true
-      requires  ACC >=Int 0
-        andBool BASEN >Int 0 andBool BASED >=Int BASEN andBool EXPONENT >=Int 0
-      [simplification]
-
-    rule (#roundpower(ACC, BASEN, BASED, EXPONENT) *Int 10) <Int pow256 => true
-      requires  ACC >=Int 0 andBool ACC *Int 10 <Int 2 ^Int 256
-        andBool BASEN >Int 0 andBool BASED >=Int BASEN andBool EXPONENT >=Int 0
-      [simplification]
-
-    rule 0 <=Int (#roundpower(ACC, BASEN, BASED, EXPONENT) *Int A /Int B *Int C) => true
-      requires  ACC >=Int 0
-        andBool BASEN >Int 0 andBool BASED >=Int BASEN andBool EXPONENT >=Int 0
-        andBool A >=Int 0 andBool B >Int 0 andBool C >=Int 0
-      [simplification]
-
-    rule #roundpower(ACC, BASEN, BASED, EXPONENT) *Int A /Int B *Int C <Int pow256 => true
-      requires  ACC >=Int 0 andBool ACC *Int A /Int B *Int C <Int 2 ^Int 256
-        andBool BASEN >Int 0 andBool BASED >=Int BASEN andBool EXPONENT >=Int 0
-        andBool A >=Int 0 andBool B >Int 0 andBool C >=Int 0
-      [simplification]
+    rule 0 <=Int (#roundpower(ACC, BASEN, BASED, EXPONENT) *Int A /Int B *Int C)            => true  requires  ACC >=Int 0 andBool BASEN >Int 0 andBool BASED >=Int BASEN andBool EXPONENT >=Int 0 andBool A >=Int 0 andBool B >Int 0 andBool C >=Int 0                                                  [simplification]
+    rule          #roundpower(ACC, BASEN, BASED, EXPONENT) *Int A /Int B *Int C <Int pow256 => true  requires  ACC >=Int 0 andBool BASEN >Int 0 andBool BASED >=Int BASEN andBool EXPONENT >=Int 0 andBool A >=Int 0 andBool B >Int 0 andBool C >=Int 0 andBool ACC *Int A /Int B *Int C <Int 2 ^Int 256 [simplification]
 
     syntax Int ::= "@remainingTokens" "(" Int "," Int "," Int ")"
                  | "@canExtractThisYear" "(" Int "," Int "," Int ")"
  // ----------------------------------------------------------------
     rule @remainingTokens(TOTAL, NOW, START) => #roundpower(TOTAL, 90, 100, (NOW -Int START) /Int 31536000)  [macro]
-
     rule @canExtractThisYear(TOTAL, NOW, START) => ((#roundpower(TOTAL, 90, 100, (NOW -Int START) /Int 31536000) *Int 10 /Int 100) *Int ((NOW -Int START) modInt 31536000)) /Int 31536000  [macro]
 
 

--- a/tests/specs/bihu/verification.k
+++ b/tests/specs/bihu/verification.k
@@ -7,6 +7,10 @@ module VERIFICATION
     imports EDSL
     imports LEMMAS
 
+  // ########################
+  // Buffer Reasoning
+  // ########################
+
     //semantics of #buf
     rule #buf(LEN, BYTES) => #padToWidth(LEN, #asByteStack( BYTES )) [simplification, concrete]
 

--- a/tests/specs/bihu/verification.k
+++ b/tests/specs/bihu/verification.k
@@ -46,6 +46,10 @@ module VERIFICATION
        andBool I2 >=Int I3
       [simplification]
 
+  // ########################
+  // #roundpower
+  // ########################
+
     syntax Int ::= "#roundpower" "(" Int "," Int "," Int "," Int ")"  [function, smtlib(smt_roundpower)]
  // ----------------------------------------------------------------------------------------------------
     rule #roundpower(0,                           BASEN, BASED, EXPONENT) => 0                                                requires BASEN >Int 0 andBool BASED >=Int BASEN andBool EXPONENT >=Int 0
@@ -62,12 +66,16 @@ module VERIFICATION
     rule 0 <=Int (#roundpower(ACC, BASEN, BASED, EXPONENT) *Int A /Int B *Int C)            => true  requires  ACC >=Int 0 andBool BASEN >Int 0 andBool BASED >=Int BASEN andBool EXPONENT >=Int 0 andBool A >=Int 0 andBool B >Int 0 andBool C >=Int 0                                                  [simplification]
     rule          #roundpower(ACC, BASEN, BASED, EXPONENT) *Int A /Int B *Int C <Int pow256 => true  requires  ACC >=Int 0 andBool BASEN >Int 0 andBool BASED >=Int BASEN andBool EXPONENT >=Int 0 andBool A >=Int 0 andBool B >Int 0 andBool C >=Int 0 andBool ACC *Int A /Int B *Int C <Int 2 ^Int 256 [simplification]
 
+
     syntax Int ::= "@remainingTokens" "(" Int "," Int "," Int ")"
                  | "@canExtractThisYear" "(" Int "," Int "," Int ")"
  // ----------------------------------------------------------------
     rule @remainingTokens(TOTAL, NOW, START) => #roundpower(TOTAL, 90, 100, (NOW -Int START) /Int 31536000)  [macro]
     rule @canExtractThisYear(TOTAL, NOW, START) => ((#roundpower(TOTAL, 90, 100, (NOW -Int START) /Int 31536000) *Int 10 /Int 100) *Int ((NOW -Int START) modInt 31536000)) /Int 31536000  [macro]
 
+  // ###############################
+  // #accumulatedReleasedTokens
+  // ###############################
 
     syntax Int ::= "#accumulatedReleasedTokens" "(" Int "," Int "," Int "," Int ")"  [function]
  // -------------------------------------------------------------------------------------------

--- a/tests/specs/bihu/verification.k
+++ b/tests/specs/bihu/verification.k
@@ -72,34 +72,16 @@ module VERIFICATION
     syntax Int ::= "#accumulatedReleasedTokens" "(" Int "," Int "," Int "," Int ")"  [function]
  // -------------------------------------------------------------------------------------------
     // proved manually
-    rule COLLECTED <=Int @canExtractThisYear(COLLECTED +Int BAL, NOW, START) +Int ((COLLECTED +Int BAL) -Int @remainingTokens(COLLECTED +Int BAL, NOW, START)) => true
-      requires #accumulatedReleasedTokens(BAL, COLLECTED, START, NOW) >Int COLLECTED +Int 3
-      [simplification]
-
-    rule 0 <=Int @canExtractThisYear(COLLECTED +Int BAL, NOW, START) +Int ((COLLECTED +Int BAL) -Int @remainingTokens(COLLECTED +Int BAL, NOW, START)) -Int COLLECTED => true
-      requires #accumulatedReleasedTokens(BAL, COLLECTED, START, NOW) >Int COLLECTED +Int 3
-      [simplification]
-
-    rule @canExtractThisYear(COLLECTED +Int BAL, NOW, START) +Int ((COLLECTED +Int BAL) -Int @remainingTokens(COLLECTED +Int BAL, NOW, START)) -Int COLLECTED <Int pow256 => true
-      requires #accumulatedReleasedTokens(BAL, COLLECTED, START, NOW) >Int COLLECTED +Int 3
-      [simplification]
-
-    rule 0 <=Int @canExtractThisYear(COLLECTED +Int BAL, NOW, START) +Int ((COLLECTED +Int BAL) -Int @remainingTokens(COLLECTED +Int BAL, NOW, START)) => true
-      requires #accumulatedReleasedTokens(BAL, COLLECTED, START, NOW) >Int COLLECTED +Int 3
-      [simplification]
-
-    rule @canExtractThisYear(COLLECTED +Int BAL, NOW, START) +Int ((COLLECTED +Int BAL) -Int @remainingTokens(COLLECTED +Int BAL, NOW, START)) <Int pow256 => true
-      requires #accumulatedReleasedTokens(BAL, COLLECTED, START, NOW) >Int COLLECTED +Int 3
-      [simplification]
+    rule COLLECTED <=Int @canExtractThisYear(COLLECTED +Int BAL, NOW, START) +Int ((COLLECTED +Int BAL) -Int @remainingTokens(COLLECTED +Int BAL, NOW, START))                => true  requires #accumulatedReleasedTokens(BAL, COLLECTED, START, NOW) >Int COLLECTED +Int 3 [simplification]
+    rule 0         <=Int @canExtractThisYear(COLLECTED +Int BAL, NOW, START) +Int ((COLLECTED +Int BAL) -Int @remainingTokens(COLLECTED +Int BAL, NOW, START))                => true  requires #accumulatedReleasedTokens(BAL, COLLECTED, START, NOW) >Int COLLECTED +Int 3 [simplification]
+    rule 0         <=Int @canExtractThisYear(COLLECTED +Int BAL, NOW, START) +Int ((COLLECTED +Int BAL) -Int @remainingTokens(COLLECTED +Int BAL, NOW, START)) -Int COLLECTED => true  requires #accumulatedReleasedTokens(BAL, COLLECTED, START, NOW) >Int COLLECTED +Int 3 [simplification]
 
     // proved manually (canExtract > balance) --- if condition
-    rule BAL <Int @canExtractThisYear(COLLECTED +Int BAL, NOW, START) +Int ((COLLECTED +Int BAL) -Int @remainingTokens(COLLECTED +Int BAL, NOW, START)) -Int COLLECTED => false
-      requires #accumulatedReleasedTokens(BAL, COLLECTED, START, NOW) <Int (BAL +Int COLLECTED) -Int 10
-      [simplification]
-
+    rule BAL        <Int @canExtractThisYear(COLLECTED +Int BAL, NOW, START) +Int ((COLLECTED +Int BAL) -Int @remainingTokens(COLLECTED +Int BAL, NOW, START)) -Int COLLECTED           => false  requires #accumulatedReleasedTokens(BAL, COLLECTED, START, NOW) <Int (BAL +Int COLLECTED) -Int 10 [simplification]
     // proved manually (balance >= canExtract) --- balance = sub(balance, canExtract)
-    rule @canExtractThisYear(COLLECTED +Int BAL, NOW, START) +Int ((COLLECTED +Int BAL) -Int @remainingTokens(COLLECTED +Int BAL, NOW, START)) -Int COLLECTED <=Int BAL => true
-      requires #accumulatedReleasedTokens(BAL, COLLECTED, START, NOW) <Int (BAL +Int COLLECTED) -Int 10
-      [simplification]
+    rule                 @canExtractThisYear(COLLECTED +Int BAL, NOW, START) +Int ((COLLECTED +Int BAL) -Int @remainingTokens(COLLECTED +Int BAL, NOW, START)) -Int COLLECTED <=Int BAL => true   requires #accumulatedReleasedTokens(BAL, COLLECTED, START, NOW) <Int (BAL +Int COLLECTED) -Int 10 [simplification]
+
+    rule                 @canExtractThisYear(COLLECTED +Int BAL, NOW, START) +Int ((COLLECTED +Int BAL) -Int @remainingTokens(COLLECTED +Int BAL, NOW, START)) -Int COLLECTED <Int pow256 => true  requires #accumulatedReleasedTokens(BAL, COLLECTED, START, NOW) >Int COLLECTED +Int 3 [simplification]
+    rule                 @canExtractThisYear(COLLECTED +Int BAL, NOW, START) +Int ((COLLECTED +Int BAL) -Int @remainingTokens(COLLECTED +Int BAL, NOW, START)) <Int pow256                => true  requires #accumulatedReleasedTokens(BAL, COLLECTED, START, NOW) >Int COLLECTED +Int 3 [simplification]
 
 endmodule

--- a/tests/specs/bihu/verification.k
+++ b/tests/specs/bihu/verification.k
@@ -40,6 +40,8 @@ module VERIFICATION
 
     rule I1 <Int I1 -Int I2 => false requires 0 <=Int I2 [simplification]
 
+    rule chop(I1 -Int I2) => I1 -Int I2 requires #rangeUInt(256, I1) andBool #rangeUInt(256, I2) andBool I2 <=Int I1 [simplification]
+
     rule chop(I1 +Int (I2 -Int I3)) => I1 +Int (I2 -Int I3)
       requires  0 <=Int I2
        andBool I2  <Int pow256

--- a/tests/specs/bihu/verification.k
+++ b/tests/specs/bihu/verification.k
@@ -40,7 +40,8 @@ module VERIFICATION
 
     rule I1 <Int I1 -Int I2 => false requires 0 <=Int I2 [simplification]
 
-    rule chop(I1 -Int I2) => I1 -Int I2 requires 0 <=Int I1 andBool I2 <Int pow256 andBool I1 >=Int I2 [simplification]
+    // TODO: is this needed?
+    // rule chop(I1 -Int I2) => I1 -Int I2 requires 0 <=Int I1 andBool I2 <Int pow256 andBool I1 >=Int I2 [simplification]
 
     rule chop(I1 +Int (I2 -Int I3)) => I1 +Int (I2 -Int I3)
       requires  0 <=Int I2

--- a/tests/specs/bihu/verification.k
+++ b/tests/specs/bihu/verification.k
@@ -40,9 +40,6 @@ module VERIFICATION
 
     rule I1 <Int I1 -Int I2 => false requires 0 <=Int I2 [simplification]
 
-    // TODO: is this needed?
-    // rule chop(I1 -Int I2) => I1 -Int I2 requires 0 <=Int I1 andBool I2 <Int pow256 andBool I1 >=Int I2 [simplification]
-
     rule chop(I1 +Int (I2 -Int I3)) => I1 +Int (I2 -Int I3)
       requires  0 <=Int I2
        andBool I2  <Int pow256

--- a/tests/specs/erc20/verification.k
+++ b/tests/specs/erc20/verification.k
@@ -16,12 +16,15 @@ module VERIFICATION-JAVA [symbolic, kast]
     imports EDSL
     imports EVM-SYMBOLIC
 
+  // ########################
+  // Buffer Reasoning
+  // ########################
+
     //semantics of #buf
     rule #buf(LEN, BYTES) => #padToWidth(LEN, #asByteStack( BYTES )) [simplification, concrete]
 
-    rule chop ( W0:Int +Int W1:Int ) -Word W1:Int => chop ( W0 )
-      requires #rangeUInt(256, W0) andBool #rangeUInt(256, W1)
-      [simplification]
+    rule chop ( W0:Int +Int W1:Int ) -Word W1:Int => chop ( W0 )  requires #rangeUInt(256, W0) andBool #rangeUInt(256, W1) [simplification]
+
 endmodule
 
 module VERIFICATION-HASKELL [symbolic, kore]

--- a/tests/specs/lemmas.k
+++ b/tests/specs/lemmas.k
@@ -5,64 +5,13 @@ module LEMMAS
     imports LEMMAS-JAVA
     imports LEMMAS-HASKELL
 
-    rule 0 <=Int #sizeWordStack ( _ , _ ) => true [smt-lemma, simplification]
-    rule 0 <=Int #sizeByteArray ( _ )     => true [smt-lemma, simplification]
-
-    rule #lookup ( _M:Map [ K1 <- V1 ] , K2 ) => #lookup ( K1 |-> V1 , K1 ) requires K1 ==Int  K2 [simplification]
-    rule #lookup (  M:Map [ K1 <- _  ] , K2 ) => #lookup ( M         , K2 ) requires K1 =/=Int K2 [simplification]
-
-    rule 0 <=Int #lookup( _M:Map , _ )             => true [simplification, smt-lemma]
-    rule         #lookup( _M:Map , _ ) <Int pow256 => true [simplification, smt-lemma]
-
-    //Required for #Ceil(#buf)
-    rule 0 <=Int keccak( _ )             => true [simplification]
-    rule         keccak( _ ) <Int pow256 => true [simplification]
-
-    rule WS ++ .ByteArray => WS  [simplification]
-    rule .ByteArray ++ WS => WS  [simplification]
-
-    //Byte array store operations sorting. Slices with lower index first. Helps applying rule below.
-    rule MEM [ N := BUF:ByteArray ] [ M := BUF' ] => MEM [ M := BUF' ] [ N := BUF ]
-      requires N >Int M andBool N -Int M >=Int #sizeByteArray(BUF')                                               [simplification]
-
-    rule M [ N := BUF ] [ N := BUF' ] => M [ N := BUF' ] requires #sizeByteArray(BUF) ==Int #sizeByteArray(BUF')  [simplification]
-
-    rule _BUF [ _ .. W ] => .ByteArray requires W ==Int 0                    [simplification]
-    rule  BUF [ 0 .. W ] => BUF        requires W ==Int #sizeByteArray(BUF)  [simplification]
-
-    rule (BUF1 ++ BUF2)[START .. WIDTH] => (BUF1[START .. #sizeByteArray(BUF1) -Int START]) ++ (BUF2[0 .. START +Int WIDTH -Int #sizeByteArray(BUF1)])
-      requires #range(0 <= START < #sizeByteArray(BUF1))
-       andBool #sizeByteArray(BUF1) <Int START +Int WIDTH [simplification]
-
-    rule (BUF1 ++ _BUF2)[START .. WIDTH] => BUF1[START .. WIDTH]
-      requires 0 <=Int START
-       andBool 0 <=Int WIDTH
-       andBool START +Int WIDTH <=Int #sizeByteArray(BUF1) [simplification]
-
-    rule (BUF1 ++ BUF2)[START .. WIDTH] => BUF2 [START -Int #sizeByteArray(BUF1) .. WIDTH]
-      requires START >=Int #sizeByteArray(BUF1) [simplification]
-
-    rule #sizeByteArray(BUF1 ++ BUF2)            => #sizeByteArray(BUF1) +Int #sizeByteArray(BUF2)     [simplification]
-    rule #sizeByteArray(#buf(SIZE, _))           => SIZE                                               [simplification]
-    rule #sizeByteArray(_BUF [ START .. WIDTH ]) => WIDTH requires 0 <=Int START andBool 0 <=Int WIDTH [simplification]
-    rule #sizeByteArray(#range(_, START, WIDTH)) => WIDTH requires 0 <=Int START andBool 0 <=Int WIDTH [simplification]
-
-    //Todo custom ==K unification doesn't work in Haskell yet
-    //++ unification
-    rule #buf(N, A) ++ BUF1 ==K #buf(N, B) ++ BUF2 => #buf(N, A) ==K #buf(N, B) andBool BUF1 ==K BUF2     [simplification]
-
-    rule #padToWidth(32, #asByteStack(V)) => #buf(32, V)
-      requires #rangeUInt(256, V)                                                                         [simplification]
+  // ########################
+  // Arithmetic
+  // ########################
 
     //For #bufStrict simplification in benchmarks
     rule 0 <=Int #ceil32(I)        => true requires 0 <=Int I [smt-lemma, simplification]
     rule 0 <=Int #ceil32(I) -Int I => true requires 0 <=Int I [simplification]
-
-    rule #asWord(WS) >>Int M => #asWord(WS [ 0 .. #sizeByteArray(WS) -Int (M /Int 8) ])
-      requires 0 <=Int M andBool M modInt 8 ==Int 0                                                       [simplification]
-
-    rule 0 <=Int keccak(_)                  => true  [simplification]
-    rule         keccak(_) <Int pow256      => true  [simplification]
 
     //Inequality sign normalization
     rule          X  >Int Y  => Y  <Int X            [simplification]
@@ -75,6 +24,22 @@ module LEMMAS
     rule 0 <=Int chop(_V)             => true        [simplification]
     rule         chop(_V) <Int pow256 => true        [simplification]
 
+    rule N /Int 1 => N  [simplification]
+
+  // ########################
+  // Set Reasoning
+  // ########################
+
+    rule X in (SetItem(Y) _   ) => true      requires X  ==Int Y [simplification]
+    rule X in (SetItem(Y) REST) => X in REST requires X =/=Int Y [simplification]
+
+  // ########################
+  // Word Reasoning
+  // ########################
+
+    rule 0 <=Int #sizeWordStack ( _ , _ ) => true [smt-lemma, simplification]
+    rule 0 <=Int #sizeByteArray ( _ )     => true [smt-lemma, simplification]
+
     // bool2Word range & simplification
     rule 0 <=Int bool2Word(_B)             => true   [simplification]
     rule         bool2Word(_B) <Int pow256 => true   [simplification]
@@ -86,17 +51,70 @@ module LEMMAS
     rule         #newAddr(_,_) <Int pow160 => true   [simplification]
     rule         #newAddr(_,_) <Int pow256 => true   [simplification]
 
-    rule N /Int 1 => N  [simplification]
-
     rule #isPrecompiledAccount(#newAddr(_, _), _) => false [simplification]
 
-    rule X in (SetItem(Y) _   ) => true      requires X  ==Int Y [simplification]
-    rule X in (SetItem(Y) REST) => X in REST requires X =/=Int Y [simplification]
+  // ########################
+  // Map Reasoning
+  // ########################
 
-    rule M:Memory [ K1 := BUF1 ] [ K2 := BUF2 ] => M [ K2 := BUF2 ]
-      requires K2 <=Int K1
-       andBool K1 +Int #sizeByteArray(BUF1) <=Int K2 +Int #sizeByteArray(BUF2)
-      [simplification]
+    rule #lookup ( _M:Map [ K1 <- V1 ] , K2 ) => #lookup ( K1 |-> V1 , K1 )  requires K1 ==Int  K2 [simplification]
+    rule #lookup (  M:Map [ K1 <- _  ] , K2 ) => #lookup ( M         , K2 )  requires K1 =/=Int K2 [simplification]
+
+    rule 0 <=Int #lookup( _M:Map , _ )             => true [simplification, smt-lemma]
+    rule         #lookup( _M:Map , _ ) <Int pow256 => true [simplification, smt-lemma]
+
+  // ########################
+  // Keccak
+  // ########################
+
+    //Required for #Ceil(#buf)
+    rule 0 <=Int keccak( _ )             => true [simplification]
+    rule         keccak( _ ) <Int pow256 => true [simplification]
+
+  // ########################
+  // Buffer Reasoning
+  // ########################
+
+    rule WS ++ .ByteArray => WS  [simplification]
+    rule .ByteArray ++ WS => WS  [simplification]
+
+  // ########################
+  // Map Reasoning
+  // ########################
+
+    // re-order assignments
+    rule MEM [ K1 := BUF1 ] [ K2 := BUF2 ] => MEM [ K2 := BUF2 ] [ K1 := BUF1 ]  requires K1  >Int K2 andBool K1 -Int K2 >=Int #sizeByteArray(BUF2)                           [simplification]
+
+    // overwritten assignment
+    rule MEM [ K1 := BUF1 ] [ K2 := BUF2 ] => MEM [ K2 := BUF2 ]                 requires K2 <=Int K1 andBool K1 +Int #sizeByteArray(BUF1) <=Int K2 +Int #sizeByteArray(BUF2) [simplification]
+
+    // redundant assignment
+    rule MEM [ K  := BUF1 ] [ K  := BUF2 ] => MEM [ K  := BUF2 ]                 requires #sizeByteArray(BUF1) ==Int #sizeByteArray(BUF2)                                     [simplification]
+
+    // lookup range in memory
+    rule _MEM [ _ .. W ] => .ByteArray  requires W ==Int 0                    [simplification]
+    rule MEM  [ 0 .. W ] => MEM         requires W ==Int #sizeByteArray(MEM)  [simplification]
+
+    // lookup range in concatenated memory buffers
+    // TODO: make sure that flipping the `START >=Int #sizeByteArray(BUF1)` to a `#sizeByteArray(BUF1) <=Int START` didn't break anything
+    rule (BUF1 ++  BUF2)[START .. WIDTH] =>  BUF2[START -Int #sizeByteArray(BUF1) .. WIDTH                          ]                                                              requires                        #sizeByteArray(BUF1) <=Int START                                                             [simplification]
+    rule (BUF1 ++  _   )[START .. WIDTH] =>  BUF1[START                           .. WIDTH                          ]                                                              requires START +Int WIDTH <=Int #sizeByteArray(BUF1)                       andBool 0 <=Int START andBool 0 <=Int WIDTH       [simplification]
+    rule (BUF1 ++  BUF2)[START .. WIDTH] => (BUF1[START                           .. #sizeByteArray(BUF1) -Int START]) ++ (BUF2[0 .. START +Int WIDTH -Int #sizeByteArray(BUF1)])  requires                        #sizeByteArray(BUF1) <Int START +Int WIDTH andBool #range(0 <= START < #sizeByteArray(BUF1)) [simplification]
+
+    // sizeByteArray
+
+    rule #sizeByteArray(BUF1 ++ BUF2)            => #sizeByteArray(BUF1) +Int #sizeByteArray(BUF2)      [simplification]
+    rule #sizeByteArray(#buf(SIZE, _))           => SIZE                                                [simplification]
+    rule #sizeByteArray(_ [ START .. WIDTH ])    => WIDTH  requires 0 <=Int START andBool 0 <=Int WIDTH [simplification]
+    rule #sizeByteArray(#range(_, START, WIDTH)) => WIDTH  requires 0 <=Int START andBool 0 <=Int WIDTH [simplification]
+
+    // TODO: custom ==K unification doesn't work in Haskell yet
+    // ++ unification
+    rule #buf(N, A) ++ BUF1 ==K #buf(N, B) ++ BUF2 => #buf(N, A) ==K #buf(N, B) andBool BUF1 ==K BUF2     [simplification]
+
+    rule #padToWidth(32, #asByteStack(V)) => #buf(32, V)  requires #rangeUInt(256, V) [simplification]
+
+    rule #asWord(WS) >>Int M => #asWord(WS [ 0 .. #sizeByteArray(WS) -Int (M /Int 8) ])  requires 0 <=Int M andBool M modInt 8 ==Int 0 [simplification]
 
 endmodule
 
@@ -106,16 +124,26 @@ module LEMMAS-JAVA [symbolic, kast]
     imports K-REFLECTION
     imports HASH2
 
+  // ########################
+  // Buffer Reasoning
+  // ########################
+
     rule BUF [ L .. _W ] => .ByteArray requires L >=Int #sizeByteArray(BUF) [simplification]
 
     rule (W0 : WS) [ 0     .. WIDTH ] => W0 : (WS [ 0            .. WIDTH -Int 1 ]) requires #rangeUInt(8, W0) andBool 0 <Int WIDTH [simplification]
     rule (W0 : WS) [ START .. WIDTH ] =>       WS [ START -Int 1 .. WIDTH        ]  requires #rangeUInt(8, W0) andBool 0 <Int START [simplification]
 
+    // #sizeByteArray
+
     rule #sizeByteArray(_W : WS)       => 1 +Int #sizeByteArray(WS)             [simplification]
+
+    // #asWord
 
     rule #asWord(#buf(_N, BUF)) => BUF [simplification]
 
     rule #asWord(BUF) /Int pow224 => #asWord(BUF [ 0 .. 4 ]) requires #sizeByteArray(BUF) ==Int 32 [simplification]
+
+    // #range
 
     rule #range(_M, _N, K) => .ByteArray requires notBool K >Int 0 [simplification]
 
@@ -139,12 +167,25 @@ module LEMMAS-JAVA [symbolic, kast]
       requires #noOverflow(WS) andBool N ==Int #sizeByteArray(WS)
       [simplification]
 
+
+    rule BA:ByteArray        ==K #buf( 32, DATA )    => #buf( 32, DATA ) ==K   BA              requires #isConcrete(BA)             [simplification]
+    rule #buf( 32, DATA )    ==K BA:ByteArray        => DATA             ==Int #asInteger(BA)  requires #isConcrete(BA)
+                                                                                                andBool #sizeByteArray(BA) <=Int 32 [simplification]
+
+  // ########################
+  // Overflow
+  // ########################
+
     syntax Bool ::= #noOverflow    ( ByteArray ) [function]
                   | #noOverflowAux ( ByteArray ) [function]
  // -------------------------------------------------------
     rule #noOverflow(WS) => #sizeByteArray(WS) <=Int 32 andBool #noOverflowAux(WS)
 
     rule #noOverflowAux(.ByteArray) => true
+
+  // ########################
+  // Arithmetic
+  // ########################
 
     rule 1 *Int N => N
     rule N *Int 1 => N
@@ -186,11 +227,27 @@ module LEMMAS-JAVA [symbolic, kast]
                             andBool 0 <=Int N andBool N <=Int MASK
       [simplification]
 
+    rule 0 <=Int X &Int Y             => true requires 0 <=Int X andBool X <Int pow256 andBool 0 <=Int Y andBool Y <Int pow256 [simplification]
+    rule         X &Int Y <Int pow256 => true requires 0 <=Int X andBool X <Int pow256 andBool 0 <=Int Y andBool Y <Int pow256 [simplification]
+
+  // ########################
+  // Boolean Logic
+  // ########################
+
+    rule B ==K false => notBool B [simplification]
+
+  // ########################
+  // Gas Calculation
+  // ########################
 
     // for gas calculation
     rule A -Int (#if C #then B1 #else B2 #fi) => #if C #then (A -Int B1) #else (A -Int B2) #fi [simplification]
 
     rule (#if C #then B1 #else B2 #fi) +Int A => #if C #then (B1 +Int A) #else (B2 +Int A) #fi [simplification]
+
+  // ########################
+  // Word Reasoning
+  // ########################
 
     rule bool2Word(A) |Int bool2Word(B) => bool2Word(A  orBool B) [simplification]
     rule bool2Word(A) &Int bool2Word(B) => bool2Word(A andBool B) [simplification]
@@ -204,33 +261,24 @@ module LEMMAS-JAVA [symbolic, kast]
     rule bool2Word(A) =/=K 0 => A          [simplification]
     rule bool2Word(A) =/=K 1 => notBool(A) [simplification]
 
-    rule notBool  (X ==K 0) => X ==K 1 requires #rangeBool(X) [simplification]
-    rule notBool  (X ==K 1) => X ==K 0 requires #rangeBool(X) [simplification]
-    rule bool2Word(X ==K 1) => X       requires #rangeBool(X) [simplification]
+    rule notBool  (X ==K 0) => X ==K 1  requires #rangeBool(X) [simplification]
+    rule notBool  (X ==K 1) => X ==K 0  requires #rangeBool(X) [simplification]
+    rule bool2Word(X ==K 1) => X        requires #rangeBool(X) [simplification]
 
-    rule B ==K false => notBool B [simplification]
-
-    rule 0 <=Int X &Int Y             => true requires 0 <=Int X andBool X <Int pow256 andBool 0 <=Int Y andBool Y <Int pow256 [simplification]
-    rule         X &Int Y <Int pow256 => true requires 0 <=Int X andBool X <Int pow256 andBool 0 <=Int Y andBool Y <Int pow256 [simplification]
-
-    rule 0 <=Int #asWord(_WS)         => true [simplification]
-    rule #asWord(_WS) <Int pow256     => true [simplification]
+    rule 0 <=Int #asWord(_WS)             => true [simplification]
+    rule         #asWord(_WS) <Int pow256 => true [simplification]
 
     rule X <=Int maxUInt256 => X <Int pow256 [simplification]
     rule X <=Int maxUInt160 => X <Int pow160 [simplification]
     rule X <=Int 255        => X <Int 256    [simplification]
 
     //Simplification of bool2Word() ==Int CONCRETE, #buf() ==K CONCRETE
-    rule I                   ==K bool2Word( B:Bool ) => bool2Word(B) ==Int I    requires #isConcrete(I) [simplification]
-    rule bool2Word( B:Bool ) ==K I                   => B ==K word2Bool(I)      requires #isConcrete(I) [simplification]
-
-    rule BA:ByteArray     ==K #buf( 32, DATA ) => #buf( 32, DATA ) ==K BA       requires #isConcrete(BA) [simplification]
-    rule #buf( 32, DATA ) ==K BA:ByteArray     => DATA ==Int #asInteger(BA)
-      requires #sizeByteArray(BA) <=Int 32                                      andBool  #isConcrete(BA) [simplification]
+    rule I                   ==K bool2Word( B:Bool ) => bool2Word(B) ==Int I             requires #isConcrete(I) [simplification]
+    rule bool2Word( B:Bool ) ==K I                   => B            ==K   word2Bool(I)  requires #isConcrete(I) [simplification]
 
     //For #bufStrict simplification in benchmarks
-    rule 0 <Int 2 ^Int I  => true      requires 0 <=Int I [simplification]
-    rule 0 <=Int I *Int 8 => 0 <=Int I                    [simplification]
+    rule 0  <Int 2 ^Int I => true       requires 0 <=Int I [simplification]
+    rule 0 <=Int I *Int 8 => 0 <=Int I                     [simplification]
 
 endmodule
 
@@ -240,7 +288,11 @@ module LEMMAS-HASKELL [symbolic, kore]
     imports EDSL
     imports HASH2
 
-    rule #asWord(BUF) /Int D => #asWord(BUF[0 .. #sizeByteArray(BUF) -Int log256Int(D)])
+  // ########################
+  // Word Reasoning
+  // ########################
+
+    rule #asWord(BUF) /Int D => #asWord(BUF[0 .. #sizeByteArray(BUF) -Int log256Int(D)]) 
       requires D ==Int 256 ^Int log256Int(D) andBool D >=Int 0
        andBool #sizeByteArray(BUF) >=Int log256Int(D) [simplification]
 
@@ -248,51 +300,47 @@ module LEMMAS-HASKELL [symbolic, kore]
       requires #range(0 < N <= 32)
        andBool #range(0 <= BUF < 2 ^Int (N *Int 8)) [simplification]
 
-    rule N &Int maxUInt160 => N
-      requires #rangeUInt(160, N) [simplification]
-
-    rule maxUInt160 &Int N => N
-      requires #rangeUInt(160, N) [simplification]
-
-    rule N modInt pow160 => N
-      requires #rangeUInt(160, N) [simplification]
-
-    rule #range(_, _, K) => .ByteArray requires notBool K >Int 0  [simplification]
-
-    rule #range(M [ N := BUF:ByteArray ], L, K) => #range(M, L, minInt(K, N -Int L)) ++ #range(M [ N := BUF ], N, K -Int minInt(K, N -Int L))
-      requires K >Int 0
-       andBool L <Int N
-      [simplification]
-
-    rule #range(M [ N := BUF ], L, K) => BUF [ L -Int N .. minInt(K, #sizeByteArray(BUF) -Int (L -Int N)) ] ++ #range(M, N +Int #sizeByteArray(BUF), K -Int minInt(K, #sizeByteArray(BUF) -Int (L -Int N)))
-      requires K  >Int 0
-       andBool L >=Int N
-       andBool L  <Int N +Int #sizeByteArray(BUF)
-      [simplification]
-
-    rule #range(M [ N := BUF ], L, K) => #range(M, L, K)
-      requires K  >Int 0
-       andBool L >=Int N +Int #sizeByteArray(BUF)
-      [simplification]
-
-    rule N <=Int maxInt(P, Q) => true requires N <=Int P orBool N <=Int Q  [simplification]
-    rule minInt(P, Q)         => P    requires P <=Int Q                   [simplification]
-
-    rule 0 <=Int lengthBytes ( _ ) => true [smt-lemma, simplification]
+    rule notBool  (X ==Int 0) => X ==Int 1 requires #rangeBool(X) [simplification]
+    rule notBool  (X ==Int 1) => X ==Int 0 requires #rangeBool(X) [simplification]
+    rule bool2Word(X ==Int 1) => X         requires #rangeBool(X) [simplification]
 
     //Simplification of bool2Word() ==Int CONCRETE, #buf() ==K CONCRETE
     rule I                   ==Int bool2Word( B:Bool ) => bool2Word(B) ==Int I  [simplification, concrete(I)]
     rule bool2Word( B:Bool ) ==Int I                   => B ==K word2Bool(I)    [simplification, concrete(I)]
 
-    rule notBool  (X ==Int 0) => X ==Int 1 requires #rangeBool(X) [simplification]
-    rule notBool  (X ==Int 1) => X ==Int 0 requires #rangeBool(X) [simplification]
-    rule bool2Word(X ==Int 1) => X         requires #rangeBool(X) [simplification]
+  // ########################
+  // Arithmetic
+  // ########################
+
+    rule N &Int maxUInt160 => N  requires #rangeUInt(160, N) [simplification]
+    rule maxUInt160 &Int N => N  requires #rangeUInt(160, N) [simplification]
+    rule N modInt pow160   => N  requires #rangeUInt(160, N) [simplification]
+
+    rule N <=Int maxInt(P, Q) => true requires N <=Int P orBool N <=Int Q  [simplification]
+    rule minInt(P, Q)         => P    requires P <=Int Q                   [simplification]
+
+
+  // ########################
+  // Buffer Reasoning
+  // ########################
+
+    // #range
+
+    rule #range(_             , _, K) => .ByteArray                                                                                                                                                          requires notBool K >Int 0                                                                               [simplification]
+    rule #range(M [ N := BUF ], L, K) => #range(M, L, minInt(K, N -Int L)) ++ #range(M [ N := BUF ], N, K -Int minInt(K, N -Int L))                                                                          requires K  >Int 0 andBool L <Int N                                                                     [simplification]
+    rule #range(M [ N := BUF ], L, K) => BUF [ L -Int N .. minInt(K, #sizeByteArray(BUF) -Int (L -Int N)) ] ++ #range(M, N +Int #sizeByteArray(BUF), K -Int minInt(K, #sizeByteArray(BUF) -Int (L -Int N)))  requires K  >Int 0 andBool L <Int N +Int #sizeByteArray(BUF) andBool L >=Int N                          [simplification]
+    rule #range(M [ N := BUF ], L, K) => #range(M, L, K)                                                                                                                                                     requires K  >Int 0                                           andBool L >=Int N +Int #sizeByteArray(BUF) [simplification]
+
+    rule 0 <=Int lengthBytes ( _ ) => true [smt-lemma, simplification]
+
+    rule BA:ByteArray     ==K #buf( 32, DATA ) => #buf( 32, DATA ) ==K              BA                                       [simplification, concrete(BA)]
+    rule #buf( 32, DATA ) ==K BA:ByteArray     =>           DATA   ==Int #asInteger(BA) requires #sizeByteArray(BA) <=Int 32 [simplification, concrete(BA)]
+
+  // ########################
+  // Boolean Logic
+  // ########################
 
     rule B ==Bool false => notBool B [simplification]
-
-    rule BA:ByteArray     ==K #buf( 32, DATA ) => #buf( 32, DATA ) ==K BA       [simplification, concrete(BA)]
-    rule #buf( 32, DATA ) ==K BA:ByteArray     => DATA ==Int #asInteger(BA)
-      requires #sizeByteArray(BA) <=Int 32                                      [simplification, concrete(BA)]
 
 endmodule
 

--- a/tests/specs/lemmas.k
+++ b/tests/specs/lemmas.k
@@ -83,13 +83,13 @@ module LEMMAS
   // ########################
 
     // re-order assignments
-    rule MEM [ K1 := BUF1 ] [ K2 := BUF2 ] => MEM [ K2 := BUF2 ] [ K1 := BUF1 ]  requires K1  >Int K2 andBool K1 -Int K2 >=Int #sizeByteArray(BUF2)                           [simplification]
+    rule MEM [ K1 := BUF1:ByteArray ] [ K2 := BUF2:ByteArray ] => MEM [ K2 := BUF2 ] [ K1 := BUF1 ]  requires K1  >Int K2 andBool K1 -Int K2 >=Int #sizeByteArray(BUF2)                           [simplification]
 
     // overwritten assignment
-    rule MEM [ K1 := BUF1 ] [ K2 := BUF2 ] => MEM [ K2 := BUF2 ]                 requires K2 <=Int K1 andBool K1 +Int #sizeByteArray(BUF1) <=Int K2 +Int #sizeByteArray(BUF2) [simplification]
+    rule MEM [ K1 := BUF1           ] [ K2 := BUF2           ] => MEM [ K2 := BUF2 ]                 requires K2 <=Int K1 andBool K1 +Int #sizeByteArray(BUF1) <=Int K2 +Int #sizeByteArray(BUF2) [simplification]
 
     // redundant assignment
-    rule MEM [ K  := BUF1 ] [ K  := BUF2 ] => MEM [ K  := BUF2 ]                 requires #sizeByteArray(BUF1) ==Int #sizeByteArray(BUF2)                                     [simplification]
+    rule MEM [ K  := BUF1           ] [ K  := BUF2           ] => MEM [ K  := BUF2 ]                 requires #sizeByteArray(BUF1) ==Int #sizeByteArray(BUF2)                                     [simplification]
 
     // lookup range in memory
     rule _MEM [ _ .. W ] => .ByteArray  requires W ==Int 0                    [simplification]
@@ -326,10 +326,10 @@ module LEMMAS-HASKELL [symbolic, kore]
 
     // #range
 
-    rule #range(_             , _, K) => .ByteArray                                                                                                                                                          requires notBool K >Int 0                                                                               [simplification]
-    rule #range(M [ N := BUF ], L, K) => #range(M, L, minInt(K, N -Int L)) ++ #range(M [ N := BUF ], N, K -Int minInt(K, N -Int L))                                                                          requires K  >Int 0 andBool L <Int N                                                                     [simplification]
-    rule #range(M [ N := BUF ], L, K) => BUF [ L -Int N .. minInt(K, #sizeByteArray(BUF) -Int (L -Int N)) ] ++ #range(M, N +Int #sizeByteArray(BUF), K -Int minInt(K, #sizeByteArray(BUF) -Int (L -Int N)))  requires K  >Int 0 andBool L <Int N +Int #sizeByteArray(BUF) andBool L >=Int N                          [simplification]
-    rule #range(M [ N := BUF ], L, K) => #range(M, L, K)                                                                                                                                                     requires K  >Int 0                                           andBool L >=Int N +Int #sizeByteArray(BUF) [simplification]
+    rule #range(_                       , _, K) => .ByteArray                                                                                                                                                          requires notBool K >Int 0                                                                               [simplification]
+    rule #range(M [ N := BUF:ByteArray ], L, K) => #range(M, L, minInt(K, N -Int L)) ++ #range(M [ N := BUF ], N, K -Int minInt(K, N -Int L))                                                                          requires K  >Int 0 andBool L <Int N                                                                     [simplification]
+    rule #range(M [ N := BUF:ByteArray ], L, K) => BUF [ L -Int N .. minInt(K, #sizeByteArray(BUF) -Int (L -Int N)) ] ++ #range(M, N +Int #sizeByteArray(BUF), K -Int minInt(K, #sizeByteArray(BUF) -Int (L -Int N)))  requires K  >Int 0 andBool L <Int N +Int #sizeByteArray(BUF) andBool L >=Int N                          [simplification]
+    rule #range(M [ N := BUF:ByteArray ], L, K) => #range(M, L, K)                                                                                                                                                     requires K  >Int 0                                           andBool L >=Int N +Int #sizeByteArray(BUF) [simplification]
 
     rule 0 <=Int lengthBytes ( _ ) => true [smt-lemma, simplification]
 

--- a/tests/specs/lemmas.k
+++ b/tests/specs/lemmas.k
@@ -37,7 +37,7 @@ module LEMMAS
   // Word Reasoning
   // ########################
 
-    rule 0 <=Int #sizeWordStack ( _ , _ ) => true [smt-lemma, simplification]
+    rule 0 <=Int #sizeWordStack ( _ , N ) => true requires 0 <=Int N [smt-lemma, simplification]
     rule 0 <=Int #sizeByteArray ( _ )     => true [smt-lemma, simplification]
 
     // bool2Word range & simplification

--- a/tests/specs/lemmas.k
+++ b/tests/specs/lemmas.k
@@ -96,7 +96,6 @@ module LEMMAS
     rule MEM  [ 0 .. W ] => MEM         requires W ==Int #sizeByteArray(MEM)  [simplification]
 
     // lookup range in concatenated memory buffers
-    // TODO: make sure that flipping the `START >=Int #sizeByteArray(BUF1)` to a `#sizeByteArray(BUF1) <=Int START` didn't break anything
     rule (BUF1 ++  BUF2)[START .. WIDTH] =>  BUF2[START -Int #sizeByteArray(BUF1) .. WIDTH                          ]                                                              requires                        #sizeByteArray(BUF1) <=Int START                                                             [simplification]
     rule (BUF1 ++  _   )[START .. WIDTH] =>  BUF1[START                           .. WIDTH                          ]                                                              requires START +Int WIDTH <=Int #sizeByteArray(BUF1)                       andBool 0 <=Int START andBool 0 <=Int WIDTH       [simplification]
     rule (BUF1 ++  BUF2)[START .. WIDTH] => (BUF1[START                           .. #sizeByteArray(BUF1) -Int START]) ++ (BUF2[0 .. START +Int WIDTH -Int #sizeByteArray(BUF1)])  requires                        #sizeByteArray(BUF1) <Int START +Int WIDTH andBool #range(0 <= START < #sizeByteArray(BUF1)) [simplification]

--- a/tests/specs/lemmas.k
+++ b/tests/specs/lemmas.k
@@ -38,7 +38,7 @@ module LEMMAS
   // ########################
 
     rule 0 <=Int #sizeWordStack ( _ , N ) => true requires 0 <=Int N [smt-lemma, simplification]
-    rule 0 <=Int #sizeByteArray ( _ )     => true [smt-lemma, simplification]
+    rule 0 <=Int #sizeByteArray ( _ )     => true                    [smt-lemma, simplification]
 
     // bool2Word range & simplification
     rule 0 <=Int bool2Word(_B)             => true   [simplification]

--- a/tests/specs/mcd/verification.k
+++ b/tests/specs/mcd/verification.k
@@ -262,8 +262,6 @@ module LEMMAS-MCD-COMMON
     // So we need this rule to do the structural simplification because the Java backend will not use this string of equalities to do the simplification directly.
     rule #WordPackAddrUInt48UInt48(ADDR, maxUInt48 &Int (ADDR_UINT48_UINT48 /Int pow160), UINT48_2) => #WordPackAddrUInt48UInt48(ADDR, 0, UINT48_2) requires maxUInt48 &Int (ADDR_UINT48_UINT48 /Int pow160) ==Int 0 [simplification]
 
-
-
   // ########################
   // Map
   // ########################

--- a/tests/specs/mcd/verification.k
+++ b/tests/specs/mcd/verification.k
@@ -8,15 +8,31 @@ module VERIFICATION
     imports DSS-BIN-RUNTIME
     imports DSS-STORAGE
     imports LEMMAS-MCD
+
 endmodule
 
 module LEMMAS-MCD
     imports LEMMAS-MCD-HASKELL
     imports LEMMAS-MCD-JAVA
+
 endmodule
 
 module LEMMAS-MCD-SYNTAX
     imports LEMMAS
+
+  // ########################
+  // Constants
+  // ########################
+
+    syntax Int ::= "#Wad" | "#Ray" | "#Rad"
+ // ---------------------------------------
+    rule #Wad => 1000000000000000000                            [macro]
+    rule #Ray => 1000000000000000000000000000                   [macro]
+    rule #Rad => 1000000000000000000000000000000000000000000000 [macro]
+
+  // ########################
+  // Word Reasoning
+  // ########################
 
     syntax Bool ::= #notPrecompileAddress ( Int ) [function]
  // --------------------------------------------------------
@@ -26,11 +42,14 @@ module LEMMAS-MCD-SYNTAX
  // -------------------------------------------------
     rule #string2Word(S) => #asWord(#padRightToWidth(32, #parseByteStackRaw(S)))
 
-    syntax Int ::= "#Wad" | "#Ray" | "#Rad"
- // ---------------------------------------
-    rule #Wad => 1000000000000000000                            [macro]
-    rule #Ray => 1000000000000000000000000000                   [macro]
-    rule #Rad => 1000000000000000000000000000000000000000000000 [macro]
+    syntax Int ::= nthbyteof ( Int , Int , Int ) [function, smtlib(smt_nthbyteof), proj]
+ // ------------------------------------------------------------------------------------
+    rule nthbyteof(V, I, N) => nthbyteof(V /Int 256, I, N -Int 1) when N  >Int (I +Int 1) [concrete]
+    rule nthbyteof(V, I, N) =>           V modInt 256             when N ==Int (I +Int 1) [concrete]
+
+  // ########################
+  // Buffer Reasoning
+  // ########################
 
     syntax ByteArray ::= #asByteStackInWidth    ( Int, Int )                 [function]
                        | #asByteStackInWidthaux ( Int, Int, Int, ByteArray ) [function]
@@ -40,10 +59,9 @@ module LEMMAS-MCD-SYNTAX
     rule #asByteStackInWidthaux(X, I, N, WS) => #asByteStackInWidthaux(X, I -Int 1, N, nthbyteof(X, I, N) : WS) when I >Int 0
     rule #asByteStackInWidthaux(X, 0, N, WS) => nthbyteof(X, 0, N) : WS
 
-    syntax Int ::= nthbyteof ( Int , Int , Int ) [function, smtlib(smt_nthbyteof), proj]
- // ------------------------------------------------------------------------------------
-    rule nthbyteof(V, I, N) => nthbyteof(V /Int 256, I, N -Int 1) when N  >Int (I +Int 1) [concrete]
-    rule nthbyteof(V, I, N) =>           V modInt 256             when N ==Int (I +Int 1) [concrete]
+  // ########################
+  // Arithmetic
+  // ########################
 
     syntax Int ::= #rmul ( Int , Int ) [function, smtlib(smt_rmul)]
  // ---------------------------------------------------------------
@@ -54,42 +72,38 @@ endmodule
 module LEMMAS-MCD-HASKELL [symbolic, kore]
     imports LEMMAS-MCD-COMMON
 
+  // ########################
+  // Arithmetic
+  // ########################
+
     // ### functional
 
     rule chop(Y) => Y +Int pow256 requires #rangeSInt(256, Y) andBool Y <Int 0 [simplification]
 
+  // ########################
+  // Map
+  // ########################
+
     // ### flapper-yank-pass-rough
 
-    rule #range(M:Memory [ K <- V ], START, WIDTH) => #range(M [ K := (V : .ByteArray) ], START, WIDTH)
-      requires START <=Int K andBool K +Int 1 ==Int START +Int WIDTH
-       andBool 0 <Int WIDTH andBool 0 <=Int START
-       [concrete(K, V), simplification]
-
-    rule #range(M:Memory [ K <- V ] [ K' := VS':ByteArray ], START, WIDTH) => #range(M [ K := (V : VS') ], START, WIDTH)
-      requires START <=Int K andBool K' +Int #sizeByteArray(VS') ==Int START +Int WIDTH
-       andBool 0 <Int WIDTH andBool 0 <=Int START
-       andBool K +Int 1 ==Int K'
-      [concrete(K, K', V, VS'), simplification]
+    rule #range(M:Memory [ K <- V ]                        , START, WIDTH) => #range(M [ K := (V : .ByteArray) ], START, WIDTH)  requires K +Int 1                    ==Int START +Int WIDTH andBool START <=Int K andBool 0 <Int WIDTH andBool 0 <=Int START [concrete(K    , V     ), simplification]
+    rule #range(M:Memory [ K <- V ] [ K' := VS':ByteArray ], START, WIDTH) => #range(M [ K := (V : VS')        ], START, WIDTH)  requires K' +Int #sizeByteArray(VS') ==Int START +Int WIDTH andBool START <=Int K andBool 0 <Int WIDTH andBool 0 <=Int START 
+                                                                                                                                  andBool K +Int 1                    ==Int K'                                                                                [concrete(K, K', V, VS'), simplification]
 
 endmodule
 
 module LEMMAS-MCD-JAVA [symbolic, kast]
     imports LEMMAS-MCD-COMMON
 
+  // ########################
+  // Range
+  // ########################
+
     // ### flapper-yank-pass-rough
 
-    rule #range(M:Memory [ K <- V ], START, WIDTH) => #range(M [ K := (V : .ByteArray) ], START, WIDTH)
-      requires #isConcrete(K) andBool #isConcrete(V)
-       andBool START <=Int K andBool K +Int 1 ==Int START +Int WIDTH
-       andBool 0 <Int WIDTH andBool 0 <=Int START
-       [simplification]
-
-    rule #range(M:Memory [ K <- V ] [ K' := VS':ByteArray ], START, WIDTH) => #range(M [ K := (V : VS') ], START, WIDTH)
-      requires #isConcrete(K) andBool #isConcrete(K') andBool #isConcrete(V) andBool #isConcrete(VS')
-       andBool START <=Int K andBool K' +Int #sizeByteArray(VS') ==Int START +Int WIDTH
-       andBool 0 <Int WIDTH andBool 0 <=Int START
-       andBool K +Int 1 ==Int K'
-      [simplification]
+    rule #range(M:Memory [ K <- V ]                        , START, WIDTH) => #range(M [ K := (V : .ByteArray) ], START, WIDTH)  requires #isConcrete(K)  andBool #isConcrete(V) andBool START <=Int K andBool 0 <Int WIDTH andBool 0 <=Int START andBool K +Int 1                    ==Int START +Int WIDTH [simplification]
+    rule #range(M:Memory [ K <- V ] [ K' := VS':ByteArray ], START, WIDTH) => #range(M [ K := (V : VS')        ], START, WIDTH)  requires #isConcrete(K)  andBool #isConcrete(V) andBool START <=Int K andBool 0 <Int WIDTH andBool 0 <=Int START andBool K +Int 1                    ==Int K'              
+                                                                                                                                  andBool #isConcrete(K') andBool #isConcrete(VS')                                                                andBool K' +Int #sizeByteArray(VS') ==Int START +Int WIDTH [simplification] 
 
 endmodule
 
@@ -98,45 +112,33 @@ module LEMMAS-MCD-COMMON
     imports INFINITE-GAS
     imports WORD-PACK
 
+  // ########################
+  // Buffer Reasoning
+  // ########################
+
     // ### vat-move-diff
 
-    rule (W0 : WS) [ 0     .. WIDTH ] => W0 : (WS [ 0 .. WIDTH -Int 1 ]) requires 0 <Int WIDTH [simplification]
-    rule (_  : WS) [ START .. WIDTH ] => WS [ START -Int 1 .. WIDTH ]    requires 0 <Int START [simplification]
+    rule (W0 : WS) [ 0     .. WIDTH ] => W0 : (WS [ 0 .. WIDTH -Int 1 ])  requires 0 <Int WIDTH [simplification]
+    rule (_  : WS) [ START .. WIDTH ] => WS [ START -Int 1 .. WIDTH ]     requires 0 <Int START [simplification]
 
     // ### cat-exhaustiveness
 
-    rule WS [ START .. WIDTH ] [ 0 .. WIDTH' ]  => WS [ START .. WIDTH' ] requires WIDTH' <=Int WIDTH [simplification]
+    rule WS [ START .. WIDTH ] [ 0 .. WIDTH' ]  => WS [ START .. WIDTH' ]  requires WIDTH' <=Int WIDTH [simplification]
+
+    rule ( BA1:ByteArray ++ BA2:ByteArray ) ++ BA3:ByteArray => BA1 ++ ( BA2 ++ BA3 ) [simplification]
+
+  // ########################
+  // Word Reasoning
+  // ########################
 
     // ### cat-file-addr-pass-rough
 
-    rule maskWordPackAddrUInt48UInt48_1 &Int ADDR => 0 requires #rangeAddress(ADDR) [simplification]
+    rule maskWordPackAddrUInt48UInt48_1 &Int ADDR => 0  requires #rangeAddress(ADDR) [simplification]
 
     // ### PERFORMANCE: dai-adduu-fail-rough
     // 99s -> 48s
 
-    rule #sizeWordStack(WS, N) => #sizeWordStack(WS, 0) +Int N requires N =/=Int 0 [simplification]
-
-    // ### PERFORMANCE: vat-deny-diff-fail-rough
-    // 27.21m -> 3.16m
-
-    rule M:Memory [ K <- V ]             [ K' <- V' ] => M [ K' <- V' ] [ K <- V ]   requires K' <Int K                                            [simplification]
-    rule M:Memory [ K := BUF:ByteArray ] [ K' <- V' ] => M [ K' <- V' ] [ K := BUF ] requires K' <Int K orBool K +Int #sizeByteArray(BUF) <=Int K' [simplification]
-
-    // ### dstoken-transferfrom-fail-rough
-
-    rule chop(N +Int M) <Int N => true requires #rangeUInt(256, N) andBool #rangeUInt(256, M) andBool notBool #rangeUInt(256, N +Int M) [simplification]
-
-    // ### dsvalue-read-pass
-
-    rule M [ K <- V ] => M requires #lookup(M, K) ==Int V [simplification]
-
-    // ### flipper-bids-pass-rough
-
-    // This lemma is considered "safe enough" because `keccak` is a hash function over a large range and is very unlikely to overflow.
-    // Note that this case comes from a solidity struct being accessed (hence the integer offsets), so it's an assumption built into the Solidity compiler anyway.
-    rule chop(keccak(BA) +Int N) => keccak(BA) +Int N requires 0 <=Int N andBool N <Int 6 [simplification]
-
-    rule ( BA1:ByteArray ++ BA2:ByteArray ) ++ BA3:ByteArray => BA1 ++ ( BA2 ++ BA3 ) [simplification]
+    rule #sizeWordStack(WS, N) => #sizeWordStack(WS, 0) +Int N  requires N =/=Int 0 [simplification]
 
     // ### vat-addui-fail-rough
 
@@ -180,9 +182,138 @@ module LEMMAS-MCD-COMMON
     //     (= (slt x 0) (= (sgn x) -1))
     // ))
     // (check-sat)
-    rule X s<Word 0 => bool2Word(sgn(X) ==Int -1) requires #rangeUInt(256, X) [simplification]
+    rule X s<Word 0 => bool2Word(sgn(X) ==Int -1)  requires #rangeUInt(256, X) [simplification]
 
-    rule sgn(chop(X)) ==Int -1 => X <Int 0 requires #rangeSInt(256, X) [simplification]
+    // ### vow-flog-fail-rough
+
+    rule X -Word Y <=Int X => #rangeUInt(256, X -Int Y) requires #rangeUInt(256, X) andBool #rangeUInt(256, Y) [simplification]
+    
+    rule 0 <=Int X +Int Y => true requires 0 <=Int X andBool 0 <=Int Y [simplification]
+
+    // ### vat-subui-fail-rough
+
+    // ;(set-option :smt.mbqi true)
+    //
+    // ; 2^256
+    // (declare-const pow256 Int)
+    // (assert (= pow256 115792089237316195423570985008687907853269984665640564039457584007913129639936))
+    //
+    // ; 2^255
+    // (declare-const pow255 Int)
+    // (assert (= pow255 57896044618658097711785492504343953926634992332820282019728792003956564819968))
+    //
+    // ; sgn
+    // (declare-fun sgn (Int) Int)
+    // (assert (forall ((x Int)) (=> (and (>= x 0)      (< x pow255)) (= (sgn x)  1))))
+    // (assert (forall ((x Int)) (=> (and (>= x pow255) (< x pow256)) (= (sgn x) -1))))
+    //
+    // ; s<Word
+    // (declare-fun slt (Int Int) Bool)
+    // (assert (forall ((x Int) (y Int)) (=> (and (= (sgn x)  1) (= (sgn y)  1)) (= (slt x y) (< x y)))))
+    // (assert (forall ((x Int) (y Int)) (=> (and (= (sgn x)  1) (= (sgn y) -1)) (= (slt x y) false))))
+    // (assert (forall ((x Int) (y Int)) (=> (and (= (sgn x) -1) (= (sgn y)  1)) (= (slt x y) true))))
+    // (assert (forall ((x Int) (y Int)) (=> (and (= (sgn x) -1) (= (sgn y) -1)) (= (slt x y) (> x y)))))
+    //
+    // ; chop
+    // (define-fun chop ((x Int)) Int (mod x pow256))
+    // ;(simplify (chop -1))
+    //
+    // ; /Word
+    // (define-fun zdiv ((x Int) (y Int)) Int (ite (= y 0) 0 (div x y)))
+    //
+    // ; /sWord
+    // (declare-fun sdiv (Int Int) Int)
+    // (assert (forall ((x Int) (y Int)) (=> (> (* (sgn x) (sgn y)) 0) (= (sdiv x y)    (zdiv (abs x) (abs y)) ))))
+    // (assert (forall ((x Int) (y Int)) (=> (< (* (sgn x) (sgn y)) 0) (= (sdiv x y) (- (zdiv (abs x) (abs y)))))))
+    //
+    // ; uint256
+    // (define-fun uint256 ((x Int)) Bool (and (>= x 0) (< x pow256)))
+    //
+    // ; sint256
+    // (define-fun sint256 ((x Int)) Bool (and (>= x (- pow255)) (< x pow255)))
+    //
+    // ;;;;
+    //
+    // (declare-const x Int)
+    // (declare-const y Int)
+
+    // Via Z3 4.7.1:
+    // (push)
+    // (assert (not (=> (uint256 x) (= (slt 0 x) (and (= (sgn x) 1) (not (= x 0))) ) ) ))
+    // (check-sat)
+    // (pop)
+    rule 0 s<Word X => bool2Word(sgn(X) ==Int 1 andBool X =/=Int 0) requires #rangeUInt(256, X) [simplification]
+
+    // ### vat-subui-pass-rough
+
+    // Via Z3 4.7.1:
+    // (push)
+    // (assert (not (=> true (= (chop (- x (chop y))) (chop (- x y)) ) ) ))
+    // (check-sat)
+    // (pop)
+    rule X -Word chop(Y) => chop(X -Int Y) [simplification]
+
+    // ### end-pack-pass-rough
+
+    rule ADDR in (SetItem(I) REST) => ADDR in REST requires #notPrecompileAddress(ADDR) andBool notBool #notPrecompileAddress(I) [simplification]
+
+    // This proof ends up with side-conditions which look like this:
+    // Tic ==K 0 andBool 0 ==K maxUInt48 &Int (#lookup(STORAGE, ADDR) /Int pow160) andBool Tic ==K maxUInt48 &Int (#lookup(STORAGE, ADDR) /Int pow160)
+    // So we need this rule to do the structural simplification because the Java backend will not use this string of equalities to do the simplification directly.
+    rule #WordPackAddrUInt48UInt48(ADDR, maxUInt48 &Int (ADDR_UINT48_UINT48 /Int pow160), UINT48_2) => #WordPackAddrUInt48UInt48(ADDR, 0, UINT48_2) requires maxUInt48 &Int (ADDR_UINT48_UINT48 /Int pow160) ==Int 0 [simplification]
+
+
+
+  // ########################
+  // Map
+  // ########################
+
+    // ### PERFORMANCE: vat-deny-diff-fail-rough
+    // 27.21m -> 3.16m
+
+    rule M:Memory [ K <- V ]             [ K' <- V' ] => M [ K' <- V' ] [ K <- V ]    requires K' <Int K                           [simplification]
+    rule M:Memory [ K := BUF:ByteArray ] [ K' <- V' ] => M [ K' <- V' ] [ K := BUF ]  requires K' <Int K 
+                                                                                        orBool K +Int #sizeByteArray(BUF) <=Int K' [simplification]
+
+    // ### dsvalue-read-pass
+
+    rule M [ K <- V ] => M requires #lookup(M, K) ==Int V [simplification]
+
+    // ### flapper-yank-pass-rough
+
+    rule M:Memory [ K := BUF:ByteArray ] [ K' := BUF':ByteArray ] => M [ K := (BUF [ 0 .. K' -Int K ]) ] [ K' := BUF' ]
+      requires K <Int K'
+       andBool K' <Int K +Int #sizeByteArray(BUF)
+       andBool K +Int #sizeByteArray(BUF) <Int K' +Int #sizeByteArray(BUF')
+      [simplification]
+
+    rule M:Map [ K1 <- _ ] [ K2 <- V2 ] [ K1 <- V1' ] => M [ K1 <- V1' ] [ K2 <- V2 ] requires K1 =/=Int K2 [simplification]
+
+    // ### end-cage-ilk-pass-rough
+
+    rule M:Memory [ K1 := (BUF11 ++ BUF12) ] [ K2 := BUF2 ] => M [ K1 +Int #sizeByteArray(BUF11) := BUF12 ] [ K2 := BUF2 ]
+      requires K2 <=Int K1
+       andBool K1 +Int #sizeByteArray(BUF11) <=Int K2 +Int #sizeByteArray(BUF2)
+      [simplification]
+
+  // ########################
+  // Arithmetic
+  // ########################
+
+    // ### dstoken-transferfrom-fail-rough
+
+    rule chop(N +Int M) <Int N => true  requires #rangeUInt(256, N) 
+                                         andBool #rangeUInt(256, M)
+                                         andBool notBool #rangeUInt(256, N +Int M)
+                                        [simplification]
+
+    // ### flipper-bids-pass-rough
+
+    // This lemma is considered "safe enough" because `keccak` is a hash function over a large range and is very unlikely to overflow.
+    // Note that this case comes from a solidity struct being accessed (hence the integer offsets), so it's an assumption built into the Solidity compiler anyway.
+    rule chop(keccak(BA) +Int N) => keccak(BA) +Int N requires 0 <=Int N andBool N <Int 6 [simplification]
+
+    rule sgn(chop(X)) ==Int -1 => X <Int 0  requires #rangeSInt(256, X) [simplification]
 
     // ### vat-mului-pass
 
@@ -275,68 +406,9 @@ module LEMMAS-MCD-COMMON
 
     rule chop(X +Int chop(Y)) => chop(X +Int Y) [simplification]
 
-    // ### vow-flog-fail-rough
-
-    rule X -Word Y <=Int X => #rangeUInt(256, X -Int Y) requires #rangeUInt(256, X) andBool #rangeUInt(256, Y) [simplification]
-    rule 0 <=Int X +Int Y => true requires 0 <=Int X andBool 0 <=Int Y                                         [simplification]
-
     // ### flipper-addu48u48-fail-rough
 
     rule maxUInt48 &Int (X +Int Y) <Int X => true requires #rangeUInt(48, X) andBool #rangeUInt(48, Y) andBool notBool (X +Int Y <Int pow48) [simplification]
-
-    // ### vat-subui-fail-rough
-
-    // ;(set-option :smt.mbqi true)
-    //
-    // ; 2^256
-    // (declare-const pow256 Int)
-    // (assert (= pow256 115792089237316195423570985008687907853269984665640564039457584007913129639936))
-    //
-    // ; 2^255
-    // (declare-const pow255 Int)
-    // (assert (= pow255 57896044618658097711785492504343953926634992332820282019728792003956564819968))
-    //
-    // ; sgn
-    // (declare-fun sgn (Int) Int)
-    // (assert (forall ((x Int)) (=> (and (>= x 0)      (< x pow255)) (= (sgn x)  1))))
-    // (assert (forall ((x Int)) (=> (and (>= x pow255) (< x pow256)) (= (sgn x) -1))))
-    //
-    // ; s<Word
-    // (declare-fun slt (Int Int) Bool)
-    // (assert (forall ((x Int) (y Int)) (=> (and (= (sgn x)  1) (= (sgn y)  1)) (= (slt x y) (< x y)))))
-    // (assert (forall ((x Int) (y Int)) (=> (and (= (sgn x)  1) (= (sgn y) -1)) (= (slt x y) false))))
-    // (assert (forall ((x Int) (y Int)) (=> (and (= (sgn x) -1) (= (sgn y)  1)) (= (slt x y) true))))
-    // (assert (forall ((x Int) (y Int)) (=> (and (= (sgn x) -1) (= (sgn y) -1)) (= (slt x y) (> x y)))))
-    //
-    // ; chop
-    // (define-fun chop ((x Int)) Int (mod x pow256))
-    // ;(simplify (chop -1))
-    //
-    // ; /Word
-    // (define-fun zdiv ((x Int) (y Int)) Int (ite (= y 0) 0 (div x y)))
-    //
-    // ; /sWord
-    // (declare-fun sdiv (Int Int) Int)
-    // (assert (forall ((x Int) (y Int)) (=> (> (* (sgn x) (sgn y)) 0) (= (sdiv x y)    (zdiv (abs x) (abs y)) ))))
-    // (assert (forall ((x Int) (y Int)) (=> (< (* (sgn x) (sgn y)) 0) (= (sdiv x y) (- (zdiv (abs x) (abs y)))))))
-    //
-    // ; uint256
-    // (define-fun uint256 ((x Int)) Bool (and (>= x 0) (< x pow256)))
-    //
-    // ; sint256
-    // (define-fun sint256 ((x Int)) Bool (and (>= x (- pow255)) (< x pow255)))
-    //
-    // ;;;;
-    //
-    // (declare-const x Int)
-    // (declare-const y Int)
-
-    // Via Z3 4.7.1:
-    // (push)
-    // (assert (not (=> (uint256 x) (= (slt 0 x) (and (= (sgn x) 1) (not (= x 0))) ) ) ))
-    // (check-sat)
-    // (pop)
-    rule 0 s<Word X => bool2Word(sgn(X) ==Int 1 andBool X =/=Int 0) requires #rangeUInt(256, X) [simplification]
 
     // Via Z3 4.7.1:
     // (push)
@@ -344,19 +416,6 @@ module LEMMAS-MCD-COMMON
     // (check-sat)
     // (pop)
     rule sgn(chop(Y)) ==K 1 => 0 <=Int Y requires #rangeSInt(256, Y) [simplification]
-
-    // ### vat-subui-pass-rough
-
-    // Via Z3 4.7.1:
-    // (push)
-    // (assert (not (=> true (= (chop (- x (chop y))) (chop (- x y)) ) ) ))
-    // (check-sat)
-    // (pop)
-    rule X -Word chop(Y) => chop(X -Int Y) [simplification]
-
-    // ### end-pack-pass-rough
-
-    rule ADDR in (SetItem(I) REST) => ADDR in REST requires #notPrecompileAddress(ADDR) andBool notBool #notPrecompileAddress(I) [simplification]
 
     // ### vat-subui-pass
 
@@ -376,18 +435,7 @@ module LEMMAS-MCD-COMMON
 
     rule chop(X *Int Y) => X *Int Y requires 0 <=Int X andBool 0 <=Int Y andBool X *Int Y <Int pow256 [simplification]
 
-    // This proof ends up with side-conditions which look like this:
-    // Tic ==K 0 andBool 0 ==K maxUInt48 &Int (#lookup(STORAGE, ADDR) /Int pow160) andBool Tic ==K maxUInt48 &Int (#lookup(STORAGE, ADDR) /Int pow160)
-    // So we need this rule to do the structural simplification because the Java backend will not use this string of equalities to do the simplification directly.
-    rule #WordPackAddrUInt48UInt48(ADDR, maxUInt48 &Int (ADDR_UINT48_UINT48 /Int pow160), UINT48_2) => #WordPackAddrUInt48UInt48(ADDR, 0, UINT48_2) requires maxUInt48 &Int (ADDR_UINT48_UINT48 /Int pow160) ==Int 0 [simplification]
-
     // ### flapper-yank-pass-rough
-
-    rule M:Memory [ K := BUF:ByteArray ] [ K' := BUF':ByteArray ] => M [ K := (BUF [ 0 .. K' -Int K ]) ] [ K' := BUF' ]
-      requires K <Int K'
-       andBool K' <Int K +Int #sizeByteArray(BUF)
-       andBool K +Int #sizeByteArray(BUF) <Int K' +Int #sizeByteArray(BUF')
-      [simplification]
 
     rule X <Int X -Int Y => false requires 0 <=Int Y [simplification]
     rule X +Int Y <Int X => false requires 0 <=Int Y [simplification]
@@ -399,15 +447,6 @@ module LEMMAS-MCD-COMMON
 
     rule ((K |-> _) REST) [ K' <- undef ] => REST                             requires K  ==K K' [simplification]
     rule ((K |-> V) REST) [ K' <- undef ] => (K |-> V) (REST [ K' <- undef ]) requires K =/=K K' [simplification]
-
-    rule M:Map [ K1 <- _ ] [ K2 <- V2 ] [ K1 <- V1' ] => M [ K1 <- V1' ] [ K2 <- V2 ] requires K1 =/=Int K2 [simplification]
-
-    // ### end-cage-ilk-pass-rough
-
-    rule M:Memory [ K1 := (BUF11 ++ BUF12) ] [ K2 := BUF2 ] => M [ K1 +Int #sizeByteArray(BUF11) := BUF12 ] [ K2 := BUF2 ]
-      requires K2 <=Int K1
-       andBool K1 +Int #sizeByteArray(BUF11) <=Int K2 +Int #sizeByteArray(BUF2)
-      [simplification]
 
     // ### vat-frob-diff-zero-dart-pass-rough
 

--- a/tests/specs/mcd/verification.k
+++ b/tests/specs/mcd/verification.k
@@ -11,463 +11,463 @@ module VERIFICATION
 
 endmodule
 
-module LEMMAS-MCD
-    imports LEMMAS-MCD-HASKELL
-    imports LEMMAS-MCD-JAVA
+// module LEMMAS-MCD
+//     imports LEMMAS-MCD-HASKELL
+//     imports LEMMAS-MCD-JAVA
 
-endmodule
+// endmodule
 
-module LEMMAS-MCD-SYNTAX
-    imports LEMMAS
+// module LEMMAS-MCD-SYNTAX
+//     imports LEMMAS
 
-  // ########################
-  // Constants
-  // ########################
+//   // ########################
+//   // Constants
+//   // ########################
 
-    syntax Int ::= "#Wad" | "#Ray" | "#Rad"
- // ---------------------------------------
-    rule #Wad => 1000000000000000000                            [macro]
-    rule #Ray => 1000000000000000000000000000                   [macro]
-    rule #Rad => 1000000000000000000000000000000000000000000000 [macro]
+//     syntax Int ::= "#Wad" | "#Ray" | "#Rad"
+//  // ---------------------------------------
+//     rule #Wad => 1000000000000000000                            [macro]
+//     rule #Ray => 1000000000000000000000000000                   [macro]
+//     rule #Rad => 1000000000000000000000000000000000000000000000 [macro]
 
-  // ########################
-  // Word Reasoning
-  // ########################
+//   // ########################
+//   // Word Reasoning
+//   // ########################
 
-    syntax Bool ::= #notPrecompileAddress ( Int ) [function]
- // --------------------------------------------------------
-    rule #notPrecompileAddress ( X ) => 0 ==Int X orBool (10 <=Int X andBool #rangeAddress(X))
+//     syntax Bool ::= #notPrecompileAddress ( Int ) [function]
+//  // --------------------------------------------------------
+//     rule #notPrecompileAddress ( X ) => 0 ==Int X orBool (10 <=Int X andBool #rangeAddress(X))
 
-    syntax Int ::= #string2Word ( String ) [function]
- // -------------------------------------------------
-    rule #string2Word(S) => #asWord(#padRightToWidth(32, #parseByteStackRaw(S)))
+//     syntax Int ::= #string2Word ( String ) [function]
+//  // -------------------------------------------------
+//     rule #string2Word(S) => #asWord(#padRightToWidth(32, #parseByteStackRaw(S)))
 
-    syntax Int ::= nthbyteof ( Int , Int , Int ) [function, smtlib(smt_nthbyteof), proj]
- // ------------------------------------------------------------------------------------
-    rule nthbyteof(V, I, N) => nthbyteof(V /Int 256, I, N -Int 1) when N  >Int (I +Int 1) [concrete]
-    rule nthbyteof(V, I, N) =>           V modInt 256             when N ==Int (I +Int 1) [concrete]
+//     syntax Int ::= nthbyteof ( Int , Int , Int ) [function, smtlib(smt_nthbyteof), proj]
+//  // ------------------------------------------------------------------------------------
+//     rule nthbyteof(V, I, N) => nthbyteof(V /Int 256, I, N -Int 1) when N  >Int (I +Int 1) [concrete]
+//     rule nthbyteof(V, I, N) =>           V modInt 256             when N ==Int (I +Int 1) [concrete]
 
-  // ########################
-  // Buffer Reasoning
-  // ########################
+//   // ########################
+//   // Buffer Reasoning
+//   // ########################
 
-    syntax ByteArray ::= #asByteStackInWidth    ( Int, Int )                 [function]
-                       | #asByteStackInWidthaux ( Int, Int, Int, ByteArray ) [function]
- // -----------------------------------------------------------------------------------
-    rule #asByteStackInWidth(X, N) => #asByteStackInWidthaux(X, N -Int 1, N, .ByteArray)
+//     syntax ByteArray ::= #asByteStackInWidth    ( Int, Int )                 [function]
+//                        | #asByteStackInWidthaux ( Int, Int, Int, ByteArray ) [function]
+//  // -----------------------------------------------------------------------------------
+//     rule #asByteStackInWidth(X, N) => #asByteStackInWidthaux(X, N -Int 1, N, .ByteArray)
 
-    rule #asByteStackInWidthaux(X, I, N, WS) => #asByteStackInWidthaux(X, I -Int 1, N, nthbyteof(X, I, N) : WS) when I >Int 0
-    rule #asByteStackInWidthaux(X, 0, N, WS) => nthbyteof(X, 0, N) : WS
+//     rule #asByteStackInWidthaux(X, I, N, WS) => #asByteStackInWidthaux(X, I -Int 1, N, nthbyteof(X, I, N) : WS) when I >Int 0
+//     rule #asByteStackInWidthaux(X, 0, N, WS) => nthbyteof(X, 0, N) : WS
 
-  // ########################
-  // Arithmetic
-  // ########################
+//   // ########################
+//   // Arithmetic
+//   // ########################
 
-    syntax Int ::= #rmul ( Int , Int ) [function, smtlib(smt_rmul)]
- // ---------------------------------------------------------------
-    rule #rmul(X, Y) => (X *Int Y) /Int #Ray
+//     syntax Int ::= #rmul ( Int , Int ) [function, smtlib(smt_rmul)]
+//  // ---------------------------------------------------------------
+//     rule #rmul(X, Y) => (X *Int Y) /Int #Ray
 
-endmodule
+// endmodule
 
-module LEMMAS-MCD-HASKELL [symbolic, kore]
-    imports LEMMAS-MCD-COMMON
+// module LEMMAS-MCD-HASKELL [symbolic, kore]
+//     imports LEMMAS-MCD-COMMON
 
-  // ########################
-  // Arithmetic
-  // ########################
+//   // ########################
+//   // Arithmetic
+//   // ########################
 
-    // ### functional
+//     // ### functional
 
-    rule chop(Y) => Y +Int pow256 requires #rangeSInt(256, Y) andBool Y <Int 0 [simplification]
+//     rule chop(Y) => Y +Int pow256 requires #rangeSInt(256, Y) andBool Y <Int 0 [simplification]
 
-  // ########################
-  // Map
-  // ########################
+//   // ########################
+//   // Map
+//   // ########################
 
-    // ### flapper-yank-pass-rough
+//     // ### flapper-yank-pass-rough
 
-    rule #range(M:Memory [ K <- V ]                        , START, WIDTH) => #range(M [ K := (V : .ByteArray) ], START, WIDTH)  requires K +Int 1                    ==Int START +Int WIDTH andBool START <=Int K andBool 0 <Int WIDTH andBool 0 <=Int START [concrete(K    , V     ), simplification]
-    rule #range(M:Memory [ K <- V ] [ K' := VS':ByteArray ], START, WIDTH) => #range(M [ K := (V : VS')        ], START, WIDTH)  requires K' +Int #sizeByteArray(VS') ==Int START +Int WIDTH andBool START <=Int K andBool 0 <Int WIDTH andBool 0 <=Int START 
-                                                                                                                                  andBool K +Int 1                    ==Int K'                                                                                [concrete(K, K', V, VS'), simplification]
+//     rule #range(M:Memory [ K <- V ]                        , START, WIDTH) => #range(M [ K := (V : .ByteArray) ], START, WIDTH)  requires K +Int 1                    ==Int START +Int WIDTH andBool START <=Int K andBool 0 <Int WIDTH andBool 0 <=Int START [concrete(K    , V     ), simplification]
+//     rule #range(M:Memory [ K <- V ] [ K' := VS':ByteArray ], START, WIDTH) => #range(M [ K := (V : VS')        ], START, WIDTH)  requires K' +Int #sizeByteArray(VS') ==Int START +Int WIDTH andBool START <=Int K andBool 0 <Int WIDTH andBool 0 <=Int START 
+//                                                                                                                                   andBool K +Int 1                    ==Int K'                                                                                [concrete(K, K', V, VS'), simplification]
 
-endmodule
+// endmodule
 
-module LEMMAS-MCD-JAVA [symbolic, kast]
-    imports LEMMAS-MCD-COMMON
+// module LEMMAS-MCD-JAVA [symbolic, kast]
+//     imports LEMMAS-MCD-COMMON
 
-  // ########################
-  // Range
-  // ########################
+//   // ########################
+//   // Range
+//   // ########################
 
-    // ### flapper-yank-pass-rough
+//     // ### flapper-yank-pass-rough
 
-    rule #range(M:Memory [ K <- V ]                        , START, WIDTH) => #range(M [ K := (V : .ByteArray) ], START, WIDTH)  requires #isConcrete(K)  andBool #isConcrete(V) andBool START <=Int K andBool 0 <Int WIDTH andBool 0 <=Int START andBool K +Int 1                    ==Int START +Int WIDTH [simplification]
-    rule #range(M:Memory [ K <- V ] [ K' := VS':ByteArray ], START, WIDTH) => #range(M [ K := (V : VS')        ], START, WIDTH)  requires #isConcrete(K)  andBool #isConcrete(V) andBool START <=Int K andBool 0 <Int WIDTH andBool 0 <=Int START andBool K +Int 1                    ==Int K'              
-                                                                                                                                  andBool #isConcrete(K') andBool #isConcrete(VS')                                                                andBool K' +Int #sizeByteArray(VS') ==Int START +Int WIDTH [simplification] 
+//     rule #range(M:Memory [ K <- V ]                        , START, WIDTH) => #range(M [ K := (V : .ByteArray) ], START, WIDTH)  requires #isConcrete(K)  andBool #isConcrete(V) andBool START <=Int K andBool 0 <Int WIDTH andBool 0 <=Int START andBool K +Int 1                    ==Int START +Int WIDTH [simplification]
+//     rule #range(M:Memory [ K <- V ] [ K' := VS':ByteArray ], START, WIDTH) => #range(M [ K := (V : VS')        ], START, WIDTH)  requires #isConcrete(K)  andBool #isConcrete(V) andBool START <=Int K andBool 0 <Int WIDTH andBool 0 <=Int START andBool K +Int 1                    ==Int K'              
+//                                                                                                                                   andBool #isConcrete(K') andBool #isConcrete(VS')                                                                andBool K' +Int #sizeByteArray(VS') ==Int START +Int WIDTH [simplification] 
 
-endmodule
+// endmodule
 
-module LEMMAS-MCD-COMMON
-    imports LEMMAS-MCD-SYNTAX
-    imports INFINITE-GAS
-    imports WORD-PACK
+// module LEMMAS-MCD-COMMON
+//     imports LEMMAS-MCD-SYNTAX
+//     imports INFINITE-GAS
+//     imports WORD-PACK
 
-  // ########################
-  // Buffer Reasoning
-  // ########################
+//   // ########################
+//   // Buffer Reasoning
+//   // ########################
 
-    // ### vat-move-diff
+//     // ### vat-move-diff
 
-    rule (W0 : WS) [ 0     .. WIDTH ] => W0 : (WS [ 0 .. WIDTH -Int 1 ])  requires 0 <Int WIDTH [simplification]
-    rule (_  : WS) [ START .. WIDTH ] => WS [ START -Int 1 .. WIDTH ]     requires 0 <Int START [simplification]
+//     rule (W0 : WS) [ 0     .. WIDTH ] => W0 : (WS [ 0 .. WIDTH -Int 1 ])  requires 0 <Int WIDTH [simplification]
+//     rule (_  : WS) [ START .. WIDTH ] => WS [ START -Int 1 .. WIDTH ]     requires 0 <Int START [simplification]
 
-    // ### cat-exhaustiveness
+//     // ### cat-exhaustiveness
 
-    rule WS [ START .. WIDTH ] [ 0 .. WIDTH' ]  => WS [ START .. WIDTH' ]  requires WIDTH' <=Int WIDTH [simplification]
+//     rule WS [ START .. WIDTH ] [ 0 .. WIDTH' ]  => WS [ START .. WIDTH' ]  requires WIDTH' <=Int WIDTH [simplification]
 
-    rule ( BA1:ByteArray ++ BA2:ByteArray ) ++ BA3:ByteArray => BA1 ++ ( BA2 ++ BA3 ) [simplification]
+//     rule ( BA1:ByteArray ++ BA2:ByteArray ) ++ BA3:ByteArray => BA1 ++ ( BA2 ++ BA3 ) [simplification]
 
-  // ########################
-  // Word Reasoning
-  // ########################
+//   // ########################
+//   // Word Reasoning
+//   // ########################
 
-    // ### cat-file-addr-pass-rough
+//     // ### cat-file-addr-pass-rough
 
-    rule maskWordPackAddrUInt48UInt48_1 &Int ADDR => 0  requires #rangeAddress(ADDR) [simplification]
+//     rule maskWordPackAddrUInt48UInt48_1 &Int ADDR => 0  requires #rangeAddress(ADDR) [simplification]
 
-    // ### PERFORMANCE: dai-adduu-fail-rough
-    // 99s -> 48s
+//     // ### PERFORMANCE: dai-adduu-fail-rough
+//     // 99s -> 48s
 
-    rule #sizeWordStack(WS, N) => #sizeWordStack(WS, 0) +Int N  requires N =/=Int 0 [simplification]
+//     rule #sizeWordStack(WS, N) => #sizeWordStack(WS, 0) +Int N  requires N =/=Int 0 [simplification]
 
-    // ### vat-addui-fail-rough
+//     // ### vat-addui-fail-rough
 
-    // Proof:
-    // case sgn(X) ==Int  1
-    //      X s<Word 0
-    //   => X <Word 0           // sgn(X) ==Int 1 andBool sgn(0) ==Int 1
-    //   => bool2Word(false)    // #rangeUInt(256, X)
-    // case sgn(X) ==Int -1
-    //      X s<Word 0
-    //   => bool2Word(true)     // sgn(X) ==Int -1 andBool sgn(0) ==Int 1
-    //
-    // Via Z3 4.8.7:
-    // ; 2^256
-    // (declare-const pow256 Int)
-    // (assert (= pow256 115792089237316195423570985008687907853269984665640564039457584007913129639936))
-    //
-    // ; 2^255
-    // (declare-const pow255 Int)
-    // (assert (= pow255 57896044618658097711785492504343953926634992332820282019728792003956564819968))
-    //
-    // ; sgn
-    // (declare-fun sgn (Int) Int)
-    // (assert (forall ((x Int)) (=> (and (>= x 0)      (< x pow255)) (= (sgn x)  1))))
-    // (assert (forall ((x Int)) (=> (and (>= x pow255) (< x pow256)) (= (sgn x) -1))))
-    //
-    // ; s<Word
-    // (declare-fun slt (Int Int) Bool)
-    // (assert (forall ((x Int) (y Int)) (=> (and (= (sgn x)  1) (= (sgn y)  1)) (= (slt x y) (< x y)))))
-    // (assert (forall ((x Int) (y Int)) (=> (and (= (sgn x)  1) (= (sgn y) -1)) (= (slt x y) false))))
-    // (assert (forall ((x Int) (y Int)) (=> (and (= (sgn x) -1) (= (sgn y)  1)) (= (slt x y) true))))
-    // (assert (forall ((x Int) (y Int)) (=> (and (= (sgn x) -1) (= (sgn y) -1)) (= (slt x y) (> x y)))))
-    //
-    // ;;;; proof
-    //
-    // ; uint256
-    // (declare-const x Int)
-    // (assert (and (>= x 0) (< x pow256)))
-    //
-    // (assert (not
-    //     (= (slt x 0) (= (sgn x) -1))
-    // ))
-    // (check-sat)
-    rule X s<Word 0 => bool2Word(sgn(X) ==Int -1)  requires #rangeUInt(256, X) [simplification]
+//     // Proof:
+//     // case sgn(X) ==Int  1
+//     //      X s<Word 0
+//     //   => X <Word 0           // sgn(X) ==Int 1 andBool sgn(0) ==Int 1
+//     //   => bool2Word(false)    // #rangeUInt(256, X)
+//     // case sgn(X) ==Int -1
+//     //      X s<Word 0
+//     //   => bool2Word(true)     // sgn(X) ==Int -1 andBool sgn(0) ==Int 1
+//     //
+//     // Via Z3 4.8.7:
+//     // ; 2^256
+//     // (declare-const pow256 Int)
+//     // (assert (= pow256 115792089237316195423570985008687907853269984665640564039457584007913129639936))
+//     //
+//     // ; 2^255
+//     // (declare-const pow255 Int)
+//     // (assert (= pow255 57896044618658097711785492504343953926634992332820282019728792003956564819968))
+//     //
+//     // ; sgn
+//     // (declare-fun sgn (Int) Int)
+//     // (assert (forall ((x Int)) (=> (and (>= x 0)      (< x pow255)) (= (sgn x)  1))))
+//     // (assert (forall ((x Int)) (=> (and (>= x pow255) (< x pow256)) (= (sgn x) -1))))
+//     //
+//     // ; s<Word
+//     // (declare-fun slt (Int Int) Bool)
+//     // (assert (forall ((x Int) (y Int)) (=> (and (= (sgn x)  1) (= (sgn y)  1)) (= (slt x y) (< x y)))))
+//     // (assert (forall ((x Int) (y Int)) (=> (and (= (sgn x)  1) (= (sgn y) -1)) (= (slt x y) false))))
+//     // (assert (forall ((x Int) (y Int)) (=> (and (= (sgn x) -1) (= (sgn y)  1)) (= (slt x y) true))))
+//     // (assert (forall ((x Int) (y Int)) (=> (and (= (sgn x) -1) (= (sgn y) -1)) (= (slt x y) (> x y)))))
+//     //
+//     // ;;;; proof
+//     //
+//     // ; uint256
+//     // (declare-const x Int)
+//     // (assert (and (>= x 0) (< x pow256)))
+//     //
+//     // (assert (not
+//     //     (= (slt x 0) (= (sgn x) -1))
+//     // ))
+//     // (check-sat)
+//     rule X s<Word 0 => bool2Word(sgn(X) ==Int -1)  requires #rangeUInt(256, X) [simplification]
 
-    // ### vow-flog-fail-rough
+//     // ### vow-flog-fail-rough
 
-    rule X -Word Y <=Int X => #rangeUInt(256, X -Int Y) requires #rangeUInt(256, X) andBool #rangeUInt(256, Y) [simplification]
+//     rule X -Word Y <=Int X => #rangeUInt(256, X -Int Y) requires #rangeUInt(256, X) andBool #rangeUInt(256, Y) [simplification]
     
-    rule 0 <=Int X +Int Y => true requires 0 <=Int X andBool 0 <=Int Y [simplification]
+//     rule 0 <=Int X +Int Y => true requires 0 <=Int X andBool 0 <=Int Y [simplification]
 
-    // ### vat-subui-fail-rough
+//     // ### vat-subui-fail-rough
 
-    // ;(set-option :smt.mbqi true)
-    //
-    // ; 2^256
-    // (declare-const pow256 Int)
-    // (assert (= pow256 115792089237316195423570985008687907853269984665640564039457584007913129639936))
-    //
-    // ; 2^255
-    // (declare-const pow255 Int)
-    // (assert (= pow255 57896044618658097711785492504343953926634992332820282019728792003956564819968))
-    //
-    // ; sgn
-    // (declare-fun sgn (Int) Int)
-    // (assert (forall ((x Int)) (=> (and (>= x 0)      (< x pow255)) (= (sgn x)  1))))
-    // (assert (forall ((x Int)) (=> (and (>= x pow255) (< x pow256)) (= (sgn x) -1))))
-    //
-    // ; s<Word
-    // (declare-fun slt (Int Int) Bool)
-    // (assert (forall ((x Int) (y Int)) (=> (and (= (sgn x)  1) (= (sgn y)  1)) (= (slt x y) (< x y)))))
-    // (assert (forall ((x Int) (y Int)) (=> (and (= (sgn x)  1) (= (sgn y) -1)) (= (slt x y) false))))
-    // (assert (forall ((x Int) (y Int)) (=> (and (= (sgn x) -1) (= (sgn y)  1)) (= (slt x y) true))))
-    // (assert (forall ((x Int) (y Int)) (=> (and (= (sgn x) -1) (= (sgn y) -1)) (= (slt x y) (> x y)))))
-    //
-    // ; chop
-    // (define-fun chop ((x Int)) Int (mod x pow256))
-    // ;(simplify (chop -1))
-    //
-    // ; /Word
-    // (define-fun zdiv ((x Int) (y Int)) Int (ite (= y 0) 0 (div x y)))
-    //
-    // ; /sWord
-    // (declare-fun sdiv (Int Int) Int)
-    // (assert (forall ((x Int) (y Int)) (=> (> (* (sgn x) (sgn y)) 0) (= (sdiv x y)    (zdiv (abs x) (abs y)) ))))
-    // (assert (forall ((x Int) (y Int)) (=> (< (* (sgn x) (sgn y)) 0) (= (sdiv x y) (- (zdiv (abs x) (abs y)))))))
-    //
-    // ; uint256
-    // (define-fun uint256 ((x Int)) Bool (and (>= x 0) (< x pow256)))
-    //
-    // ; sint256
-    // (define-fun sint256 ((x Int)) Bool (and (>= x (- pow255)) (< x pow255)))
-    //
-    // ;;;;
-    //
-    // (declare-const x Int)
-    // (declare-const y Int)
+//     // ;(set-option :smt.mbqi true)
+//     //
+//     // ; 2^256
+//     // (declare-const pow256 Int)
+//     // (assert (= pow256 115792089237316195423570985008687907853269984665640564039457584007913129639936))
+//     //
+//     // ; 2^255
+//     // (declare-const pow255 Int)
+//     // (assert (= pow255 57896044618658097711785492504343953926634992332820282019728792003956564819968))
+//     //
+//     // ; sgn
+//     // (declare-fun sgn (Int) Int)
+//     // (assert (forall ((x Int)) (=> (and (>= x 0)      (< x pow255)) (= (sgn x)  1))))
+//     // (assert (forall ((x Int)) (=> (and (>= x pow255) (< x pow256)) (= (sgn x) -1))))
+//     //
+//     // ; s<Word
+//     // (declare-fun slt (Int Int) Bool)
+//     // (assert (forall ((x Int) (y Int)) (=> (and (= (sgn x)  1) (= (sgn y)  1)) (= (slt x y) (< x y)))))
+//     // (assert (forall ((x Int) (y Int)) (=> (and (= (sgn x)  1) (= (sgn y) -1)) (= (slt x y) false))))
+//     // (assert (forall ((x Int) (y Int)) (=> (and (= (sgn x) -1) (= (sgn y)  1)) (= (slt x y) true))))
+//     // (assert (forall ((x Int) (y Int)) (=> (and (= (sgn x) -1) (= (sgn y) -1)) (= (slt x y) (> x y)))))
+//     //
+//     // ; chop
+//     // (define-fun chop ((x Int)) Int (mod x pow256))
+//     // ;(simplify (chop -1))
+//     //
+//     // ; /Word
+//     // (define-fun zdiv ((x Int) (y Int)) Int (ite (= y 0) 0 (div x y)))
+//     //
+//     // ; /sWord
+//     // (declare-fun sdiv (Int Int) Int)
+//     // (assert (forall ((x Int) (y Int)) (=> (> (* (sgn x) (sgn y)) 0) (= (sdiv x y)    (zdiv (abs x) (abs y)) ))))
+//     // (assert (forall ((x Int) (y Int)) (=> (< (* (sgn x) (sgn y)) 0) (= (sdiv x y) (- (zdiv (abs x) (abs y)))))))
+//     //
+//     // ; uint256
+//     // (define-fun uint256 ((x Int)) Bool (and (>= x 0) (< x pow256)))
+//     //
+//     // ; sint256
+//     // (define-fun sint256 ((x Int)) Bool (and (>= x (- pow255)) (< x pow255)))
+//     //
+//     // ;;;;
+//     //
+//     // (declare-const x Int)
+//     // (declare-const y Int)
 
-    // Via Z3 4.7.1:
-    // (push)
-    // (assert (not (=> (uint256 x) (= (slt 0 x) (and (= (sgn x) 1) (not (= x 0))) ) ) ))
-    // (check-sat)
-    // (pop)
-    rule 0 s<Word X => bool2Word(sgn(X) ==Int 1 andBool X =/=Int 0) requires #rangeUInt(256, X) [simplification]
+//     // Via Z3 4.7.1:
+//     // (push)
+//     // (assert (not (=> (uint256 x) (= (slt 0 x) (and (= (sgn x) 1) (not (= x 0))) ) ) ))
+//     // (check-sat)
+//     // (pop)
+//     rule 0 s<Word X => bool2Word(sgn(X) ==Int 1 andBool X =/=Int 0) requires #rangeUInt(256, X) [simplification]
 
-    // ### vat-subui-pass-rough
+//     // ### vat-subui-pass-rough
 
-    // Via Z3 4.7.1:
-    // (push)
-    // (assert (not (=> true (= (chop (- x (chop y))) (chop (- x y)) ) ) ))
-    // (check-sat)
-    // (pop)
-    rule X -Word chop(Y) => chop(X -Int Y) [simplification]
+//     // Via Z3 4.7.1:
+//     // (push)
+//     // (assert (not (=> true (= (chop (- x (chop y))) (chop (- x y)) ) ) ))
+//     // (check-sat)
+//     // (pop)
+//     rule X -Word chop(Y) => chop(X -Int Y) [simplification]
 
-    // ### end-pack-pass-rough
+//     // ### end-pack-pass-rough
 
-    rule ADDR in (SetItem(I) REST) => ADDR in REST requires #notPrecompileAddress(ADDR) andBool notBool #notPrecompileAddress(I) [simplification]
+//     rule ADDR in (SetItem(I) REST) => ADDR in REST requires #notPrecompileAddress(ADDR) andBool notBool #notPrecompileAddress(I) [simplification]
 
-    // This proof ends up with side-conditions which look like this:
-    // Tic ==K 0 andBool 0 ==K maxUInt48 &Int (#lookup(STORAGE, ADDR) /Int pow160) andBool Tic ==K maxUInt48 &Int (#lookup(STORAGE, ADDR) /Int pow160)
-    // So we need this rule to do the structural simplification because the Java backend will not use this string of equalities to do the simplification directly.
-    rule #WordPackAddrUInt48UInt48(ADDR, maxUInt48 &Int (ADDR_UINT48_UINT48 /Int pow160), UINT48_2) => #WordPackAddrUInt48UInt48(ADDR, 0, UINT48_2) requires maxUInt48 &Int (ADDR_UINT48_UINT48 /Int pow160) ==Int 0 [simplification]
+//     // This proof ends up with side-conditions which look like this:
+//     // Tic ==K 0 andBool 0 ==K maxUInt48 &Int (#lookup(STORAGE, ADDR) /Int pow160) andBool Tic ==K maxUInt48 &Int (#lookup(STORAGE, ADDR) /Int pow160)
+//     // So we need this rule to do the structural simplification because the Java backend will not use this string of equalities to do the simplification directly.
+//     rule #WordPackAddrUInt48UInt48(ADDR, maxUInt48 &Int (ADDR_UINT48_UINT48 /Int pow160), UINT48_2) => #WordPackAddrUInt48UInt48(ADDR, 0, UINT48_2) requires maxUInt48 &Int (ADDR_UINT48_UINT48 /Int pow160) ==Int 0 [simplification]
 
-  // ########################
-  // Map
-  // ########################
+//   // ########################
+//   // Map
+//   // ########################
 
-    // ### PERFORMANCE: vat-deny-diff-fail-rough
-    // 27.21m -> 3.16m
+//     // ### PERFORMANCE: vat-deny-diff-fail-rough
+//     // 27.21m -> 3.16m
 
-    rule M:Memory [ K <- V ]             [ K' <- V' ] => M [ K' <- V' ] [ K <- V ]    requires K' <Int K                           [simplification]
-    rule M:Memory [ K := BUF:ByteArray ] [ K' <- V' ] => M [ K' <- V' ] [ K := BUF ]  requires K' <Int K 
-                                                                                        orBool K +Int #sizeByteArray(BUF) <=Int K' [simplification]
+//     rule M:Memory [ K <- V ]             [ K' <- V' ] => M [ K' <- V' ] [ K <- V ]    requires K' <Int K                           [simplification]
+//     rule M:Memory [ K := BUF:ByteArray ] [ K' <- V' ] => M [ K' <- V' ] [ K := BUF ]  requires K' <Int K 
+//                                                                                         orBool K +Int #sizeByteArray(BUF) <=Int K' [simplification]
 
-    // ### dsvalue-read-pass
+//     // ### dsvalue-read-pass
 
-    rule M [ K <- V ] => M requires #lookup(M, K) ==Int V [simplification]
+//     rule M [ K <- V ] => M requires #lookup(M, K) ==Int V [simplification]
 
-    // ### flapper-yank-pass-rough
+//     // ### flapper-yank-pass-rough
 
-    rule M:Memory [ K := BUF:ByteArray ] [ K' := BUF':ByteArray ] => M [ K := (BUF [ 0 .. K' -Int K ]) ] [ K' := BUF' ]
-      requires K <Int K'
-       andBool K' <Int K +Int #sizeByteArray(BUF)
-       andBool K +Int #sizeByteArray(BUF) <Int K' +Int #sizeByteArray(BUF')
-      [simplification]
+//     rule M:Memory [ K := BUF:ByteArray ] [ K' := BUF':ByteArray ] => M [ K := (BUF [ 0 .. K' -Int K ]) ] [ K' := BUF' ]
+//       requires K <Int K'
+//        andBool K' <Int K +Int #sizeByteArray(BUF)
+//        andBool K +Int #sizeByteArray(BUF) <Int K' +Int #sizeByteArray(BUF')
+//       [simplification]
 
-    rule M:Map [ K1 <- _ ] [ K2 <- V2 ] [ K1 <- V1' ] => M [ K1 <- V1' ] [ K2 <- V2 ] requires K1 =/=Int K2 [simplification]
+//     rule M:Map [ K1 <- _ ] [ K2 <- V2 ] [ K1 <- V1' ] => M [ K1 <- V1' ] [ K2 <- V2 ] requires K1 =/=Int K2 [simplification]
 
-    // ### end-cage-ilk-pass-rough
+//     // ### end-cage-ilk-pass-rough
 
-    rule M:Memory [ K1 := (BUF11 ++ BUF12) ] [ K2 := BUF2 ] => M [ K1 +Int #sizeByteArray(BUF11) := BUF12 ] [ K2 := BUF2 ]
-      requires K2 <=Int K1
-       andBool K1 +Int #sizeByteArray(BUF11) <=Int K2 +Int #sizeByteArray(BUF2)
-      [simplification]
+//     rule M:Memory [ K1 := (BUF11 ++ BUF12) ] [ K2 := BUF2 ] => M [ K1 +Int #sizeByteArray(BUF11) := BUF12 ] [ K2 := BUF2 ]
+//       requires K2 <=Int K1
+//        andBool K1 +Int #sizeByteArray(BUF11) <=Int K2 +Int #sizeByteArray(BUF2)
+//       [simplification]
 
-  // ########################
-  // Arithmetic
-  // ########################
+//   // ########################
+//   // Arithmetic
+//   // ########################
 
-    // ### dstoken-transferfrom-fail-rough
+//     // ### dstoken-transferfrom-fail-rough
 
-    rule chop(N +Int M) <Int N => true  requires #rangeUInt(256, N) 
-                                         andBool #rangeUInt(256, M)
-                                         andBool notBool #rangeUInt(256, N +Int M)
-                                        [simplification]
+//     rule chop(N +Int M) <Int N => true  requires #rangeUInt(256, N) 
+//                                          andBool #rangeUInt(256, M)
+//                                          andBool notBool #rangeUInt(256, N +Int M)
+//                                         [simplification]
 
-    // ### flipper-bids-pass-rough
+//     // ### flipper-bids-pass-rough
 
-    // This lemma is considered "safe enough" because `keccak` is a hash function over a large range and is very unlikely to overflow.
-    // Note that this case comes from a solidity struct being accessed (hence the integer offsets), so it's an assumption built into the Solidity compiler anyway.
-    rule chop(keccak(BA) +Int N) => keccak(BA) +Int N requires 0 <=Int N andBool N <Int 6 [simplification]
+//     // This lemma is considered "safe enough" because `keccak` is a hash function over a large range and is very unlikely to overflow.
+//     // Note that this case comes from a solidity struct being accessed (hence the integer offsets), so it's an assumption built into the Solidity compiler anyway.
+//     rule chop(keccak(BA) +Int N) => keccak(BA) +Int N requires 0 <=Int N andBool N <Int 6 [simplification]
 
-    rule sgn(chop(X)) ==Int -1 => X <Int 0  requires #rangeSInt(256, X) [simplification]
+//     rule sgn(chop(X)) ==Int -1 => X <Int 0  requires #rangeSInt(256, X) [simplification]
 
-    // ### vat-mului-pass
+//     // ### vat-mului-pass
 
-    rule chop(X *Int chop(Y)) => chop(X *Int Y) [simplification]
+//     rule chop(X *Int chop(Y)) => chop(X *Int Y) [simplification]
 
-    // Proof #rangeUInt(256, X) andBool #rangeSInt(256, Y) andBool #rangeSInt(256, X *Int Y) andBool Y =/=Int 0
-    //      chop(X *Int Y) /sWord chop(Y)
-    //   => #sgnInterp(sgn(chop(X *Int Y)) *Int sgn(chop(Y)), abs(chop(X *Int Y)) /Word abs(chop(Y)))
-    // Focus: sgn(chop(X *Int Y)) *Int sgn(chop(Y))
-    //      case 0 <=Int Y
-    //           sgn(chop(X *Int Y)) *Int sgn(chop(Y))
-    //        => sgn(chop(X *Int Y)) *Int sgn(Y)                     // chop(Y) ==Int Y
-    //        => sgn(X *Int Y) *Int sgn(Y)                           // 0 <=Int X andBool 0 <=Int Y
-    //        => 1 *Int 1                                            // 0 <=Int X *Int Y andBool 0 <=Int Y
-    //        => 1
-    //      case Y <Int 0
-    //           sgn(chop(X *Int Y)) *Int sgn(chop(Y))
-    //        => sgn(X *Int Y +Int pow256) *Int sgn(Y +Int pow256)   // chop(Y) ==Int Y +Int pow256
-    //        => -1 *Int -1                                          // X *Int Y <Int 0 andBool Y <Int 0
-    //        => 1
-    // Focus: abs(chop(X *Int Y)) /Word abs(chop(Y))
-    //      case 0 <=Int Y
-    //           abs(chop(X *Int Y)) /Word abs(chop(Y))
-    //        => abs(chop(X *Int Y)) /Int  abs(chop(Y))
-    //        => abs(X *Int Y) /Int abs(Y)                                                   // 0 <=Int X andBool 0 <=Int Y andBool #rangeSigne andBool chop(Y) ==Int Y
-    //        => X *Int Y /Int Y                                                             // #rangeSInt(256, X *Int Y) andBool 0 <=Int X *Int Y andBool #rangeSInt(256, Y) andBool 0 <=Int Y
-    //        => X
-    //      case Y <Int 0
-    //           abs(chop(X *Int Y)) /Int abs(chop(Y))
-    //        => abs(X *Int Y +Int pow256) /Int abs(Y +Int pow256)                           // #rangeSInt(256, X *Int Y) andBool chop(Y) ==Int Y +Int pow256
-    //        => (0 -Word (X *Int Y +Int pow256)) /Int (0 -Word (Y +Int pow256))             // #rangeSInt(256, X *Int Y) andBool X *Int Y <Int 0 andBool #rangeSInt(256, Y) andBool Y <Int 0
-    //        => (pow256 -Int (X *Int Y +Int pow256)) /Int (pow256 -Int (Y +Int pow256))     // 0 <Int (X *Int Y +Int pow256) andBool 0 <Int (Y +Int pow256)
-    //        => (X *Int Y) /Int Y
-    //        => X
-    //
-    // Via Z3 4.7.1:
-    // ; 2^4 and 2^3 instead of 2^256 and 2^255 for small model proof
-    // (declare-const pow256 Int)
-    // (assert (= pow256 16))
-    // (declare-const pow255 Int)
-    // (assert (= pow255 8))
-    //
-    // ; sgn
-    // (declare-fun sgn (Int) Int)
-    // (assert (forall ((x Int)) (=> (and (>= x 0)      (< x pow255)) (= (sgn x)  1))))
-    // (assert (forall ((x Int)) (=> (and (>= x pow255) (< x pow256)) (= (sgn x) -1))))
-    //
-    // ; s<Word
-    // (declare-fun slt (Int Int) Bool)
-    // (assert (forall ((x Int) (y Int)) (=> (and (= (sgn x)  1) (= (sgn y)  1)) (= (slt x y) (< x y)))))
-    // (assert (forall ((x Int) (y Int)) (=> (and (= (sgn x)  1) (= (sgn y) -1)) (= (slt x y) false))))
-    // (assert (forall ((x Int) (y Int)) (=> (and (= (sgn x) -1) (= (sgn y)  1)) (= (slt x y) true))))
-    // (assert (forall ((x Int) (y Int)) (=> (and (= (sgn x) -1) (= (sgn y) -1)) (= (slt x y) (> x y)))))
-    //
-    // ; chop
-    // (define-fun chop ((x Int)) Int (mod x pow256))
-    //
-    // ; /Word
-    // ;(define-fun zdiv ((x Int) (y Int)) Int (ite (= y 0) 0 (div x y)))
-    // (define-fun zdiv ((x Int) (y Int)) Int (div x y)) ; y is non-zero in the query below
-    //
-    // ; /sWord
-    // (declare-fun sdiv (Int Int) Int)
-    // (assert (forall ((x Int) (y Int)) (=> (> (* (sgn x) (sgn y)) 0) (= (sdiv x y)    (zdiv (abs x) (abs y)) ))))
-    // (assert (forall ((x Int) (y Int)) (=> (< (* (sgn x) (sgn y)) 0) (= (sdiv x y) (- (zdiv (abs x) (abs y)))))))
-    //
-    // ; uint256
-    // (define-fun uint256 ((x Int)) Bool (and (>= x 0) (< x pow256)))
-    //
-    // ; sint256
-    // (define-fun sint256 ((x Int)) Bool (and (>= x (- pow255)) (< x pow255)))
-    //
-    // ;;;; proof
-    //
-    // (declare-const x Int)
-    // (declare-const y Int)
-    //
-    // (assert (uint256 x))
-    // (assert (sint256 y))
-    // (assert (sint256 (* x y)))
-    // (assert (not (= y 0)))
-    //
-    // (assert (not
-    //     (= (sdiv (chop (* x y)) (chop y)) x)
-    // ))
-    // (check-sat)
-    rule chop(X *Int Y) /sWord chop(Y) => X requires #rangeUInt(256, X) andBool #rangeSInt(256, Y) andBool #rangeSInt(256, X *Int Y) andBool Y =/=Int 0 [simplification]
+//     // Proof #rangeUInt(256, X) andBool #rangeSInt(256, Y) andBool #rangeSInt(256, X *Int Y) andBool Y =/=Int 0
+//     //      chop(X *Int Y) /sWord chop(Y)
+//     //   => #sgnInterp(sgn(chop(X *Int Y)) *Int sgn(chop(Y)), abs(chop(X *Int Y)) /Word abs(chop(Y)))
+//     // Focus: sgn(chop(X *Int Y)) *Int sgn(chop(Y))
+//     //      case 0 <=Int Y
+//     //           sgn(chop(X *Int Y)) *Int sgn(chop(Y))
+//     //        => sgn(chop(X *Int Y)) *Int sgn(Y)                     // chop(Y) ==Int Y
+//     //        => sgn(X *Int Y) *Int sgn(Y)                           // 0 <=Int X andBool 0 <=Int Y
+//     //        => 1 *Int 1                                            // 0 <=Int X *Int Y andBool 0 <=Int Y
+//     //        => 1
+//     //      case Y <Int 0
+//     //           sgn(chop(X *Int Y)) *Int sgn(chop(Y))
+//     //        => sgn(X *Int Y +Int pow256) *Int sgn(Y +Int pow256)   // chop(Y) ==Int Y +Int pow256
+//     //        => -1 *Int -1                                          // X *Int Y <Int 0 andBool Y <Int 0
+//     //        => 1
+//     // Focus: abs(chop(X *Int Y)) /Word abs(chop(Y))
+//     //      case 0 <=Int Y
+//     //           abs(chop(X *Int Y)) /Word abs(chop(Y))
+//     //        => abs(chop(X *Int Y)) /Int  abs(chop(Y))
+//     //        => abs(X *Int Y) /Int abs(Y)                                                   // 0 <=Int X andBool 0 <=Int Y andBool #rangeSigne andBool chop(Y) ==Int Y
+//     //        => X *Int Y /Int Y                                                             // #rangeSInt(256, X *Int Y) andBool 0 <=Int X *Int Y andBool #rangeSInt(256, Y) andBool 0 <=Int Y
+//     //        => X
+//     //      case Y <Int 0
+//     //           abs(chop(X *Int Y)) /Int abs(chop(Y))
+//     //        => abs(X *Int Y +Int pow256) /Int abs(Y +Int pow256)                           // #rangeSInt(256, X *Int Y) andBool chop(Y) ==Int Y +Int pow256
+//     //        => (0 -Word (X *Int Y +Int pow256)) /Int (0 -Word (Y +Int pow256))             // #rangeSInt(256, X *Int Y) andBool X *Int Y <Int 0 andBool #rangeSInt(256, Y) andBool Y <Int 0
+//     //        => (pow256 -Int (X *Int Y +Int pow256)) /Int (pow256 -Int (Y +Int pow256))     // 0 <Int (X *Int Y +Int pow256) andBool 0 <Int (Y +Int pow256)
+//     //        => (X *Int Y) /Int Y
+//     //        => X
+//     //
+//     // Via Z3 4.7.1:
+//     // ; 2^4 and 2^3 instead of 2^256 and 2^255 for small model proof
+//     // (declare-const pow256 Int)
+//     // (assert (= pow256 16))
+//     // (declare-const pow255 Int)
+//     // (assert (= pow255 8))
+//     //
+//     // ; sgn
+//     // (declare-fun sgn (Int) Int)
+//     // (assert (forall ((x Int)) (=> (and (>= x 0)      (< x pow255)) (= (sgn x)  1))))
+//     // (assert (forall ((x Int)) (=> (and (>= x pow255) (< x pow256)) (= (sgn x) -1))))
+//     //
+//     // ; s<Word
+//     // (declare-fun slt (Int Int) Bool)
+//     // (assert (forall ((x Int) (y Int)) (=> (and (= (sgn x)  1) (= (sgn y)  1)) (= (slt x y) (< x y)))))
+//     // (assert (forall ((x Int) (y Int)) (=> (and (= (sgn x)  1) (= (sgn y) -1)) (= (slt x y) false))))
+//     // (assert (forall ((x Int) (y Int)) (=> (and (= (sgn x) -1) (= (sgn y)  1)) (= (slt x y) true))))
+//     // (assert (forall ((x Int) (y Int)) (=> (and (= (sgn x) -1) (= (sgn y) -1)) (= (slt x y) (> x y)))))
+//     //
+//     // ; chop
+//     // (define-fun chop ((x Int)) Int (mod x pow256))
+//     //
+//     // ; /Word
+//     // ;(define-fun zdiv ((x Int) (y Int)) Int (ite (= y 0) 0 (div x y)))
+//     // (define-fun zdiv ((x Int) (y Int)) Int (div x y)) ; y is non-zero in the query below
+//     //
+//     // ; /sWord
+//     // (declare-fun sdiv (Int Int) Int)
+//     // (assert (forall ((x Int) (y Int)) (=> (> (* (sgn x) (sgn y)) 0) (= (sdiv x y)    (zdiv (abs x) (abs y)) ))))
+//     // (assert (forall ((x Int) (y Int)) (=> (< (* (sgn x) (sgn y)) 0) (= (sdiv x y) (- (zdiv (abs x) (abs y)))))))
+//     //
+//     // ; uint256
+//     // (define-fun uint256 ((x Int)) Bool (and (>= x 0) (< x pow256)))
+//     //
+//     // ; sint256
+//     // (define-fun sint256 ((x Int)) Bool (and (>= x (- pow255)) (< x pow255)))
+//     //
+//     // ;;;; proof
+//     //
+//     // (declare-const x Int)
+//     // (declare-const y Int)
+//     //
+//     // (assert (uint256 x))
+//     // (assert (sint256 y))
+//     // (assert (sint256 (* x y)))
+//     // (assert (not (= y 0)))
+//     //
+//     // (assert (not
+//     //     (= (sdiv (chop (* x y)) (chop y)) x)
+//     // ))
+//     // (check-sat)
+//     rule chop(X *Int Y) /sWord chop(Y) => X requires #rangeUInt(256, X) andBool #rangeSInt(256, Y) andBool #rangeSInt(256, X *Int Y) andBool Y =/=Int 0 [simplification]
 
-    // ### vat-slip-pass-rough
+//     // ### vat-slip-pass-rough
 
-    rule chop(X +Int chop(Y)) => chop(X +Int Y) [simplification]
+//     rule chop(X +Int chop(Y)) => chop(X +Int Y) [simplification]
 
-    // ### flipper-addu48u48-fail-rough
+//     // ### flipper-addu48u48-fail-rough
 
-    rule maxUInt48 &Int (X +Int Y) <Int X => true requires #rangeUInt(48, X) andBool #rangeUInt(48, Y) andBool notBool (X +Int Y <Int pow48) [simplification]
+//     rule maxUInt48 &Int (X +Int Y) <Int X => true requires #rangeUInt(48, X) andBool #rangeUInt(48, Y) andBool notBool (X +Int Y <Int pow48) [simplification]
 
-    // Via Z3 4.7.1:
-    // (push)
-    // (assert (not (=> (sint256 y) (= (= (sgn (chop y)) 1) (<= 0 y) ) ) ))
-    // (check-sat)
-    // (pop)
-    rule sgn(chop(Y)) ==K 1 => 0 <=Int Y requires #rangeSInt(256, Y) [simplification]
+//     // Via Z3 4.7.1:
+//     // (push)
+//     // (assert (not (=> (sint256 y) (= (= (sgn (chop y)) 1) (<= 0 y) ) ) ))
+//     // (check-sat)
+//     // (pop)
+//     rule sgn(chop(Y)) ==K 1 => 0 <=Int Y requires #rangeSInt(256, Y) [simplification]
 
-    // ### vat-subui-pass
+//     // ### vat-subui-pass
 
-    rule chop(X) ==K 0 => X ==Int 0 requires #rangeSInt(256, X) [simplification]
+//     rule chop(X) ==K 0 => X ==Int 0 requires #rangeSInt(256, X) [simplification]
 
-    // ### flopper-kick-pass-rough
+//     // ### flopper-kick-pass-rough
 
-    rule 0 <=Int X |Int Y => true requires 0 <=Int X andBool 0 <=Int Y [simplification]
-    rule 0 <=Int X &Int Y => true requires 0 <=Int X andBool 0 <=Int Y [simplification]
+//     rule 0 <=Int X |Int Y => true requires 0 <=Int X andBool 0 <=Int Y [simplification]
+//     rule 0 <=Int X &Int Y => true requires 0 <=Int X andBool 0 <=Int Y [simplification]
 
-    rule X |Int Y <Int pow256 => true requires X <Int pow256 andBool Y <Int pow256 [simplification]
-    rule X &Int Y <Int pow256 => true requires X <Int pow256 andBool Y <Int pow256 [simplification]
+//     rule X |Int Y <Int pow256 => true requires X <Int pow256 andBool Y <Int pow256 [simplification]
+//     rule X &Int Y <Int pow256 => true requires X <Int pow256 andBool Y <Int pow256 [simplification]
 
-    rule (maxUInt160 &Int (X |Int Y)) => (maxUInt160 &Int X) |Int (maxUInt160 &Int Y) [simplification]
+//     rule (maxUInt160 &Int (X |Int Y)) => (maxUInt160 &Int X) |Int (maxUInt160 &Int Y) [simplification]
 
-    // ### flopper-tick-pass-rough
+//     // ### flopper-tick-pass-rough
 
-    rule chop(X *Int Y) => X *Int Y requires 0 <=Int X andBool 0 <=Int Y andBool X *Int Y <Int pow256 [simplification]
+//     rule chop(X *Int Y) => X *Int Y requires 0 <=Int X andBool 0 <=Int Y andBool X *Int Y <Int pow256 [simplification]
 
-    // ### flapper-yank-pass-rough
+//     // ### flapper-yank-pass-rough
 
-    rule X <Int X -Int Y => false requires 0 <=Int Y [simplification]
-    rule X +Int Y <Int X => false requires 0 <=Int Y [simplification]
+//     rule X <Int X -Int Y => false requires 0 <=Int Y [simplification]
+//     rule X +Int Y <Int X => false requires 0 <=Int Y [simplification]
 
-    // ### vow-cage-surplus-pass-rough
+//     // ### vow-cage-surplus-pass-rough
 
-    rule <acctID> ACCTID </acctID>  ==K <acctID> ACCTID' </acctID> => ACCTID  ==Int ACCTID' [simplification]
-    rule <acctID> ACCTID </acctID> =/=K <acctID> ACCTID' </acctID> => ACCTID =/=Int ACCTID' [simplification]
+//     rule <acctID> ACCTID </acctID>  ==K <acctID> ACCTID' </acctID> => ACCTID  ==Int ACCTID' [simplification]
+//     rule <acctID> ACCTID </acctID> =/=K <acctID> ACCTID' </acctID> => ACCTID =/=Int ACCTID' [simplification]
 
-    rule ((K |-> _) REST) [ K' <- undef ] => REST                             requires K  ==K K' [simplification]
-    rule ((K |-> V) REST) [ K' <- undef ] => (K |-> V) (REST [ K' <- undef ]) requires K =/=K K' [simplification]
+//     rule ((K |-> _) REST) [ K' <- undef ] => REST                             requires K  ==K K' [simplification]
+//     rule ((K |-> V) REST) [ K' <- undef ] => (K |-> V) (REST [ K' <- undef ]) requires K =/=K K' [simplification]
 
-    // ### vat-frob-diff-zero-dart-pass-rough
+//     // ### vat-frob-diff-zero-dart-pass-rough
 
-    rule chop( X -Int chop(Y))         => chop( X -Int Y)         [simplification]
-    rule chop((X -Int chop(Y)) *Int Z) => chop((X -Int Y) *Int Z) [simplification]
+//     rule chop( X -Int chop(Y))         => chop( X -Int Y)         [simplification]
+//     rule chop((X -Int chop(Y)) *Int Z) => chop((X -Int Y) *Int Z) [simplification]
 
-    // ### vat-fork-diff-pass-rough
+//     // ### vat-fork-diff-pass-rough
 
-    rule chop(X +Int pow256)  => chop(X)        [simplification]
-    rule chop(chop(X) *Int Y) => chop(X *Int Y) [simplification]
+//     rule chop(X +Int pow256)  => chop(X)        [simplification]
+//     rule chop(chop(X) *Int Y) => chop(X *Int Y) [simplification]
 
-    // ### vow-cage-deficit-pass-rough
+//     // ### vow-cage-deficit-pass-rough
 
-    rule (I1 +Int I2) -Int I1 => I2 [simplification]
+//     rule (I1 +Int I2) -Int I1 => I2 [simplification]
 
-    // ### flapper-tend-guy-diff-pass-rough
+//     // ### flapper-tend-guy-diff-pass-rough
 
-    rule ((I1 -Int I2) -Int I3) +Int I2 => I1 -Int I3 [simplification]
+//     rule ((I1 -Int I2) -Int I3) +Int I2 => I1 -Int I3 [simplification]
 
-    rule M:Map [ K1 <- _ ] [ K2 <- V2 ] [ K3 <- V3 ] [ K1 <- V4 ] => M [ K1 <- V4 ] [ K2 <- V2 ] [ K3 <- V3 ] requires K1 =/=Int K2 andBool K1 =/=Int K3 [simplification]
+//     rule M:Map [ K1 <- _ ] [ K2 <- V2 ] [ K3 <- V3 ] [ K1 <- V4 ] => M [ K1 <- V4 ] [ K2 <- V2 ] [ K3 <- V3 ] requires K1 =/=Int K2 andBool K1 =/=Int K3 [simplification]
 
-    // ### vat-fold-pass-rough
+//     // ### vat-fold-pass-rough
 
-    rule chop(X *Int (Y +Int pow256)) => chop(X *Int Y) [simplification]
+//     rule chop(X *Int (Y +Int pow256)) => chop(X *Int Y) [simplification]
 
-endmodule
+// endmodule

--- a/tests/specs/mcd/verification.k
+++ b/tests/specs/mcd/verification.k
@@ -83,7 +83,7 @@ module LEMMAS-MCD-HASKELL [symbolic, kore]
   // ########################
 
     rule #range(M:Memory [ K <- V ]                        , START, WIDTH) => #range(M [ K := (V : .ByteArray) ], START, WIDTH)  requires K +Int 1                    ==Int START +Int WIDTH andBool START <=Int K andBool 0 <Int WIDTH andBool 0 <=Int START [concrete(K    , V     ), simplification]
-    rule #range(M:Memory [ K <- V ] [ K' := VS':ByteArray ], START, WIDTH) => #range(M [ K := (V : VS')        ], START, WIDTH)  requires K' +Int #sizeByteArray(VS') ==Int START +Int WIDTH andBool START <=Int K andBool 0 <Int WIDTH andBool 0 <=Int START 
+    rule #range(M:Memory [ K <- V ] [ K' := VS':ByteArray ], START, WIDTH) => #range(M [ K := (V : VS')        ], START, WIDTH)  requires K' +Int #sizeByteArray(VS') ==Int START +Int WIDTH andBool START <=Int K andBool 0 <Int WIDTH andBool 0 <=Int START
                                                                                                                                   andBool K +Int 1                    ==Int K'                                                                                [concrete(K, K', V, VS'), simplification]
 
 endmodule
@@ -96,8 +96,8 @@ module LEMMAS-MCD-JAVA [symbolic, kast]
   // ########################
 
     rule #range(M:Memory [ K <- V ]                        , START, WIDTH) => #range(M [ K := (V : .ByteArray) ], START, WIDTH)  requires #isConcrete(K)  andBool #isConcrete(V) andBool START <=Int K andBool 0 <Int WIDTH andBool 0 <=Int START andBool K +Int 1                    ==Int START +Int WIDTH [simplification]
-    rule #range(M:Memory [ K <- V ] [ K' := VS':ByteArray ], START, WIDTH) => #range(M [ K := (V : VS')        ], START, WIDTH)  requires #isConcrete(K)  andBool #isConcrete(V) andBool START <=Int K andBool 0 <Int WIDTH andBool 0 <=Int START andBool K +Int 1                    ==Int K'              
-                                                                                                                                  andBool #isConcrete(K') andBool #isConcrete(VS')                                                                andBool K' +Int #sizeByteArray(VS') ==Int START +Int WIDTH [simplification] 
+    rule #range(M:Memory [ K <- V ] [ K' := VS':ByteArray ], START, WIDTH) => #range(M [ K := (V : VS')        ], START, WIDTH)  requires #isConcrete(K)  andBool #isConcrete(V) andBool START <=Int K andBool 0 <Int WIDTH andBool 0 <=Int START andBool K +Int 1                    ==Int K'
+                                                                                                                                  andBool #isConcrete(K') andBool #isConcrete(VS')                                                                andBool K' +Int #sizeByteArray(VS') ==Int START +Int WIDTH [simplification]
 
 endmodule
 
@@ -128,7 +128,7 @@ module LEMMAS-MCD-COMMON
     rule #sizeWordStack(WS, N) => #sizeWordStack(WS, 0) +Int N  requires N =/=Int 0 [simplification]
 
     // ### vat-addui-fail-rough
-    // 
+    //
     // Proof:
     // case sgn(X) ==Int  1
     //      X s<Word 0
@@ -172,7 +172,7 @@ module LEMMAS-MCD-COMMON
     rule X s<Word 0 => bool2Word(sgn(X) ==Int -1)  requires #rangeUInt(256, X) [simplification]
 
     rule X -Word Y <=Int X => #rangeUInt(256, X -Int Y) requires #rangeUInt(256, X) andBool #rangeUInt(256, Y) [simplification]
-    
+
     rule 0 <=Int X +Int Y => true requires 0 <=Int X andBool 0 <=Int Y [simplification]
 
     // ;(set-option :smt.mbqi true)
@@ -246,7 +246,7 @@ module LEMMAS-MCD-COMMON
   // ########################
 
     rule M:Memory [ K <- V ]             [ K' <- V' ] => M [ K' <- V' ] [ K <- V ]    requires K' <Int K                           [simplification]
-    rule M:Memory [ K := BUF:ByteArray ] [ K' <- V' ] => M [ K' <- V' ] [ K := BUF ]  requires K' <Int K 
+    rule M:Memory [ K := BUF:ByteArray ] [ K' <- V' ] => M [ K' <- V' ] [ K := BUF ]  requires K' <Int K
                                                                                         orBool K +Int #sizeByteArray(BUF) <=Int K' [simplification]
 
     rule M [ K <- V ] => M requires #lookup(M, K) ==Int V [simplification]
@@ -268,7 +268,7 @@ module LEMMAS-MCD-COMMON
   // Arithmetic
   // ########################
 
-    rule chop(N +Int M) <Int N => true  requires #rangeUInt(256, N) 
+    rule chop(N +Int M) <Int N => true  requires #rangeUInt(256, N)
                                          andBool #rangeUInt(256, M)
                                          andBool notBool #rangeUInt(256, N +Int M)
                                         [simplification]

--- a/tests/specs/mcd/verification.k
+++ b/tests/specs/mcd/verification.k
@@ -76,15 +76,11 @@ module LEMMAS-MCD-HASKELL [symbolic, kore]
   // Arithmetic
   // ########################
 
-    // ### functional
-
     rule chop(Y) => Y +Int pow256 requires #rangeSInt(256, Y) andBool Y <Int 0 [simplification]
 
   // ########################
   // Map
   // ########################
-
-    // ### flapper-yank-pass-rough
 
     rule #range(M:Memory [ K <- V ]                        , START, WIDTH) => #range(M [ K := (V : .ByteArray) ], START, WIDTH)  requires K +Int 1                    ==Int START +Int WIDTH andBool START <=Int K andBool 0 <Int WIDTH andBool 0 <=Int START [concrete(K    , V     ), simplification]
     rule #range(M:Memory [ K <- V ] [ K' := VS':ByteArray ], START, WIDTH) => #range(M [ K := (V : VS')        ], START, WIDTH)  requires K' +Int #sizeByteArray(VS') ==Int START +Int WIDTH andBool START <=Int K andBool 0 <Int WIDTH andBool 0 <=Int START 
@@ -116,8 +112,6 @@ module LEMMAS-MCD-COMMON
   // Buffer Reasoning
   // ########################
 
-    // ### vat-move-diff
-
     rule (W0 : WS) [ 0     .. WIDTH ] => W0 : (WS [ 0 .. WIDTH -Int 1 ])  requires 0 <Int WIDTH [simplification]
     rule (_  : WS) [ START .. WIDTH ] => WS [ START -Int 1 .. WIDTH ]     requires 0 <Int START [simplification]
 
@@ -131,17 +125,12 @@ module LEMMAS-MCD-COMMON
   // Word Reasoning
   // ########################
 
-    // ### cat-file-addr-pass-rough
-
     rule maskWordPackAddrUInt48UInt48_1 &Int ADDR => 0  requires #rangeAddress(ADDR) [simplification]
-
-    // ### PERFORMANCE: dai-adduu-fail-rough
-    // 99s -> 48s
 
     rule #sizeWordStack(WS, N) => #sizeWordStack(WS, 0) +Int N  requires N =/=Int 0 [simplification]
 
     // ### vat-addui-fail-rough
-
+    // 
     // Proof:
     // case sgn(X) ==Int  1
     //      X s<Word 0
@@ -184,13 +173,9 @@ module LEMMAS-MCD-COMMON
     // (check-sat)
     rule X s<Word 0 => bool2Word(sgn(X) ==Int -1)  requires #rangeUInt(256, X) [simplification]
 
-    // ### vow-flog-fail-rough
-
     rule X -Word Y <=Int X => #rangeUInt(256, X -Int Y) requires #rangeUInt(256, X) andBool #rangeUInt(256, Y) [simplification]
     
     rule 0 <=Int X +Int Y => true requires 0 <=Int X andBool 0 <=Int Y [simplification]
-
-    // ### vat-subui-fail-rough
 
     // ;(set-option :smt.mbqi true)
     //
@@ -266,18 +251,11 @@ module LEMMAS-MCD-COMMON
   // Map
   // ########################
 
-    // ### PERFORMANCE: vat-deny-diff-fail-rough
-    // 27.21m -> 3.16m
-
     rule M:Memory [ K <- V ]             [ K' <- V' ] => M [ K' <- V' ] [ K <- V ]    requires K' <Int K                           [simplification]
     rule M:Memory [ K := BUF:ByteArray ] [ K' <- V' ] => M [ K' <- V' ] [ K := BUF ]  requires K' <Int K 
                                                                                         orBool K +Int #sizeByteArray(BUF) <=Int K' [simplification]
 
-    // ### dsvalue-read-pass
-
     rule M [ K <- V ] => M requires #lookup(M, K) ==Int V [simplification]
-
-    // ### flapper-yank-pass-rough
 
     rule M:Memory [ K := BUF:ByteArray ] [ K' := BUF':ByteArray ] => M [ K := (BUF [ 0 .. K' -Int K ]) ] [ K' := BUF' ]
       requires K <Int K'
@@ -286,8 +264,6 @@ module LEMMAS-MCD-COMMON
       [simplification]
 
     rule M:Map [ K1 <- _ ] [ K2 <- V2 ] [ K1 <- V1' ] => M [ K1 <- V1' ] [ K2 <- V2 ] requires K1 =/=Int K2 [simplification]
-
-    // ### end-cage-ilk-pass-rough
 
     rule M:Memory [ K1 := (BUF11 ++ BUF12) ] [ K2 := BUF2 ] => M [ K1 +Int #sizeByteArray(BUF11) := BUF12 ] [ K2 := BUF2 ]
       requires K2 <=Int K1
@@ -298,22 +274,16 @@ module LEMMAS-MCD-COMMON
   // Arithmetic
   // ########################
 
-    // ### dstoken-transferfrom-fail-rough
-
     rule chop(N +Int M) <Int N => true  requires #rangeUInt(256, N) 
                                          andBool #rangeUInt(256, M)
                                          andBool notBool #rangeUInt(256, N +Int M)
                                         [simplification]
-
-    // ### flipper-bids-pass-rough
 
     // This lemma is considered "safe enough" because `keccak` is a hash function over a large range and is very unlikely to overflow.
     // Note that this case comes from a solidity struct being accessed (hence the integer offsets), so it's an assumption built into the Solidity compiler anyway.
     rule chop(keccak(BA) +Int N) => keccak(BA) +Int N requires 0 <=Int N andBool N <Int 6 [simplification]
 
     rule sgn(chop(X)) ==Int -1 => X <Int 0  requires #rangeSInt(256, X) [simplification]
-
-    // ### vat-mului-pass
 
     rule chop(X *Int chop(Y)) => chop(X *Int Y) [simplification]
 
@@ -400,11 +370,7 @@ module LEMMAS-MCD-COMMON
     // (check-sat)
     rule chop(X *Int Y) /sWord chop(Y) => X requires #rangeUInt(256, X) andBool #rangeSInt(256, Y) andBool #rangeSInt(256, X *Int Y) andBool Y =/=Int 0 [simplification]
 
-    // ### vat-slip-pass-rough
-
     rule chop(X +Int chop(Y)) => chop(X +Int Y) [simplification]
-
-    // ### flipper-addu48u48-fail-rough
 
     rule maxUInt48 &Int (X +Int Y) <Int X => true requires #rangeUInt(48, X) andBool #rangeUInt(48, Y) andBool notBool (X +Int Y <Int pow48) [simplification]
 
@@ -415,11 +381,7 @@ module LEMMAS-MCD-COMMON
     // (pop)
     rule sgn(chop(Y)) ==K 1 => 0 <=Int Y requires #rangeSInt(256, Y) [simplification]
 
-    // ### vat-subui-pass
-
     rule chop(X) ==K 0 => X ==Int 0 requires #rangeSInt(256, X) [simplification]
-
-    // ### flopper-kick-pass-rough
 
     rule 0 <=Int X |Int Y => true requires 0 <=Int X andBool 0 <=Int Y [simplification]
     rule 0 <=Int X &Int Y => true requires 0 <=Int X andBool 0 <=Int Y [simplification]
@@ -429,16 +391,10 @@ module LEMMAS-MCD-COMMON
 
     rule (maxUInt160 &Int (X |Int Y)) => (maxUInt160 &Int X) |Int (maxUInt160 &Int Y) [simplification]
 
-    // ### flopper-tick-pass-rough
-
     rule chop(X *Int Y) => X *Int Y requires 0 <=Int X andBool 0 <=Int Y andBool X *Int Y <Int pow256 [simplification]
-
-    // ### flapper-yank-pass-rough
 
     rule X <Int X -Int Y => false requires 0 <=Int Y [simplification]
     rule X +Int Y <Int X => false requires 0 <=Int Y [simplification]
-
-    // ### vow-cage-surplus-pass-rough
 
     rule <acctID> ACCTID </acctID>  ==K <acctID> ACCTID' </acctID> => ACCTID  ==Int ACCTID' [simplification]
     rule <acctID> ACCTID </acctID> =/=K <acctID> ACCTID' </acctID> => ACCTID =/=Int ACCTID' [simplification]
@@ -446,27 +402,17 @@ module LEMMAS-MCD-COMMON
     rule ((K |-> _) REST) [ K' <- undef ] => REST                             requires K  ==K K' [simplification]
     rule ((K |-> V) REST) [ K' <- undef ] => (K |-> V) (REST [ K' <- undef ]) requires K =/=K K' [simplification]
 
-    // ### vat-frob-diff-zero-dart-pass-rough
-
     rule chop( X -Int chop(Y))         => chop( X -Int Y)         [simplification]
     rule chop((X -Int chop(Y)) *Int Z) => chop((X -Int Y) *Int Z) [simplification]
-
-    // ### vat-fork-diff-pass-rough
 
     rule chop(X +Int pow256)  => chop(X)        [simplification]
     rule chop(chop(X) *Int Y) => chop(X *Int Y) [simplification]
 
-    // ### vow-cage-deficit-pass-rough
-
     rule (I1 +Int I2) -Int I1 => I2 [simplification]
-
-    // ### flapper-tend-guy-diff-pass-rough
 
     rule ((I1 -Int I2) -Int I3) +Int I2 => I1 -Int I3 [simplification]
 
     rule M:Map [ K1 <- _ ] [ K2 <- V2 ] [ K3 <- V3 ] [ K1 <- V4 ] => M [ K1 <- V4 ] [ K2 <- V2 ] [ K3 <- V3 ] requires K1 =/=Int K2 andBool K1 =/=Int K3 [simplification]
-
-    // ### vat-fold-pass-rough
 
     rule chop(X *Int (Y +Int pow256)) => chop(X *Int Y) [simplification]
 

--- a/tests/specs/mcd/verification.k
+++ b/tests/specs/mcd/verification.k
@@ -11,463 +11,463 @@ module VERIFICATION
 
 endmodule
 
-// module LEMMAS-MCD
-//     imports LEMMAS-MCD-HASKELL
-//     imports LEMMAS-MCD-JAVA
+module LEMMAS-MCD
+    imports LEMMAS-MCD-HASKELL
+    imports LEMMAS-MCD-JAVA
 
-// endmodule
+endmodule
 
-// module LEMMAS-MCD-SYNTAX
-//     imports LEMMAS
+module LEMMAS-MCD-SYNTAX
+    imports LEMMAS
 
-//   // ########################
-//   // Constants
-//   // ########################
+  // ########################
+  // Constants
+  // ########################
 
-//     syntax Int ::= "#Wad" | "#Ray" | "#Rad"
-//  // ---------------------------------------
-//     rule #Wad => 1000000000000000000                            [macro]
-//     rule #Ray => 1000000000000000000000000000                   [macro]
-//     rule #Rad => 1000000000000000000000000000000000000000000000 [macro]
+    syntax Int ::= "#Wad" | "#Ray" | "#Rad"
+ // ---------------------------------------
+    rule #Wad => 1000000000000000000                            [macro]
+    rule #Ray => 1000000000000000000000000000                   [macro]
+    rule #Rad => 1000000000000000000000000000000000000000000000 [macro]
 
-//   // ########################
-//   // Word Reasoning
-//   // ########################
+  // ########################
+  // Word Reasoning
+  // ########################
 
-//     syntax Bool ::= #notPrecompileAddress ( Int ) [function]
-//  // --------------------------------------------------------
-//     rule #notPrecompileAddress ( X ) => 0 ==Int X orBool (10 <=Int X andBool #rangeAddress(X))
+    syntax Bool ::= #notPrecompileAddress ( Int ) [function]
+ // --------------------------------------------------------
+    rule #notPrecompileAddress ( X ) => 0 ==Int X orBool (10 <=Int X andBool #rangeAddress(X))
 
-//     syntax Int ::= #string2Word ( String ) [function]
-//  // -------------------------------------------------
-//     rule #string2Word(S) => #asWord(#padRightToWidth(32, #parseByteStackRaw(S)))
+    syntax Int ::= #string2Word ( String ) [function]
+ // -------------------------------------------------
+    rule #string2Word(S) => #asWord(#padRightToWidth(32, #parseByteStackRaw(S)))
 
-//     syntax Int ::= nthbyteof ( Int , Int , Int ) [function, smtlib(smt_nthbyteof), proj]
-//  // ------------------------------------------------------------------------------------
-//     rule nthbyteof(V, I, N) => nthbyteof(V /Int 256, I, N -Int 1) when N  >Int (I +Int 1) [concrete]
-//     rule nthbyteof(V, I, N) =>           V modInt 256             when N ==Int (I +Int 1) [concrete]
+    syntax Int ::= nthbyteof ( Int , Int , Int ) [function, smtlib(smt_nthbyteof), proj]
+ // ------------------------------------------------------------------------------------
+    rule nthbyteof(V, I, N) => nthbyteof(V /Int 256, I, N -Int 1) when N  >Int (I +Int 1) [concrete]
+    rule nthbyteof(V, I, N) =>           V modInt 256             when N ==Int (I +Int 1) [concrete]
 
-//   // ########################
-//   // Buffer Reasoning
-//   // ########################
+  // ########################
+  // Buffer Reasoning
+  // ########################
 
-//     syntax ByteArray ::= #asByteStackInWidth    ( Int, Int )                 [function]
-//                        | #asByteStackInWidthaux ( Int, Int, Int, ByteArray ) [function]
-//  // -----------------------------------------------------------------------------------
-//     rule #asByteStackInWidth(X, N) => #asByteStackInWidthaux(X, N -Int 1, N, .ByteArray)
+    syntax ByteArray ::= #asByteStackInWidth    ( Int, Int )                 [function]
+                       | #asByteStackInWidthaux ( Int, Int, Int, ByteArray ) [function]
+ // -----------------------------------------------------------------------------------
+    rule #asByteStackInWidth(X, N) => #asByteStackInWidthaux(X, N -Int 1, N, .ByteArray)
 
-//     rule #asByteStackInWidthaux(X, I, N, WS) => #asByteStackInWidthaux(X, I -Int 1, N, nthbyteof(X, I, N) : WS) when I >Int 0
-//     rule #asByteStackInWidthaux(X, 0, N, WS) => nthbyteof(X, 0, N) : WS
+    rule #asByteStackInWidthaux(X, I, N, WS) => #asByteStackInWidthaux(X, I -Int 1, N, nthbyteof(X, I, N) : WS) when I >Int 0
+    rule #asByteStackInWidthaux(X, 0, N, WS) => nthbyteof(X, 0, N) : WS
 
-//   // ########################
-//   // Arithmetic
-//   // ########################
+  // ########################
+  // Arithmetic
+  // ########################
 
-//     syntax Int ::= #rmul ( Int , Int ) [function, smtlib(smt_rmul)]
-//  // ---------------------------------------------------------------
-//     rule #rmul(X, Y) => (X *Int Y) /Int #Ray
+    syntax Int ::= #rmul ( Int , Int ) [function, smtlib(smt_rmul)]
+ // ---------------------------------------------------------------
+    rule #rmul(X, Y) => (X *Int Y) /Int #Ray
 
-// endmodule
+endmodule
 
-// module LEMMAS-MCD-HASKELL [symbolic, kore]
-//     imports LEMMAS-MCD-COMMON
+module LEMMAS-MCD-HASKELL [symbolic, kore]
+    imports LEMMAS-MCD-COMMON
 
-//   // ########################
-//   // Arithmetic
-//   // ########################
+  // ########################
+  // Arithmetic
+  // ########################
 
-//     // ### functional
+    // ### functional
 
-//     rule chop(Y) => Y +Int pow256 requires #rangeSInt(256, Y) andBool Y <Int 0 [simplification]
+    rule chop(Y) => Y +Int pow256 requires #rangeSInt(256, Y) andBool Y <Int 0 [simplification]
 
-//   // ########################
-//   // Map
-//   // ########################
+  // ########################
+  // Map
+  // ########################
 
-//     // ### flapper-yank-pass-rough
+    // ### flapper-yank-pass-rough
 
-//     rule #range(M:Memory [ K <- V ]                        , START, WIDTH) => #range(M [ K := (V : .ByteArray) ], START, WIDTH)  requires K +Int 1                    ==Int START +Int WIDTH andBool START <=Int K andBool 0 <Int WIDTH andBool 0 <=Int START [concrete(K    , V     ), simplification]
-//     rule #range(M:Memory [ K <- V ] [ K' := VS':ByteArray ], START, WIDTH) => #range(M [ K := (V : VS')        ], START, WIDTH)  requires K' +Int #sizeByteArray(VS') ==Int START +Int WIDTH andBool START <=Int K andBool 0 <Int WIDTH andBool 0 <=Int START 
-//                                                                                                                                   andBool K +Int 1                    ==Int K'                                                                                [concrete(K, K', V, VS'), simplification]
+    rule #range(M:Memory [ K <- V ]                        , START, WIDTH) => #range(M [ K := (V : .ByteArray) ], START, WIDTH)  requires K +Int 1                    ==Int START +Int WIDTH andBool START <=Int K andBool 0 <Int WIDTH andBool 0 <=Int START [concrete(K    , V     ), simplification]
+    rule #range(M:Memory [ K <- V ] [ K' := VS':ByteArray ], START, WIDTH) => #range(M [ K := (V : VS')        ], START, WIDTH)  requires K' +Int #sizeByteArray(VS') ==Int START +Int WIDTH andBool START <=Int K andBool 0 <Int WIDTH andBool 0 <=Int START 
+                                                                                                                                  andBool K +Int 1                    ==Int K'                                                                                [concrete(K, K', V, VS'), simplification]
 
-// endmodule
+endmodule
 
-// module LEMMAS-MCD-JAVA [symbolic, kast]
-//     imports LEMMAS-MCD-COMMON
+module LEMMAS-MCD-JAVA [symbolic, kast]
+    imports LEMMAS-MCD-COMMON
 
-//   // ########################
-//   // Range
-//   // ########################
+  // ########################
+  // Range
+  // ########################
 
-//     // ### flapper-yank-pass-rough
+    // ### flapper-yank-pass-rough
 
-//     rule #range(M:Memory [ K <- V ]                        , START, WIDTH) => #range(M [ K := (V : .ByteArray) ], START, WIDTH)  requires #isConcrete(K)  andBool #isConcrete(V) andBool START <=Int K andBool 0 <Int WIDTH andBool 0 <=Int START andBool K +Int 1                    ==Int START +Int WIDTH [simplification]
-//     rule #range(M:Memory [ K <- V ] [ K' := VS':ByteArray ], START, WIDTH) => #range(M [ K := (V : VS')        ], START, WIDTH)  requires #isConcrete(K)  andBool #isConcrete(V) andBool START <=Int K andBool 0 <Int WIDTH andBool 0 <=Int START andBool K +Int 1                    ==Int K'              
-//                                                                                                                                   andBool #isConcrete(K') andBool #isConcrete(VS')                                                                andBool K' +Int #sizeByteArray(VS') ==Int START +Int WIDTH [simplification] 
+    rule #range(M:Memory [ K <- V ]                        , START, WIDTH) => #range(M [ K := (V : .ByteArray) ], START, WIDTH)  requires #isConcrete(K)  andBool #isConcrete(V) andBool START <=Int K andBool 0 <Int WIDTH andBool 0 <=Int START andBool K +Int 1                    ==Int START +Int WIDTH [simplification]
+    rule #range(M:Memory [ K <- V ] [ K' := VS':ByteArray ], START, WIDTH) => #range(M [ K := (V : VS')        ], START, WIDTH)  requires #isConcrete(K)  andBool #isConcrete(V) andBool START <=Int K andBool 0 <Int WIDTH andBool 0 <=Int START andBool K +Int 1                    ==Int K'              
+                                                                                                                                  andBool #isConcrete(K') andBool #isConcrete(VS')                                                                andBool K' +Int #sizeByteArray(VS') ==Int START +Int WIDTH [simplification] 
 
-// endmodule
+endmodule
 
-// module LEMMAS-MCD-COMMON
-//     imports LEMMAS-MCD-SYNTAX
-//     imports INFINITE-GAS
-//     imports WORD-PACK
+module LEMMAS-MCD-COMMON
+    imports LEMMAS-MCD-SYNTAX
+    imports INFINITE-GAS
+    imports WORD-PACK
 
-//   // ########################
-//   // Buffer Reasoning
-//   // ########################
+  // ########################
+  // Buffer Reasoning
+  // ########################
 
-//     // ### vat-move-diff
+    // ### vat-move-diff
 
-//     rule (W0 : WS) [ 0     .. WIDTH ] => W0 : (WS [ 0 .. WIDTH -Int 1 ])  requires 0 <Int WIDTH [simplification]
-//     rule (_  : WS) [ START .. WIDTH ] => WS [ START -Int 1 .. WIDTH ]     requires 0 <Int START [simplification]
+    rule (W0 : WS) [ 0     .. WIDTH ] => W0 : (WS [ 0 .. WIDTH -Int 1 ])  requires 0 <Int WIDTH [simplification]
+    rule (_  : WS) [ START .. WIDTH ] => WS [ START -Int 1 .. WIDTH ]     requires 0 <Int START [simplification]
 
-//     // ### cat-exhaustiveness
+    // ### cat-exhaustiveness
 
-//     rule WS [ START .. WIDTH ] [ 0 .. WIDTH' ]  => WS [ START .. WIDTH' ]  requires WIDTH' <=Int WIDTH [simplification]
+    rule WS [ START .. WIDTH ] [ 0 .. WIDTH' ]  => WS [ START .. WIDTH' ]  requires WIDTH' <=Int WIDTH [simplification]
 
-//     rule ( BA1:ByteArray ++ BA2:ByteArray ) ++ BA3:ByteArray => BA1 ++ ( BA2 ++ BA3 ) [simplification]
+    rule ( BA1:ByteArray ++ BA2:ByteArray ) ++ BA3:ByteArray => BA1 ++ ( BA2 ++ BA3 ) [simplification]
 
-//   // ########################
-//   // Word Reasoning
-//   // ########################
+  // ########################
+  // Word Reasoning
+  // ########################
 
-//     // ### cat-file-addr-pass-rough
+    // ### cat-file-addr-pass-rough
 
-//     rule maskWordPackAddrUInt48UInt48_1 &Int ADDR => 0  requires #rangeAddress(ADDR) [simplification]
+    rule maskWordPackAddrUInt48UInt48_1 &Int ADDR => 0  requires #rangeAddress(ADDR) [simplification]
 
-//     // ### PERFORMANCE: dai-adduu-fail-rough
-//     // 99s -> 48s
+    // ### PERFORMANCE: dai-adduu-fail-rough
+    // 99s -> 48s
 
-//     rule #sizeWordStack(WS, N) => #sizeWordStack(WS, 0) +Int N  requires N =/=Int 0 [simplification]
+    rule #sizeWordStack(WS, N) => #sizeWordStack(WS, 0) +Int N  requires N =/=Int 0 [simplification]
 
-//     // ### vat-addui-fail-rough
+    // ### vat-addui-fail-rough
 
-//     // Proof:
-//     // case sgn(X) ==Int  1
-//     //      X s<Word 0
-//     //   => X <Word 0           // sgn(X) ==Int 1 andBool sgn(0) ==Int 1
-//     //   => bool2Word(false)    // #rangeUInt(256, X)
-//     // case sgn(X) ==Int -1
-//     //      X s<Word 0
-//     //   => bool2Word(true)     // sgn(X) ==Int -1 andBool sgn(0) ==Int 1
-//     //
-//     // Via Z3 4.8.7:
-//     // ; 2^256
-//     // (declare-const pow256 Int)
-//     // (assert (= pow256 115792089237316195423570985008687907853269984665640564039457584007913129639936))
-//     //
-//     // ; 2^255
-//     // (declare-const pow255 Int)
-//     // (assert (= pow255 57896044618658097711785492504343953926634992332820282019728792003956564819968))
-//     //
-//     // ; sgn
-//     // (declare-fun sgn (Int) Int)
-//     // (assert (forall ((x Int)) (=> (and (>= x 0)      (< x pow255)) (= (sgn x)  1))))
-//     // (assert (forall ((x Int)) (=> (and (>= x pow255) (< x pow256)) (= (sgn x) -1))))
-//     //
-//     // ; s<Word
-//     // (declare-fun slt (Int Int) Bool)
-//     // (assert (forall ((x Int) (y Int)) (=> (and (= (sgn x)  1) (= (sgn y)  1)) (= (slt x y) (< x y)))))
-//     // (assert (forall ((x Int) (y Int)) (=> (and (= (sgn x)  1) (= (sgn y) -1)) (= (slt x y) false))))
-//     // (assert (forall ((x Int) (y Int)) (=> (and (= (sgn x) -1) (= (sgn y)  1)) (= (slt x y) true))))
-//     // (assert (forall ((x Int) (y Int)) (=> (and (= (sgn x) -1) (= (sgn y) -1)) (= (slt x y) (> x y)))))
-//     //
-//     // ;;;; proof
-//     //
-//     // ; uint256
-//     // (declare-const x Int)
-//     // (assert (and (>= x 0) (< x pow256)))
-//     //
-//     // (assert (not
-//     //     (= (slt x 0) (= (sgn x) -1))
-//     // ))
-//     // (check-sat)
-//     rule X s<Word 0 => bool2Word(sgn(X) ==Int -1)  requires #rangeUInt(256, X) [simplification]
+    // Proof:
+    // case sgn(X) ==Int  1
+    //      X s<Word 0
+    //   => X <Word 0           // sgn(X) ==Int 1 andBool sgn(0) ==Int 1
+    //   => bool2Word(false)    // #rangeUInt(256, X)
+    // case sgn(X) ==Int -1
+    //      X s<Word 0
+    //   => bool2Word(true)     // sgn(X) ==Int -1 andBool sgn(0) ==Int 1
+    //
+    // Via Z3 4.8.7:
+    // ; 2^256
+    // (declare-const pow256 Int)
+    // (assert (= pow256 115792089237316195423570985008687907853269984665640564039457584007913129639936))
+    //
+    // ; 2^255
+    // (declare-const pow255 Int)
+    // (assert (= pow255 57896044618658097711785492504343953926634992332820282019728792003956564819968))
+    //
+    // ; sgn
+    // (declare-fun sgn (Int) Int)
+    // (assert (forall ((x Int)) (=> (and (>= x 0)      (< x pow255)) (= (sgn x)  1))))
+    // (assert (forall ((x Int)) (=> (and (>= x pow255) (< x pow256)) (= (sgn x) -1))))
+    //
+    // ; s<Word
+    // (declare-fun slt (Int Int) Bool)
+    // (assert (forall ((x Int) (y Int)) (=> (and (= (sgn x)  1) (= (sgn y)  1)) (= (slt x y) (< x y)))))
+    // (assert (forall ((x Int) (y Int)) (=> (and (= (sgn x)  1) (= (sgn y) -1)) (= (slt x y) false))))
+    // (assert (forall ((x Int) (y Int)) (=> (and (= (sgn x) -1) (= (sgn y)  1)) (= (slt x y) true))))
+    // (assert (forall ((x Int) (y Int)) (=> (and (= (sgn x) -1) (= (sgn y) -1)) (= (slt x y) (> x y)))))
+    //
+    // ;;;; proof
+    //
+    // ; uint256
+    // (declare-const x Int)
+    // (assert (and (>= x 0) (< x pow256)))
+    //
+    // (assert (not
+    //     (= (slt x 0) (= (sgn x) -1))
+    // ))
+    // (check-sat)
+    rule X s<Word 0 => bool2Word(sgn(X) ==Int -1)  requires #rangeUInt(256, X) [simplification]
 
-//     // ### vow-flog-fail-rough
+    // ### vow-flog-fail-rough
 
-//     rule X -Word Y <=Int X => #rangeUInt(256, X -Int Y) requires #rangeUInt(256, X) andBool #rangeUInt(256, Y) [simplification]
+    rule X -Word Y <=Int X => #rangeUInt(256, X -Int Y) requires #rangeUInt(256, X) andBool #rangeUInt(256, Y) [simplification]
     
-//     rule 0 <=Int X +Int Y => true requires 0 <=Int X andBool 0 <=Int Y [simplification]
+    rule 0 <=Int X +Int Y => true requires 0 <=Int X andBool 0 <=Int Y [simplification]
 
-//     // ### vat-subui-fail-rough
+    // ### vat-subui-fail-rough
 
-//     // ;(set-option :smt.mbqi true)
-//     //
-//     // ; 2^256
-//     // (declare-const pow256 Int)
-//     // (assert (= pow256 115792089237316195423570985008687907853269984665640564039457584007913129639936))
-//     //
-//     // ; 2^255
-//     // (declare-const pow255 Int)
-//     // (assert (= pow255 57896044618658097711785492504343953926634992332820282019728792003956564819968))
-//     //
-//     // ; sgn
-//     // (declare-fun sgn (Int) Int)
-//     // (assert (forall ((x Int)) (=> (and (>= x 0)      (< x pow255)) (= (sgn x)  1))))
-//     // (assert (forall ((x Int)) (=> (and (>= x pow255) (< x pow256)) (= (sgn x) -1))))
-//     //
-//     // ; s<Word
-//     // (declare-fun slt (Int Int) Bool)
-//     // (assert (forall ((x Int) (y Int)) (=> (and (= (sgn x)  1) (= (sgn y)  1)) (= (slt x y) (< x y)))))
-//     // (assert (forall ((x Int) (y Int)) (=> (and (= (sgn x)  1) (= (sgn y) -1)) (= (slt x y) false))))
-//     // (assert (forall ((x Int) (y Int)) (=> (and (= (sgn x) -1) (= (sgn y)  1)) (= (slt x y) true))))
-//     // (assert (forall ((x Int) (y Int)) (=> (and (= (sgn x) -1) (= (sgn y) -1)) (= (slt x y) (> x y)))))
-//     //
-//     // ; chop
-//     // (define-fun chop ((x Int)) Int (mod x pow256))
-//     // ;(simplify (chop -1))
-//     //
-//     // ; /Word
-//     // (define-fun zdiv ((x Int) (y Int)) Int (ite (= y 0) 0 (div x y)))
-//     //
-//     // ; /sWord
-//     // (declare-fun sdiv (Int Int) Int)
-//     // (assert (forall ((x Int) (y Int)) (=> (> (* (sgn x) (sgn y)) 0) (= (sdiv x y)    (zdiv (abs x) (abs y)) ))))
-//     // (assert (forall ((x Int) (y Int)) (=> (< (* (sgn x) (sgn y)) 0) (= (sdiv x y) (- (zdiv (abs x) (abs y)))))))
-//     //
-//     // ; uint256
-//     // (define-fun uint256 ((x Int)) Bool (and (>= x 0) (< x pow256)))
-//     //
-//     // ; sint256
-//     // (define-fun sint256 ((x Int)) Bool (and (>= x (- pow255)) (< x pow255)))
-//     //
-//     // ;;;;
-//     //
-//     // (declare-const x Int)
-//     // (declare-const y Int)
+    // ;(set-option :smt.mbqi true)
+    //
+    // ; 2^256
+    // (declare-const pow256 Int)
+    // (assert (= pow256 115792089237316195423570985008687907853269984665640564039457584007913129639936))
+    //
+    // ; 2^255
+    // (declare-const pow255 Int)
+    // (assert (= pow255 57896044618658097711785492504343953926634992332820282019728792003956564819968))
+    //
+    // ; sgn
+    // (declare-fun sgn (Int) Int)
+    // (assert (forall ((x Int)) (=> (and (>= x 0)      (< x pow255)) (= (sgn x)  1))))
+    // (assert (forall ((x Int)) (=> (and (>= x pow255) (< x pow256)) (= (sgn x) -1))))
+    //
+    // ; s<Word
+    // (declare-fun slt (Int Int) Bool)
+    // (assert (forall ((x Int) (y Int)) (=> (and (= (sgn x)  1) (= (sgn y)  1)) (= (slt x y) (< x y)))))
+    // (assert (forall ((x Int) (y Int)) (=> (and (= (sgn x)  1) (= (sgn y) -1)) (= (slt x y) false))))
+    // (assert (forall ((x Int) (y Int)) (=> (and (= (sgn x) -1) (= (sgn y)  1)) (= (slt x y) true))))
+    // (assert (forall ((x Int) (y Int)) (=> (and (= (sgn x) -1) (= (sgn y) -1)) (= (slt x y) (> x y)))))
+    //
+    // ; chop
+    // (define-fun chop ((x Int)) Int (mod x pow256))
+    // ;(simplify (chop -1))
+    //
+    // ; /Word
+    // (define-fun zdiv ((x Int) (y Int)) Int (ite (= y 0) 0 (div x y)))
+    //
+    // ; /sWord
+    // (declare-fun sdiv (Int Int) Int)
+    // (assert (forall ((x Int) (y Int)) (=> (> (* (sgn x) (sgn y)) 0) (= (sdiv x y)    (zdiv (abs x) (abs y)) ))))
+    // (assert (forall ((x Int) (y Int)) (=> (< (* (sgn x) (sgn y)) 0) (= (sdiv x y) (- (zdiv (abs x) (abs y)))))))
+    //
+    // ; uint256
+    // (define-fun uint256 ((x Int)) Bool (and (>= x 0) (< x pow256)))
+    //
+    // ; sint256
+    // (define-fun sint256 ((x Int)) Bool (and (>= x (- pow255)) (< x pow255)))
+    //
+    // ;;;;
+    //
+    // (declare-const x Int)
+    // (declare-const y Int)
 
-//     // Via Z3 4.7.1:
-//     // (push)
-//     // (assert (not (=> (uint256 x) (= (slt 0 x) (and (= (sgn x) 1) (not (= x 0))) ) ) ))
-//     // (check-sat)
-//     // (pop)
-//     rule 0 s<Word X => bool2Word(sgn(X) ==Int 1 andBool X =/=Int 0) requires #rangeUInt(256, X) [simplification]
+    // Via Z3 4.7.1:
+    // (push)
+    // (assert (not (=> (uint256 x) (= (slt 0 x) (and (= (sgn x) 1) (not (= x 0))) ) ) ))
+    // (check-sat)
+    // (pop)
+    rule 0 s<Word X => bool2Word(sgn(X) ==Int 1 andBool X =/=Int 0) requires #rangeUInt(256, X) [simplification]
 
-//     // ### vat-subui-pass-rough
+    // ### vat-subui-pass-rough
 
-//     // Via Z3 4.7.1:
-//     // (push)
-//     // (assert (not (=> true (= (chop (- x (chop y))) (chop (- x y)) ) ) ))
-//     // (check-sat)
-//     // (pop)
-//     rule X -Word chop(Y) => chop(X -Int Y) [simplification]
+    // Via Z3 4.7.1:
+    // (push)
+    // (assert (not (=> true (= (chop (- x (chop y))) (chop (- x y)) ) ) ))
+    // (check-sat)
+    // (pop)
+    rule X -Word chop(Y) => chop(X -Int Y) [simplification]
 
-//     // ### end-pack-pass-rough
+    // ### end-pack-pass-rough
 
-//     rule ADDR in (SetItem(I) REST) => ADDR in REST requires #notPrecompileAddress(ADDR) andBool notBool #notPrecompileAddress(I) [simplification]
+    rule ADDR in (SetItem(I) REST) => ADDR in REST requires #notPrecompileAddress(ADDR) andBool notBool #notPrecompileAddress(I) [simplification]
 
-//     // This proof ends up with side-conditions which look like this:
-//     // Tic ==K 0 andBool 0 ==K maxUInt48 &Int (#lookup(STORAGE, ADDR) /Int pow160) andBool Tic ==K maxUInt48 &Int (#lookup(STORAGE, ADDR) /Int pow160)
-//     // So we need this rule to do the structural simplification because the Java backend will not use this string of equalities to do the simplification directly.
-//     rule #WordPackAddrUInt48UInt48(ADDR, maxUInt48 &Int (ADDR_UINT48_UINT48 /Int pow160), UINT48_2) => #WordPackAddrUInt48UInt48(ADDR, 0, UINT48_2) requires maxUInt48 &Int (ADDR_UINT48_UINT48 /Int pow160) ==Int 0 [simplification]
+    // This proof ends up with side-conditions which look like this:
+    // Tic ==K 0 andBool 0 ==K maxUInt48 &Int (#lookup(STORAGE, ADDR) /Int pow160) andBool Tic ==K maxUInt48 &Int (#lookup(STORAGE, ADDR) /Int pow160)
+    // So we need this rule to do the structural simplification because the Java backend will not use this string of equalities to do the simplification directly.
+    rule #WordPackAddrUInt48UInt48(ADDR, maxUInt48 &Int (ADDR_UINT48_UINT48 /Int pow160), UINT48_2) => #WordPackAddrUInt48UInt48(ADDR, 0, UINT48_2) requires maxUInt48 &Int (ADDR_UINT48_UINT48 /Int pow160) ==Int 0 [simplification]
 
-//   // ########################
-//   // Map
-//   // ########################
+  // ########################
+  // Map
+  // ########################
 
-//     // ### PERFORMANCE: vat-deny-diff-fail-rough
-//     // 27.21m -> 3.16m
+    // ### PERFORMANCE: vat-deny-diff-fail-rough
+    // 27.21m -> 3.16m
 
-//     rule M:Memory [ K <- V ]             [ K' <- V' ] => M [ K' <- V' ] [ K <- V ]    requires K' <Int K                           [simplification]
-//     rule M:Memory [ K := BUF:ByteArray ] [ K' <- V' ] => M [ K' <- V' ] [ K := BUF ]  requires K' <Int K 
-//                                                                                         orBool K +Int #sizeByteArray(BUF) <=Int K' [simplification]
+    rule M:Memory [ K <- V ]             [ K' <- V' ] => M [ K' <- V' ] [ K <- V ]    requires K' <Int K                           [simplification]
+    rule M:Memory [ K := BUF:ByteArray ] [ K' <- V' ] => M [ K' <- V' ] [ K := BUF ]  requires K' <Int K 
+                                                                                        orBool K +Int #sizeByteArray(BUF) <=Int K' [simplification]
 
-//     // ### dsvalue-read-pass
+    // ### dsvalue-read-pass
 
-//     rule M [ K <- V ] => M requires #lookup(M, K) ==Int V [simplification]
+    rule M [ K <- V ] => M requires #lookup(M, K) ==Int V [simplification]
 
-//     // ### flapper-yank-pass-rough
+    // ### flapper-yank-pass-rough
 
-//     rule M:Memory [ K := BUF:ByteArray ] [ K' := BUF':ByteArray ] => M [ K := (BUF [ 0 .. K' -Int K ]) ] [ K' := BUF' ]
-//       requires K <Int K'
-//        andBool K' <Int K +Int #sizeByteArray(BUF)
-//        andBool K +Int #sizeByteArray(BUF) <Int K' +Int #sizeByteArray(BUF')
-//       [simplification]
+    rule M:Memory [ K := BUF:ByteArray ] [ K' := BUF':ByteArray ] => M [ K := (BUF [ 0 .. K' -Int K ]) ] [ K' := BUF' ]
+      requires K <Int K'
+       andBool K' <Int K +Int #sizeByteArray(BUF)
+       andBool K +Int #sizeByteArray(BUF) <Int K' +Int #sizeByteArray(BUF')
+      [simplification]
 
-//     rule M:Map [ K1 <- _ ] [ K2 <- V2 ] [ K1 <- V1' ] => M [ K1 <- V1' ] [ K2 <- V2 ] requires K1 =/=Int K2 [simplification]
+    rule M:Map [ K1 <- _ ] [ K2 <- V2 ] [ K1 <- V1' ] => M [ K1 <- V1' ] [ K2 <- V2 ] requires K1 =/=Int K2 [simplification]
 
-//     // ### end-cage-ilk-pass-rough
+    // ### end-cage-ilk-pass-rough
 
-//     rule M:Memory [ K1 := (BUF11 ++ BUF12) ] [ K2 := BUF2 ] => M [ K1 +Int #sizeByteArray(BUF11) := BUF12 ] [ K2 := BUF2 ]
-//       requires K2 <=Int K1
-//        andBool K1 +Int #sizeByteArray(BUF11) <=Int K2 +Int #sizeByteArray(BUF2)
-//       [simplification]
+    rule M:Memory [ K1 := (BUF11 ++ BUF12) ] [ K2 := BUF2 ] => M [ K1 +Int #sizeByteArray(BUF11) := BUF12 ] [ K2 := BUF2 ]
+      requires K2 <=Int K1
+       andBool K1 +Int #sizeByteArray(BUF11) <=Int K2 +Int #sizeByteArray(BUF2)
+      [simplification]
 
-//   // ########################
-//   // Arithmetic
-//   // ########################
+  // ########################
+  // Arithmetic
+  // ########################
 
-//     // ### dstoken-transferfrom-fail-rough
+    // ### dstoken-transferfrom-fail-rough
 
-//     rule chop(N +Int M) <Int N => true  requires #rangeUInt(256, N) 
-//                                          andBool #rangeUInt(256, M)
-//                                          andBool notBool #rangeUInt(256, N +Int M)
-//                                         [simplification]
+    rule chop(N +Int M) <Int N => true  requires #rangeUInt(256, N) 
+                                         andBool #rangeUInt(256, M)
+                                         andBool notBool #rangeUInt(256, N +Int M)
+                                        [simplification]
 
-//     // ### flipper-bids-pass-rough
+    // ### flipper-bids-pass-rough
 
-//     // This lemma is considered "safe enough" because `keccak` is a hash function over a large range and is very unlikely to overflow.
-//     // Note that this case comes from a solidity struct being accessed (hence the integer offsets), so it's an assumption built into the Solidity compiler anyway.
-//     rule chop(keccak(BA) +Int N) => keccak(BA) +Int N requires 0 <=Int N andBool N <Int 6 [simplification]
+    // This lemma is considered "safe enough" because `keccak` is a hash function over a large range and is very unlikely to overflow.
+    // Note that this case comes from a solidity struct being accessed (hence the integer offsets), so it's an assumption built into the Solidity compiler anyway.
+    rule chop(keccak(BA) +Int N) => keccak(BA) +Int N requires 0 <=Int N andBool N <Int 6 [simplification]
 
-//     rule sgn(chop(X)) ==Int -1 => X <Int 0  requires #rangeSInt(256, X) [simplification]
+    rule sgn(chop(X)) ==Int -1 => X <Int 0  requires #rangeSInt(256, X) [simplification]
 
-//     // ### vat-mului-pass
+    // ### vat-mului-pass
 
-//     rule chop(X *Int chop(Y)) => chop(X *Int Y) [simplification]
+    rule chop(X *Int chop(Y)) => chop(X *Int Y) [simplification]
 
-//     // Proof #rangeUInt(256, X) andBool #rangeSInt(256, Y) andBool #rangeSInt(256, X *Int Y) andBool Y =/=Int 0
-//     //      chop(X *Int Y) /sWord chop(Y)
-//     //   => #sgnInterp(sgn(chop(X *Int Y)) *Int sgn(chop(Y)), abs(chop(X *Int Y)) /Word abs(chop(Y)))
-//     // Focus: sgn(chop(X *Int Y)) *Int sgn(chop(Y))
-//     //      case 0 <=Int Y
-//     //           sgn(chop(X *Int Y)) *Int sgn(chop(Y))
-//     //        => sgn(chop(X *Int Y)) *Int sgn(Y)                     // chop(Y) ==Int Y
-//     //        => sgn(X *Int Y) *Int sgn(Y)                           // 0 <=Int X andBool 0 <=Int Y
-//     //        => 1 *Int 1                                            // 0 <=Int X *Int Y andBool 0 <=Int Y
-//     //        => 1
-//     //      case Y <Int 0
-//     //           sgn(chop(X *Int Y)) *Int sgn(chop(Y))
-//     //        => sgn(X *Int Y +Int pow256) *Int sgn(Y +Int pow256)   // chop(Y) ==Int Y +Int pow256
-//     //        => -1 *Int -1                                          // X *Int Y <Int 0 andBool Y <Int 0
-//     //        => 1
-//     // Focus: abs(chop(X *Int Y)) /Word abs(chop(Y))
-//     //      case 0 <=Int Y
-//     //           abs(chop(X *Int Y)) /Word abs(chop(Y))
-//     //        => abs(chop(X *Int Y)) /Int  abs(chop(Y))
-//     //        => abs(X *Int Y) /Int abs(Y)                                                   // 0 <=Int X andBool 0 <=Int Y andBool #rangeSigne andBool chop(Y) ==Int Y
-//     //        => X *Int Y /Int Y                                                             // #rangeSInt(256, X *Int Y) andBool 0 <=Int X *Int Y andBool #rangeSInt(256, Y) andBool 0 <=Int Y
-//     //        => X
-//     //      case Y <Int 0
-//     //           abs(chop(X *Int Y)) /Int abs(chop(Y))
-//     //        => abs(X *Int Y +Int pow256) /Int abs(Y +Int pow256)                           // #rangeSInt(256, X *Int Y) andBool chop(Y) ==Int Y +Int pow256
-//     //        => (0 -Word (X *Int Y +Int pow256)) /Int (0 -Word (Y +Int pow256))             // #rangeSInt(256, X *Int Y) andBool X *Int Y <Int 0 andBool #rangeSInt(256, Y) andBool Y <Int 0
-//     //        => (pow256 -Int (X *Int Y +Int pow256)) /Int (pow256 -Int (Y +Int pow256))     // 0 <Int (X *Int Y +Int pow256) andBool 0 <Int (Y +Int pow256)
-//     //        => (X *Int Y) /Int Y
-//     //        => X
-//     //
-//     // Via Z3 4.7.1:
-//     // ; 2^4 and 2^3 instead of 2^256 and 2^255 for small model proof
-//     // (declare-const pow256 Int)
-//     // (assert (= pow256 16))
-//     // (declare-const pow255 Int)
-//     // (assert (= pow255 8))
-//     //
-//     // ; sgn
-//     // (declare-fun sgn (Int) Int)
-//     // (assert (forall ((x Int)) (=> (and (>= x 0)      (< x pow255)) (= (sgn x)  1))))
-//     // (assert (forall ((x Int)) (=> (and (>= x pow255) (< x pow256)) (= (sgn x) -1))))
-//     //
-//     // ; s<Word
-//     // (declare-fun slt (Int Int) Bool)
-//     // (assert (forall ((x Int) (y Int)) (=> (and (= (sgn x)  1) (= (sgn y)  1)) (= (slt x y) (< x y)))))
-//     // (assert (forall ((x Int) (y Int)) (=> (and (= (sgn x)  1) (= (sgn y) -1)) (= (slt x y) false))))
-//     // (assert (forall ((x Int) (y Int)) (=> (and (= (sgn x) -1) (= (sgn y)  1)) (= (slt x y) true))))
-//     // (assert (forall ((x Int) (y Int)) (=> (and (= (sgn x) -1) (= (sgn y) -1)) (= (slt x y) (> x y)))))
-//     //
-//     // ; chop
-//     // (define-fun chop ((x Int)) Int (mod x pow256))
-//     //
-//     // ; /Word
-//     // ;(define-fun zdiv ((x Int) (y Int)) Int (ite (= y 0) 0 (div x y)))
-//     // (define-fun zdiv ((x Int) (y Int)) Int (div x y)) ; y is non-zero in the query below
-//     //
-//     // ; /sWord
-//     // (declare-fun sdiv (Int Int) Int)
-//     // (assert (forall ((x Int) (y Int)) (=> (> (* (sgn x) (sgn y)) 0) (= (sdiv x y)    (zdiv (abs x) (abs y)) ))))
-//     // (assert (forall ((x Int) (y Int)) (=> (< (* (sgn x) (sgn y)) 0) (= (sdiv x y) (- (zdiv (abs x) (abs y)))))))
-//     //
-//     // ; uint256
-//     // (define-fun uint256 ((x Int)) Bool (and (>= x 0) (< x pow256)))
-//     //
-//     // ; sint256
-//     // (define-fun sint256 ((x Int)) Bool (and (>= x (- pow255)) (< x pow255)))
-//     //
-//     // ;;;; proof
-//     //
-//     // (declare-const x Int)
-//     // (declare-const y Int)
-//     //
-//     // (assert (uint256 x))
-//     // (assert (sint256 y))
-//     // (assert (sint256 (* x y)))
-//     // (assert (not (= y 0)))
-//     //
-//     // (assert (not
-//     //     (= (sdiv (chop (* x y)) (chop y)) x)
-//     // ))
-//     // (check-sat)
-//     rule chop(X *Int Y) /sWord chop(Y) => X requires #rangeUInt(256, X) andBool #rangeSInt(256, Y) andBool #rangeSInt(256, X *Int Y) andBool Y =/=Int 0 [simplification]
+    // Proof #rangeUInt(256, X) andBool #rangeSInt(256, Y) andBool #rangeSInt(256, X *Int Y) andBool Y =/=Int 0
+    //      chop(X *Int Y) /sWord chop(Y)
+    //   => #sgnInterp(sgn(chop(X *Int Y)) *Int sgn(chop(Y)), abs(chop(X *Int Y)) /Word abs(chop(Y)))
+    // Focus: sgn(chop(X *Int Y)) *Int sgn(chop(Y))
+    //      case 0 <=Int Y
+    //           sgn(chop(X *Int Y)) *Int sgn(chop(Y))
+    //        => sgn(chop(X *Int Y)) *Int sgn(Y)                     // chop(Y) ==Int Y
+    //        => sgn(X *Int Y) *Int sgn(Y)                           // 0 <=Int X andBool 0 <=Int Y
+    //        => 1 *Int 1                                            // 0 <=Int X *Int Y andBool 0 <=Int Y
+    //        => 1
+    //      case Y <Int 0
+    //           sgn(chop(X *Int Y)) *Int sgn(chop(Y))
+    //        => sgn(X *Int Y +Int pow256) *Int sgn(Y +Int pow256)   // chop(Y) ==Int Y +Int pow256
+    //        => -1 *Int -1                                          // X *Int Y <Int 0 andBool Y <Int 0
+    //        => 1
+    // Focus: abs(chop(X *Int Y)) /Word abs(chop(Y))
+    //      case 0 <=Int Y
+    //           abs(chop(X *Int Y)) /Word abs(chop(Y))
+    //        => abs(chop(X *Int Y)) /Int  abs(chop(Y))
+    //        => abs(X *Int Y) /Int abs(Y)                                                   // 0 <=Int X andBool 0 <=Int Y andBool #rangeSigne andBool chop(Y) ==Int Y
+    //        => X *Int Y /Int Y                                                             // #rangeSInt(256, X *Int Y) andBool 0 <=Int X *Int Y andBool #rangeSInt(256, Y) andBool 0 <=Int Y
+    //        => X
+    //      case Y <Int 0
+    //           abs(chop(X *Int Y)) /Int abs(chop(Y))
+    //        => abs(X *Int Y +Int pow256) /Int abs(Y +Int pow256)                           // #rangeSInt(256, X *Int Y) andBool chop(Y) ==Int Y +Int pow256
+    //        => (0 -Word (X *Int Y +Int pow256)) /Int (0 -Word (Y +Int pow256))             // #rangeSInt(256, X *Int Y) andBool X *Int Y <Int 0 andBool #rangeSInt(256, Y) andBool Y <Int 0
+    //        => (pow256 -Int (X *Int Y +Int pow256)) /Int (pow256 -Int (Y +Int pow256))     // 0 <Int (X *Int Y +Int pow256) andBool 0 <Int (Y +Int pow256)
+    //        => (X *Int Y) /Int Y
+    //        => X
+    //
+    // Via Z3 4.7.1:
+    // ; 2^4 and 2^3 instead of 2^256 and 2^255 for small model proof
+    // (declare-const pow256 Int)
+    // (assert (= pow256 16))
+    // (declare-const pow255 Int)
+    // (assert (= pow255 8))
+    //
+    // ; sgn
+    // (declare-fun sgn (Int) Int)
+    // (assert (forall ((x Int)) (=> (and (>= x 0)      (< x pow255)) (= (sgn x)  1))))
+    // (assert (forall ((x Int)) (=> (and (>= x pow255) (< x pow256)) (= (sgn x) -1))))
+    //
+    // ; s<Word
+    // (declare-fun slt (Int Int) Bool)
+    // (assert (forall ((x Int) (y Int)) (=> (and (= (sgn x)  1) (= (sgn y)  1)) (= (slt x y) (< x y)))))
+    // (assert (forall ((x Int) (y Int)) (=> (and (= (sgn x)  1) (= (sgn y) -1)) (= (slt x y) false))))
+    // (assert (forall ((x Int) (y Int)) (=> (and (= (sgn x) -1) (= (sgn y)  1)) (= (slt x y) true))))
+    // (assert (forall ((x Int) (y Int)) (=> (and (= (sgn x) -1) (= (sgn y) -1)) (= (slt x y) (> x y)))))
+    //
+    // ; chop
+    // (define-fun chop ((x Int)) Int (mod x pow256))
+    //
+    // ; /Word
+    // ;(define-fun zdiv ((x Int) (y Int)) Int (ite (= y 0) 0 (div x y)))
+    // (define-fun zdiv ((x Int) (y Int)) Int (div x y)) ; y is non-zero in the query below
+    //
+    // ; /sWord
+    // (declare-fun sdiv (Int Int) Int)
+    // (assert (forall ((x Int) (y Int)) (=> (> (* (sgn x) (sgn y)) 0) (= (sdiv x y)    (zdiv (abs x) (abs y)) ))))
+    // (assert (forall ((x Int) (y Int)) (=> (< (* (sgn x) (sgn y)) 0) (= (sdiv x y) (- (zdiv (abs x) (abs y)))))))
+    //
+    // ; uint256
+    // (define-fun uint256 ((x Int)) Bool (and (>= x 0) (< x pow256)))
+    //
+    // ; sint256
+    // (define-fun sint256 ((x Int)) Bool (and (>= x (- pow255)) (< x pow255)))
+    //
+    // ;;;; proof
+    //
+    // (declare-const x Int)
+    // (declare-const y Int)
+    //
+    // (assert (uint256 x))
+    // (assert (sint256 y))
+    // (assert (sint256 (* x y)))
+    // (assert (not (= y 0)))
+    //
+    // (assert (not
+    //     (= (sdiv (chop (* x y)) (chop y)) x)
+    // ))
+    // (check-sat)
+    rule chop(X *Int Y) /sWord chop(Y) => X requires #rangeUInt(256, X) andBool #rangeSInt(256, Y) andBool #rangeSInt(256, X *Int Y) andBool Y =/=Int 0 [simplification]
 
-//     // ### vat-slip-pass-rough
+    // ### vat-slip-pass-rough
 
-//     rule chop(X +Int chop(Y)) => chop(X +Int Y) [simplification]
+    rule chop(X +Int chop(Y)) => chop(X +Int Y) [simplification]
 
-//     // ### flipper-addu48u48-fail-rough
+    // ### flipper-addu48u48-fail-rough
 
-//     rule maxUInt48 &Int (X +Int Y) <Int X => true requires #rangeUInt(48, X) andBool #rangeUInt(48, Y) andBool notBool (X +Int Y <Int pow48) [simplification]
+    rule maxUInt48 &Int (X +Int Y) <Int X => true requires #rangeUInt(48, X) andBool #rangeUInt(48, Y) andBool notBool (X +Int Y <Int pow48) [simplification]
 
-//     // Via Z3 4.7.1:
-//     // (push)
-//     // (assert (not (=> (sint256 y) (= (= (sgn (chop y)) 1) (<= 0 y) ) ) ))
-//     // (check-sat)
-//     // (pop)
-//     rule sgn(chop(Y)) ==K 1 => 0 <=Int Y requires #rangeSInt(256, Y) [simplification]
+    // Via Z3 4.7.1:
+    // (push)
+    // (assert (not (=> (sint256 y) (= (= (sgn (chop y)) 1) (<= 0 y) ) ) ))
+    // (check-sat)
+    // (pop)
+    rule sgn(chop(Y)) ==K 1 => 0 <=Int Y requires #rangeSInt(256, Y) [simplification]
 
-//     // ### vat-subui-pass
+    // ### vat-subui-pass
 
-//     rule chop(X) ==K 0 => X ==Int 0 requires #rangeSInt(256, X) [simplification]
+    rule chop(X) ==K 0 => X ==Int 0 requires #rangeSInt(256, X) [simplification]
 
-//     // ### flopper-kick-pass-rough
+    // ### flopper-kick-pass-rough
 
-//     rule 0 <=Int X |Int Y => true requires 0 <=Int X andBool 0 <=Int Y [simplification]
-//     rule 0 <=Int X &Int Y => true requires 0 <=Int X andBool 0 <=Int Y [simplification]
+    rule 0 <=Int X |Int Y => true requires 0 <=Int X andBool 0 <=Int Y [simplification]
+    rule 0 <=Int X &Int Y => true requires 0 <=Int X andBool 0 <=Int Y [simplification]
 
-//     rule X |Int Y <Int pow256 => true requires X <Int pow256 andBool Y <Int pow256 [simplification]
-//     rule X &Int Y <Int pow256 => true requires X <Int pow256 andBool Y <Int pow256 [simplification]
+    rule X |Int Y <Int pow256 => true requires X <Int pow256 andBool Y <Int pow256 [simplification]
+    rule X &Int Y <Int pow256 => true requires X <Int pow256 andBool Y <Int pow256 [simplification]
 
-//     rule (maxUInt160 &Int (X |Int Y)) => (maxUInt160 &Int X) |Int (maxUInt160 &Int Y) [simplification]
+    rule (maxUInt160 &Int (X |Int Y)) => (maxUInt160 &Int X) |Int (maxUInt160 &Int Y) [simplification]
 
-//     // ### flopper-tick-pass-rough
+    // ### flopper-tick-pass-rough
 
-//     rule chop(X *Int Y) => X *Int Y requires 0 <=Int X andBool 0 <=Int Y andBool X *Int Y <Int pow256 [simplification]
+    rule chop(X *Int Y) => X *Int Y requires 0 <=Int X andBool 0 <=Int Y andBool X *Int Y <Int pow256 [simplification]
 
-//     // ### flapper-yank-pass-rough
+    // ### flapper-yank-pass-rough
 
-//     rule X <Int X -Int Y => false requires 0 <=Int Y [simplification]
-//     rule X +Int Y <Int X => false requires 0 <=Int Y [simplification]
+    rule X <Int X -Int Y => false requires 0 <=Int Y [simplification]
+    rule X +Int Y <Int X => false requires 0 <=Int Y [simplification]
 
-//     // ### vow-cage-surplus-pass-rough
+    // ### vow-cage-surplus-pass-rough
 
-//     rule <acctID> ACCTID </acctID>  ==K <acctID> ACCTID' </acctID> => ACCTID  ==Int ACCTID' [simplification]
-//     rule <acctID> ACCTID </acctID> =/=K <acctID> ACCTID' </acctID> => ACCTID =/=Int ACCTID' [simplification]
+    rule <acctID> ACCTID </acctID>  ==K <acctID> ACCTID' </acctID> => ACCTID  ==Int ACCTID' [simplification]
+    rule <acctID> ACCTID </acctID> =/=K <acctID> ACCTID' </acctID> => ACCTID =/=Int ACCTID' [simplification]
 
-//     rule ((K |-> _) REST) [ K' <- undef ] => REST                             requires K  ==K K' [simplification]
-//     rule ((K |-> V) REST) [ K' <- undef ] => (K |-> V) (REST [ K' <- undef ]) requires K =/=K K' [simplification]
+    rule ((K |-> _) REST) [ K' <- undef ] => REST                             requires K  ==K K' [simplification]
+    rule ((K |-> V) REST) [ K' <- undef ] => (K |-> V) (REST [ K' <- undef ]) requires K =/=K K' [simplification]
 
-//     // ### vat-frob-diff-zero-dart-pass-rough
+    // ### vat-frob-diff-zero-dart-pass-rough
 
-//     rule chop( X -Int chop(Y))         => chop( X -Int Y)         [simplification]
-//     rule chop((X -Int chop(Y)) *Int Z) => chop((X -Int Y) *Int Z) [simplification]
+    rule chop( X -Int chop(Y))         => chop( X -Int Y)         [simplification]
+    rule chop((X -Int chop(Y)) *Int Z) => chop((X -Int Y) *Int Z) [simplification]
 
-//     // ### vat-fork-diff-pass-rough
+    // ### vat-fork-diff-pass-rough
 
-//     rule chop(X +Int pow256)  => chop(X)        [simplification]
-//     rule chop(chop(X) *Int Y) => chop(X *Int Y) [simplification]
+    rule chop(X +Int pow256)  => chop(X)        [simplification]
+    rule chop(chop(X) *Int Y) => chop(X *Int Y) [simplification]
 
-//     // ### vow-cage-deficit-pass-rough
+    // ### vow-cage-deficit-pass-rough
 
-//     rule (I1 +Int I2) -Int I1 => I2 [simplification]
+    rule (I1 +Int I2) -Int I1 => I2 [simplification]
 
-//     // ### flapper-tend-guy-diff-pass-rough
+    // ### flapper-tend-guy-diff-pass-rough
 
-//     rule ((I1 -Int I2) -Int I3) +Int I2 => I1 -Int I3 [simplification]
+    rule ((I1 -Int I2) -Int I3) +Int I2 => I1 -Int I3 [simplification]
 
-//     rule M:Map [ K1 <- _ ] [ K2 <- V2 ] [ K3 <- V3 ] [ K1 <- V4 ] => M [ K1 <- V4 ] [ K2 <- V2 ] [ K3 <- V3 ] requires K1 =/=Int K2 andBool K1 =/=Int K3 [simplification]
+    rule M:Map [ K1 <- _ ] [ K2 <- V2 ] [ K3 <- V3 ] [ K1 <- V4 ] => M [ K1 <- V4 ] [ K2 <- V2 ] [ K3 <- V3 ] requires K1 =/=Int K2 andBool K1 =/=Int K3 [simplification]
 
-//     // ### vat-fold-pass-rough
+    // ### vat-fold-pass-rough
 
-//     rule chop(X *Int (Y +Int pow256)) => chop(X *Int Y) [simplification]
+    rule chop(X *Int (Y +Int pow256)) => chop(X *Int Y) [simplification]
 
-// endmodule
+endmodule

--- a/tests/specs/mcd/verification.k
+++ b/tests/specs/mcd/verification.k
@@ -95,8 +95,6 @@ module LEMMAS-MCD-JAVA [symbolic, kast]
   // Range
   // ########################
 
-    // ### flapper-yank-pass-rough
-
     rule #range(M:Memory [ K <- V ]                        , START, WIDTH) => #range(M [ K := (V : .ByteArray) ], START, WIDTH)  requires #isConcrete(K)  andBool #isConcrete(V) andBool START <=Int K andBool 0 <Int WIDTH andBool 0 <=Int START andBool K +Int 1                    ==Int START +Int WIDTH [simplification]
     rule #range(M:Memory [ K <- V ] [ K' := VS':ByteArray ], START, WIDTH) => #range(M [ K := (V : VS')        ], START, WIDTH)  requires #isConcrete(K)  andBool #isConcrete(V) andBool START <=Int K andBool 0 <Int WIDTH andBool 0 <=Int START andBool K +Int 1                    ==Int K'              
                                                                                                                                   andBool #isConcrete(K') andBool #isConcrete(VS')                                                                andBool K' +Int #sizeByteArray(VS') ==Int START +Int WIDTH [simplification] 
@@ -229,16 +227,12 @@ module LEMMAS-MCD-COMMON
     // (pop)
     rule 0 s<Word X => bool2Word(sgn(X) ==Int 1 andBool X =/=Int 0) requires #rangeUInt(256, X) [simplification]
 
-    // ### vat-subui-pass-rough
-
     // Via Z3 4.7.1:
     // (push)
     // (assert (not (=> true (= (chop (- x (chop y))) (chop (- x y)) ) ) ))
     // (check-sat)
     // (pop)
     rule X -Word chop(Y) => chop(X -Int Y) [simplification]
-
-    // ### end-pack-pass-rough
 
     rule ADDR in (SetItem(I) REST) => ADDR in REST requires #notPrecompileAddress(ADDR) andBool notBool #notPrecompileAddress(I) [simplification]
 

--- a/tests/specs/opcodes/verification.k
+++ b/tests/specs/opcodes/verification.k
@@ -3,6 +3,10 @@ requires "edsl.md"
 module VERIFICATION
     imports EDSL
 
+  // ########################
+  // Buffer Reasoning
+  // ########################
+
     syntax ByteArray ::= "#generatedCode" [function]
  // ------------------------------------------------
     // This rule is used to avoid complicated memory allocation gas cost.
@@ -10,6 +14,9 @@ module VERIFICATION
     // as #generatedCode will be a concrete byte array.
     rule #sizeByteArray(#generatedCode) => 0 [simplification]
 
+  // ########################
+  // Placeholders
+  // ########################
 
     // TODO: should these be here or in tests/specs/opcodes/create-spec.k?
     //       see comment at beginning of that file.

--- a/tests/specs/opcodes/verification.k
+++ b/tests/specs/opcodes/verification.k
@@ -4,17 +4,6 @@ module VERIFICATION
     imports EDSL
 
   // ########################
-  // Buffer Reasoning
-  // ########################
-
-    syntax ByteArray ::= "#generatedCode" [function]
- // ------------------------------------------------
-    // This rule is used to avoid complicated memory allocation gas cost.
-    // when doing actual proof, the rule is no longer needed 
-    // as #generatedCode will be a concrete byte array.
-    rule #sizeByteArray(#generatedCode) => 0 [simplification]
-
-  // ########################
   // Placeholders
   // ########################
 
@@ -24,6 +13,17 @@ module VERIFICATION
                  | "#memWidth" [function]
 
     syntax Memory ::= "#mapWithCode" [function]
+
+  // ########################
+  // Buffer Reasoning
+  // ########################
+
+    syntax ByteArray ::= "#generatedCode" [function]
+ // ------------------------------------------------
+    // This rule is used to avoid complicated memory allocation gas cost.
+    // when doing actual proof, the rule is no longer needed 
+    // as #generatedCode will be a concrete byte array.
+    rule #sizeByteArray(#generatedCode) => 0 [simplification]
 
   // ########################
   // Arithmetic

--- a/tests/specs/opcodes/verification.k
+++ b/tests/specs/opcodes/verification.k
@@ -4,11 +4,23 @@ module VERIFICATION
     imports EDSL
 
     syntax ByteArray ::= "#generatedCode" [function]
+ // ------------------------------------------------
+    // This rule is used to avoid complicated memory allocation gas cost.
+    // when doing actual proof, the rule is no longer needed 
+    // as #generatedCode will be a concrete byte array.
+    rule #sizeByteArray(#generatedCode) => 0 [simplification]
 
+
+    // TODO: should these be here or in tests/specs/opcodes/create-spec.k?
+    //       see comment at beginning of that file.
     syntax Int ::= "#memStart" [function]
                  | "#memWidth" [function]
 
     syntax Memory ::= "#mapWithCode" [function]
+
+  // ########################
+  // Arithmetic
+  // ########################
 
     rule I -Int 0 => I [simplification]
 
@@ -16,17 +28,9 @@ module VERIFICATION
 
     rule I +Int 0 => I [simplification]
 
-    rule chop(I) => I requires 0 <=Int I andBool I <Int pow256 [simplification]
+    rule chop(I) => I  requires 0 <=Int I andBool I <Int pow256 [simplification]
 
-    // This rule is used to avoid complicated memory allocation gas cost.
-    // when doing actual proof, the rule is no longer needed 
-    // as #generatedCode will be a concrete byte array.
-    rule #sizeByteArray(#generatedCode) => 0 [simplification]
-
-    rule #sizeWordStack ( WS , N:Int ) => N +Int #sizeWordStack ( WS , 0 )
-      requires N =/=K 0
-      [simplification]
-
-    rule 0 <=Int #sizeWordStack ( _ , _ ) => true [simplification, smt-lemma]
+    rule 0 <=Int #sizeWordStack ( _  , _     ) => true                                                [simplification, smt-lemma]
+    rule         #sizeWordStack ( WS , N:Int ) => N +Int #sizeWordStack ( WS , 0 )  requires N =/=K 0 [simplification]
 
 endmodule

--- a/tests/specs/opcodes/verification.k
+++ b/tests/specs/opcodes/verification.k
@@ -37,7 +37,7 @@ module VERIFICATION
 
     rule chop(I) => I  requires 0 <=Int I andBool I <Int pow256 [simplification]
 
-    rule 0 <=Int #sizeWordStack ( _  , _     ) => true                              requires 0  <=Int N [simplification, smt-lemma]
-    rule         #sizeWordStack ( WS , N:Int ) => N +Int #sizeWordStack ( WS , 0 )  requires N =/=K   0 [simplification]
+    rule 0 <=Int #sizeWordStack ( _  , N ) => true                             requires 0  <=Int N [simplification, smt-lemma]
+    rule         #sizeWordStack ( WS , N ) => N +Int #sizeWordStack ( WS , 0 ) requires N =/=Int 0 [simplification]
 
 endmodule

--- a/tests/specs/opcodes/verification.k
+++ b/tests/specs/opcodes/verification.k
@@ -37,7 +37,7 @@ module VERIFICATION
 
     rule chop(I) => I  requires 0 <=Int I andBool I <Int pow256 [simplification]
 
-    rule 0 <=Int #sizeWordStack ( _  , _     ) => true                                                [simplification, smt-lemma]
-    rule         #sizeWordStack ( WS , N:Int ) => N +Int #sizeWordStack ( WS , 0 )  requires N =/=K 0 [simplification]
+    rule 0 <=Int #sizeWordStack ( _  , _     ) => true                              requires 0  <=Int N [simplification, smt-lemma]
+    rule         #sizeWordStack ( WS , N:Int ) => N +Int #sizeWordStack ( WS , 0 )  requires N =/=K   0 [simplification]
 
 endmodule


### PR DESCRIPTION
Fixes #1071

Organized the lemmas is `tests/specs/lemmas.k` and `tests/specs/**/verification.k` into
- titled sections
- standardized formatting conventions
- matching column formatting for related lemmas

**no semantic changes to the lemmas should have been performed.**