### PR TITLE
Generalize Haskell lemmas in `tests/specs/lemmas.k` and `tests/specs/benchmarks/verification.k`

### DIFF
--- a/tests/specs/benchmarks/verification.k
+++ b/tests/specs/benchmarks/verification.k
@@ -113,7 +113,8 @@ module VERIFICATION
   // Simplification
   // ########################
 
-    rule #asWord(#buf(32, DATA)) => DATA  requires #rangeUInt(256, DATA) [simplification]
+    // TODO: possibly generalizes via lemma from lemmas.k
+    // rule #asWord(#buf(32, DATA)) => DATA  requires #rangeUInt(256, DATA) [simplification]
 
     rule #range(_M [ N := #buf(WIDTH, DATA) ], N, WIDTH) => #buf(WIDTH, DATA) [simplification]
 

--- a/tests/specs/benchmarks/verification.k
+++ b/tests/specs/benchmarks/verification.k
@@ -50,20 +50,6 @@ module VERIFICATION
     rule          #symEcrec(_DATA) <Int pow256 => true [simplification]
 
   // ########################
-  // Symbolic Call
-  // ########################
-
-    syntax Int ::= #extCodeSize ( Int )  [function]
- // -----------------------------------------------
-
-  // ########################
-  // Rule Replacement
-  // ########################
-
-    // TODO: is this needed anymore?
-    // claim <k> EXTCODESIZE ACCT => #extCodeSize(ACCT) ~> #push ... </k>  [trusted]
-
-  // ########################
   // ABI Encoding
   // ########################
 

--- a/tests/specs/benchmarks/verification.k
+++ b/tests/specs/benchmarks/verification.k
@@ -96,7 +96,7 @@ module VERIFICATION
     rule #sizeWordStack(WS, N) <Int SIZE => #sizeWordStack(WS, 0) +Int N <Int SIZE  requires N =/=Int 0 [simplification]
 
     rule SIZELIMIT <Int #sizeWordStack(WS, N) +Int DELTA  => SIZELIMIT <Int (#sizeWordStack(WS, 0) +Int N) +Int DELTA  requires N =/=Int 0 [simplification]
-    rule SIZELIMIT <Int #sizeWordStack(WS, N)             => SIZELIMIT <Int #sizeWordStack(WS, 0) +Int N               requires N =/=Int 0 [simplification]
+    rule SIZELIMIT <Int #sizeWordStack(WS, N)             => SIZELIMIT <Int  #sizeWordStack(WS, 0) +Int N              requires N =/=Int 0 [simplification]
 
     rule #sizeWordStack(WS, N) <=Int SIZE => #sizeWordStack(WS, 0) +Int N <=Int SIZE  requires N =/=Int 0 [simplification]
 

--- a/tests/specs/benchmarks/verification.k
+++ b/tests/specs/benchmarks/verification.k
@@ -60,7 +60,8 @@ module VERIFICATION
   // Rule Replacement
   // ########################
 
-    claim <k> EXTCODESIZE ACCT => #extCodeSize(ACCT) ~> #push ... </k>  [trusted]
+    // TODO: is this needed anymore?
+    // claim <k> EXTCODESIZE ACCT => #extCodeSize(ACCT) ~> #push ... </k>  [trusted]
 
   // ########################
   // ABI Encoding

--- a/tests/specs/benchmarks/verification.k
+++ b/tests/specs/benchmarks/verification.k
@@ -182,7 +182,7 @@ module VERIFICATION
 
     rule ((X *Int Y) /Int Z) /Int Y => X /Int Z  requires Y =/=Int 0 [simplification]
 
-    // x &Int (NOT 31)
+    // X &Int (NOT 31)
     rule X &Int 115792089237316195423570985008687907853269984665640564039457584007913129639904 => (X /Int 32) *Int 32  requires 0 <=Int X [simplification]
 
     rule (X /Int 32) *Int 32 => X  requires X modInt 32 ==Int 0 [simplification]

--- a/tests/specs/benchmarks/verification.k
+++ b/tests/specs/benchmarks/verification.k
@@ -127,7 +127,8 @@ module VERIFICATION
   // Simplification
   // ########################
 
-    rule #asWord(#buf(32, DATA)) => DATA  requires #rangeUInt(256, DATA) [simplification]
+    // TODO: is generalized by `#asWord(#buf(N, BUF)) => BUF` in `lemmas.k`?
+    // rule #asWord(#buf(32, DATA)) => DATA  requires #rangeUInt(256, DATA) [simplification]
 
     rule #range(_M [ N := #buf(WIDTH, DATA) ], N, WIDTH) => #buf(WIDTH, DATA) [simplification]
 

--- a/tests/specs/benchmarks/verification.k
+++ b/tests/specs/benchmarks/verification.k
@@ -127,8 +127,7 @@ module VERIFICATION
   // Simplification
   // ########################
 
-    // TODO: is generalized by `#asWord(#buf(N, BUF)) => BUF` in `lemmas.k`?
-    // rule #asWord(#buf(32, DATA)) => DATA  requires #rangeUInt(256, DATA) [simplification]
+    rule #asWord(#buf(32, DATA)) => DATA  requires #rangeUInt(256, DATA) [simplification]
 
     rule #range(_M [ N := #buf(WIDTH, DATA) ], N, WIDTH) => #buf(WIDTH, DATA) [simplification]
 

--- a/tests/specs/benchmarks/verification.k
+++ b/tests/specs/benchmarks/verification.k
@@ -32,7 +32,7 @@ module VERIFICATION
   // Gas Calculation
   // ########################
 
-    rule Rsstore(BYZANTIUM, NEW, _CURR, _ORIG) => 0  requires NEW =/=Int 0 [simplification]
+    rule Rsstore(_BYZANTIUM, NEW, _CURR, _ORIG) => 0  requires NEW =/=Int 0 [simplification]
 
   // ########################
   // Ecrecover
@@ -42,10 +42,8 @@ module VERIFICATION
 
     //case 0 is never wrapped into #symEcrec(), corresponds to #ecrecEmpty(DATA) == true
     rule 0 <Int   #symEcrec(_DATA)             => true [simplification]
-
     //that's because the result in concrete semantics is trimmed to Address range.
     rule          #symEcrec(_DATA) <Int pow160 => true [simplification]
-
     // Lemmas implied by the above, but still required to match side conditions of #padToWidth rule in lemmas.md
     // General range conversion lemmas like below are not an option, dramatic performance decrease:
     rule 0 <=Int  #symEcrec(_DATA)             => true [simplification]
@@ -80,17 +78,8 @@ module VERIFICATION
   // Memory Usage
   // ########################
 
-    rule #memoryUsageUpdate(#memoryUsageUpdate(MU, START0, WIDTH0), START1, WIDTH1) => #memoryUsageUpdate(MU, START0, WIDTH0)
-      requires START1 +Int WIDTH1 <=Int START0 +Int WIDTH0
-       andBool 0  <Int WIDTH0
-       andBool 0 <=Int WIDTH1
-      [simplification]
-
-    rule #memoryUsageUpdate(#memoryUsageUpdate(MU, START0, WIDTH0), START1, WIDTH1) => #memoryUsageUpdate(MU, START1, WIDTH1)
-      requires START0 +Int WIDTH0 <Int START1 +Int WIDTH1
-       andBool 0 <=Int WIDTH0
-       andBool 0  <Int WIDTH1
-      [simplification]
+    rule #memoryUsageUpdate(#memoryUsageUpdate(MU, START0, WIDTH0), START1, WIDTH1) => #memoryUsageUpdate(MU, START0, WIDTH0) requires START1 +Int WIDTH1 <=Int START0 +Int WIDTH0 andBool 0  <Int WIDTH0 andBool 0 <=Int WIDTH1 [simplification]
+    rule #memoryUsageUpdate(#memoryUsageUpdate(MU, START0, WIDTH0), START1, WIDTH1) => #memoryUsageUpdate(MU, START1, WIDTH1) requires START0 +Int WIDTH0  <Int START1 +Int WIDTH1 andBool 0 <=Int WIDTH0 andBool 0  <Int WIDTH1 [simplification]
 
     rule 0 <=Int #memoryUsageUpdate(_MU, _START, _WIDTH) => true [simplification]
 
@@ -98,8 +87,10 @@ module VERIFICATION
   // Buffer Reasoning
   // ########################
 
+    // ++-identity-right
     rule WS ++ .ByteArray => WS [simplification]
 
+    // ++-associativity
     rule ( WS1 ++ WS2 ) ++ WS3 => WS1 ++ ( WS2 ++ WS3 ) [simplification]
 
     rule #sizeWordStack(WS, N) <Int SIZE => #sizeWordStack(WS, 0) +Int N <Int SIZE  requires N =/=Int 0 [simplification]

--- a/tests/specs/benchmarks/verification.k
+++ b/tests/specs/benchmarks/verification.k
@@ -113,9 +113,6 @@ module VERIFICATION
   // Simplification
   // ########################
 
-    // TODO: possibly generalizes via lemma from lemmas.k
-    // rule #asWord(#buf(32, DATA)) => DATA  requires #rangeUInt(256, DATA) [simplification]
-
     rule #range(_M [ N := #buf(WIDTH, DATA) ], N, WIDTH) => #buf(WIDTH, DATA) [simplification]
 
     rule #asWord(WS) &Int maxUInt256 => #asWord(WS) [simplification]

--- a/tests/specs/lemmas.k
+++ b/tests/specs/lemmas.k
@@ -200,10 +200,6 @@ module LEMMAS-JAVA [symbolic, kast]
 
     // associate concrete terms to the left and symbolic terms to the right
     
-    // // OLD
-    // rule (A  +Int  J) +Int  K  =>  A +Int (J  +Int K) requires #isConcrete(J) andBool #isConcrete(K) andBool notBool #isConcrete(A) [simplification]
-    // rule  I  +Int (B  +Int  K) =>  B +Int (I  +Int K) requires #isConcrete(I) andBool #isConcrete(K) andBool notBool #isConcrete(B) [simplification]
-    // NEW (moves symbolic terms to the fight)
     rule (A  +Int  J) +Int  K  => (J +Int K) +Int A requires #isConcrete(J) andBool #isConcrete(K) andBool notBool #isConcrete(A) [simplification]
     rule  I  +Int (B  +Int  K) => (I +Int K) +Int B requires #isConcrete(I) andBool #isConcrete(K) andBool notBool #isConcrete(B) [simplification]
 

--- a/tests/specs/lemmas.k
+++ b/tests/specs/lemmas.k
@@ -212,15 +212,15 @@ module LEMMAS-JAVA [symbolic, kast]
  notBool #isConcrete(C) andBool
 
     // NEW
-    rule (A +Int J) +Int K => A +Int (J +Int K) requires #isConcrete(J) andBool #isConcrete(K) andBool notBool #isConcrete(A) [simplification]
-    rule I +Int (B +Int K) => B +Int (I +Int K) requires #isConcrete(I) andBool #isConcrete(K) andBool notBool #isConcrete(B) [simplification]
-    rule I -Int (B +Int K) => (I -Int K) -Int B requires #isConcrete(I) andBool #isConcrete(K) andBool notBool #isConcrete(B) [simplification]
-    rule (I -Int B) +Int K => (I +Int K) -Int B requires #isConcrete(I) andBool #isConcrete(K) andBool notBool #isConcrete(B) [simplification]
-    rule I +Int (J +Int C) => (I +Int J) +Int C requires #isConcrete(I) andBool #isConcrete(J) andBool notBool #isConcrete(C) [simplification]
-    rule I +Int (J -Int C) => (I +Int J) -Int C requires #isConcrete(I) andBool #isConcrete(J) andBool notBool #isConcrete(C) [simplification]
-    rule I -Int (J +Int C) => (I -Int J) -Int C requires #isConcrete(I) andBool #isConcrete(J) andBool notBool #isConcrete(C) [simplification]
-    rule I -Int (J -Int C) => (I -Int J) +Int C requires #isConcrete(I) andBool #isConcrete(J) andBool notBool #isConcrete(C) [simplification]
-    rule I &Int (J &Int C) => (I &Int J) &Int C requires #isConcrete(I) andBool #isConcrete(J) andBool notBool #isConcrete(C) [simplification]
+    rule (A +Int  J) +Int K  =>  A +Int (J  +Int K) requires #isConcrete(J) andBool #isConcrete(K) andBool notBool #isConcrete(A) [simplification]
+    rule  I +Int (B  +Int K) =>  B +Int (I  +Int K) requires #isConcrete(I) andBool #isConcrete(K) andBool notBool #isConcrete(B) [simplification]
+    rule  I -Int (B  +Int K) => (I -Int  K) -Int B  requires #isConcrete(I) andBool #isConcrete(K) andBool notBool #isConcrete(B) [simplification]
+    rule (I -Int  B) +Int K  => (I +Int  K) -Int B  requires #isConcrete(I) andBool #isConcrete(K) andBool notBool #isConcrete(B) [simplification]
+    rule  I +Int (J  +Int C) => (I +Int  J) +Int C  requires #isConcrete(I) andBool #isConcrete(J) andBool notBool #isConcrete(C) [simplification]
+    rule  I +Int (J  -Int C) => (I +Int  J) -Int C  requires #isConcrete(I) andBool #isConcrete(J) andBool notBool #isConcrete(C) [simplification]
+    rule  I -Int (J  +Int C) => (I -Int  J) -Int C  requires #isConcrete(I) andBool #isConcrete(J) andBool notBool #isConcrete(C) [simplification]
+    rule  I -Int (J  -Int C) => (I -Int  J) +Int C  requires #isConcrete(I) andBool #isConcrete(J) andBool notBool #isConcrete(C) [simplification]
+    rule  I &Int (J  &Int C) => (I &Int  J) &Int C  requires #isConcrete(I) andBool #isConcrete(J) andBool notBool #isConcrete(C) [simplification]
 
     // 0xffff...f &Int N = N
     // MASK = 0xffff...f

--- a/tests/specs/lemmas.k
+++ b/tests/specs/lemmas.k
@@ -9,12 +9,12 @@ module LEMMAS
   // Arithmetic
   // ########################
 
-    //For #bufStrict simplification in benchmarks
-    // // TODO: why does this need to be an `smt-lemma`?
-    // rule 0 <=Int #ceil32(I)        => true requires 0 <=Int I [simplification, smt-lemma]
-    // rule 0 <=Int #ceil32(I) -Int I => true requires 0 <=Int I [simplification]
-    // TODO: possibly generalizes the above two rules
-    rule 0 <=Int #ceil32(I) -Int J => true requires J <=Int I [simplification, smt-lemma]
+    // For #bufStrict simplification in benchmarks
+    // TODO: why does this need to be an `smt-lemma`?
+    rule 0 <=Int #ceil32(I)        => true requires 0 <=Int I [simplification, smt-lemma]
+    rule 0 <=Int #ceil32(I) -Int I => true requires 0 <=Int I [simplification]
+    // // TODO: possibly generalizes the above two rules
+    // rule 0 <=Int #ceil32(I) -Int J => true requires J <=Int I [simplification, smt-lemma]
 
     //Inequality sign normalization
     rule          X  >Int Y  => Y  <Int X            [simplification]

--- a/tests/specs/lemmas.k
+++ b/tests/specs/lemmas.k
@@ -205,17 +205,18 @@ module LEMMAS-JAVA [symbolic, kast]
     // 3 terms
 
     // symbolic first: A, J, K
-    rule (A  +Int  J) +Int  K  =>  A  +Int (J  +Int  K) requires #isConcrete(J) andBool #isConcrete(K) andBool (notBool #isConcrete(A)) [simplification]
+    //rule (A  +Int  J) +Int  K  =>  A  +Int (J  +Int  K) requires #isConcrete(J) andBool #isConcrete(K) andBool (notBool #isConcrete(A)) [simplification]
+    rule (A  +Int  J) +Int  K  => (J +Int K) +Int A  requires #isConcrete(J) andBool #isConcrete(K) andBool (notBool #isConcrete(A)) [simplification]
     // symbolic second: I, B, K
-    rule  I  +Int (B  +Int  K) => (I  +Int  K) +Int  B  requires #isConcrete(I) andBool #isConcrete(K) andBool (notBool #isConcrete(B)) [simplification]
-    rule  I  -Int (B  +Int  K) => (I  -Int  K) -Int  B  requires #isConcrete(I) andBool #isConcrete(K) andBool (notBool #isConcrete(B)) [simplification]
-    rule (I  -Int  B) +Int  K  => (I  +Int  K) -Int  B  requires #isConcrete(I) andBool #isConcrete(K) andBool (notBool #isConcrete(B)) [simplification]
+    rule  I  +Int (B  +Int  K) => (I +Int K) +Int B  requires #isConcrete(I) andBool #isConcrete(K) andBool (notBool #isConcrete(B)) [simplification]
+    rule  I  -Int (B  +Int  K) => (I -Int K) -Int B  requires #isConcrete(I) andBool #isConcrete(K) andBool (notBool #isConcrete(B)) [simplification]
+    rule (I  -Int  B) +Int  K  => (I +Int K) -Int B  requires #isConcrete(I) andBool #isConcrete(K) andBool (notBool #isConcrete(B)) [simplification]
     // symbolic third: I, J, C
-    rule  I  +Int (J  +Int  C) => (I  +Int  J) +Int  C  requires #isConcrete(I) andBool #isConcrete(J) andBool (notBool #isConcrete(C)) [simplification]
-    rule  I  +Int (J  -Int  C) => (I  +Int  J) -Int  C  requires #isConcrete(I) andBool #isConcrete(J) andBool (notBool #isConcrete(C)) [simplification]
-    rule  I  -Int (J  +Int  C) => (I  -Int  J) -Int  C  requires #isConcrete(I) andBool #isConcrete(J) andBool (notBool #isConcrete(C)) [simplification]
-    rule  I  -Int (J  -Int  C) => (I  -Int  J) +Int  C  requires #isConcrete(I) andBool #isConcrete(J) andBool (notBool #isConcrete(C)) [simplification]
-    rule  I  &Int (J  &Int  C) => (I  &Int  J) &Int  C  requires #isConcrete(I) andBool #isConcrete(J) andBool (notBool #isConcrete(C)) [simplification]
+    rule  I  +Int (J  +Int  C) => (I +Int J) +Int C  requires #isConcrete(I) andBool #isConcrete(J) andBool (notBool #isConcrete(C)) [simplification]
+    rule  I  +Int (J  -Int  C) => (I +Int J) -Int C  requires #isConcrete(I) andBool #isConcrete(J) andBool (notBool #isConcrete(C)) [simplification]
+    rule  I  -Int (J  +Int  C) => (I -Int J) -Int C  requires #isConcrete(I) andBool #isConcrete(J) andBool (notBool #isConcrete(C)) [simplification]
+    rule  I  -Int (J  -Int  C) => (I -Int J) +Int C  requires #isConcrete(I) andBool #isConcrete(J) andBool (notBool #isConcrete(C)) [simplification]
+    rule  I  &Int (J  &Int  C) => (I &Int J) &Int C  requires #isConcrete(I) andBool #isConcrete(J) andBool (notBool #isConcrete(C)) [simplification]
 
     // 0xffff...f &Int N = N
     // MASK = 0xffff...f

--- a/tests/specs/lemmas.k
+++ b/tests/specs/lemmas.k
@@ -194,25 +194,27 @@ module LEMMAS-JAVA [symbolic, kast]
     rule _N &Int  0 => 0
     rule  N &Int  N => N
 
-    // orienting symbolic term to be first, converting -Int to +Int for concrete values.
-    rule I +Int B => B         +Int I  requires #isConcrete(I) andBool notBool #isConcrete(B) [simplification]
-    rule A -Int I => A +Int (0 -Int I) requires #isConcrete(I) andBool notBool #isConcrete(A) [simplification]
+    // 2 terms
 
-    // associate concrete terms to the left and symbolic terms to the right
+    // associate symbolic terms to the left, concrete terms to the right
+    rule I +Int B => B +Int I          requires #isConcrete(I) andBool (notBool #isConcrete(B)) [simplification]
+    // converting -Int to +Int for concrete values.
+    rule A -Int I => A +Int (0 -Int I) requires #isConcrete(I) andBool (notBool #isConcrete(A)) [simplification]
     
-    rule (A  +Int  J) +Int  K  => (J +Int K) +Int A requires #isConcrete(J) andBool #isConcrete(K) andBool notBool #isConcrete(A) [simplification]
-    rule  I  +Int (B  +Int  K) => (I +Int K) +Int B requires #isConcrete(I) andBool #isConcrete(K) andBool notBool #isConcrete(B) [simplification]
+    // 3 terms
 
-    rule  I  -Int (B  +Int  K) => (I -Int K) -Int B requires #isConcrete(I) andBool #isConcrete(K) andBool notBool #isConcrete(B) [simplification]
-    rule (I  -Int  B) +Int  K  => (I +Int K) -Int B requires #isConcrete(I) andBool #isConcrete(K) andBool notBool #isConcrete(B) [simplification]
-
-    rule  I  +Int (J  +Int  C) => (I +Int J) +Int C requires #isConcrete(I) andBool #isConcrete(J) andBool notBool #isConcrete(C) [simplification]
-    rule  I  +Int (J  -Int  C) => (I +Int J) -Int C requires #isConcrete(I) andBool #isConcrete(J) andBool notBool #isConcrete(C) [simplification]
-
-    rule  I  -Int (J  +Int  C) => (I -Int J) -Int C requires #isConcrete(I) andBool #isConcrete(J) andBool notBool #isConcrete(C) [simplification]
-    rule  I  -Int (J  -Int  C) => (I -Int J) +Int C requires #isConcrete(I) andBool #isConcrete(J) andBool notBool #isConcrete(C) [simplification]
-
-    rule  I  &Int (J  &Int  C) => (I &Int J) &Int C requires #isConcrete(I) andBool #isConcrete(J) andBool notBool #isConcrete(C) [simplification]
+    // symbolic first: A, J, K
+    rule (A  +Int  J) +Int  K  =>  A  +Int (J  +Int  K) requires #isConcrete(J) andBool #isConcrete(K) andBool (notBool #isConcrete(A)) [simplification]
+    // symbolic second: I, B, K
+    rule  I  +Int (B  +Int  K) => (I  +Int  K) +Int  B  requires #isConcrete(I) andBool #isConcrete(K) andBool (notBool #isConcrete(B)) [simplification]
+    rule  I  -Int (B  +Int  K) => (I  -Int  K) -Int  B  requires #isConcrete(I) andBool #isConcrete(K) andBool (notBool #isConcrete(B)) [simplification]
+    rule (I  -Int  B) +Int  K  => (I  +Int  K) -Int  B  requires #isConcrete(I) andBool #isConcrete(K) andBool (notBool #isConcrete(B)) [simplification]
+    // symbolic third: I, J, C
+    rule  I  +Int (J  +Int  C) => (I  +Int  J) +Int  C  requires #isConcrete(I) andBool #isConcrete(J) andBool (notBool #isConcrete(C)) [simplification]
+    rule  I  +Int (J  -Int  C) => (I  +Int  J) -Int  C  requires #isConcrete(I) andBool #isConcrete(J) andBool (notBool #isConcrete(C)) [simplification]
+    rule  I  -Int (J  +Int  C) => (I  -Int  J) -Int  C  requires #isConcrete(I) andBool #isConcrete(J) andBool (notBool #isConcrete(C)) [simplification]
+    rule  I  -Int (J  -Int  C) => (I  -Int  J) +Int  C  requires #isConcrete(I) andBool #isConcrete(J) andBool (notBool #isConcrete(C)) [simplification]
+    rule  I  &Int (J  &Int  C) => (I  &Int  J) &Int  C  requires #isConcrete(I) andBool #isConcrete(J) andBool (notBool #isConcrete(C)) [simplification]
 
     // 0xffff...f &Int N = N
     // MASK = 0xffff...f

--- a/tests/specs/lemmas.k
+++ b/tests/specs/lemmas.k
@@ -10,7 +10,7 @@ module LEMMAS
   // ########################
 
     //For #bufStrict simplification in benchmarks
-    rule 0 <=Int #ceil32(I)        => true requires 0 <=Int I [smt-lemma, simplification]
+    rule 0 <=Int #ceil32(I)        => true requires 0 <=Int I [simplification, smt-lemma]
     rule 0 <=Int #ceil32(I) -Int I => true requires 0 <=Int I [simplification]
 
     //Inequality sign normalization
@@ -75,25 +75,23 @@ module LEMMAS
   // Buffer Reasoning
   // ########################
 
-    rule WS ++ .ByteArray => WS  [simplification]
-    rule .ByteArray ++ WS => WS  [simplification]
+    rule WS         ++ .ByteArray => WS  [simplification]
+    rule .ByteArray ++ WS         => WS  [simplification]
 
   // ########################
   // Map Reasoning
   // ########################
 
     // re-order assignments
-    rule MEM [ K1 := BUF1:ByteArray ] [ K2 := BUF2:ByteArray ] => MEM [ K2 := BUF2 ] [ K1 := BUF1 ]  requires K1  >Int K2 andBool K1 -Int K2 >=Int #sizeByteArray(BUF2)                           [simplification]
-
+    rule MEM [ K1 := BUF1:ByteArray ] [ K2 := BUF2:ByteArray ] => MEM [ K2 := BUF2 ] [ K1 := BUF1 ]  requires         #sizeByteArray(BUF2) <=Int K1 -Int K2                   andBool K2  <Int K1 [simplification]
     // overwritten assignment
-    rule MEM [ K1 := BUF1           ] [ K2 := BUF2           ] => MEM [ K2 := BUF2 ]                 requires K2 <=Int K1 andBool K1 +Int #sizeByteArray(BUF1) <=Int K2 +Int #sizeByteArray(BUF2) [simplification]
-
+    rule MEM [ K1 := BUF1           ] [ K2 := BUF2           ] => MEM [ K2 := BUF2 ]                 requires K1 +Int #sizeByteArray(BUF1) <=Int K2 +Int #sizeByteArray(BUF2) andBool K2 <=Int K1 [simplification]
     // redundant assignment
-    rule MEM [ K  := BUF1           ] [ K  := BUF2           ] => MEM [ K  := BUF2 ]                 requires #sizeByteArray(BUF1) ==Int #sizeByteArray(BUF2)                                     [simplification]
+    rule MEM [ K  := BUF1           ] [ K  := BUF2           ] => MEM [ K  := BUF2 ]                 requires         #sizeByteArray(BUF1) ==Int #sizeByteArray(BUF2)                             [simplification]
 
     // lookup range in memory
     rule _MEM [ _ .. W ] => .ByteArray  requires W ==Int 0                    [simplification]
-    rule MEM  [ 0 .. W ] => MEM         requires W ==Int #sizeByteArray(MEM)  [simplification]
+    rule  MEM [ 0 .. W ] => MEM         requires W ==Int #sizeByteArray(MEM)  [simplification]
 
     // lookup range in concatenated memory buffers
     rule (BUF1 ++  BUF2)[START .. WIDTH] =>  BUF2[START -Int #sizeByteArray(BUF1) .. WIDTH                          ]                                                              requires                        #sizeByteArray(BUF1) <=Int START                                                             [simplification]
@@ -104,7 +102,7 @@ module LEMMAS
 
     rule #sizeByteArray(BUF1 ++ BUF2)            => #sizeByteArray(BUF1) +Int #sizeByteArray(BUF2)      [simplification]
     rule #sizeByteArray(#buf(SIZE, _))           => SIZE                                                [simplification]
-    rule #sizeByteArray(_ [ START .. WIDTH ])    => WIDTH  requires 0 <=Int START andBool 0 <=Int WIDTH [simplification]
+    rule #sizeByteArray(_MEM [ START .. WIDTH ]) => WIDTH  requires 0 <=Int START andBool 0 <=Int WIDTH [simplification]
     rule #sizeByteArray(#range(_, START, WIDTH)) => WIDTH  requires 0 <=Int START andBool 0 <=Int WIDTH [simplification]
 
     // TODO: custom ==K unification doesn't work in Haskell yet
@@ -134,7 +132,7 @@ module LEMMAS-JAVA [symbolic, kast]
 
     // #sizeByteArray
 
-    rule #sizeByteArray(_W : WS)       => 1 +Int #sizeByteArray(WS)             [simplification]
+    rule #sizeByteArray(_W : WS) => 1 +Int #sizeByteArray(WS) [simplification]
 
     // #asWord
 
@@ -144,32 +142,33 @@ module LEMMAS-JAVA [symbolic, kast]
 
     // #range
 
-    rule #range(_M, _N, K) => .ByteArray requires notBool K >Int 0 [simplification]
+    rule #range(_M, _N, K) => .ByteArray requires notBool 0 <Int K [simplification]
 
     rule #range(M [ N := BUF:ByteArray ], L, K) => #range(M, L, minInt(K, N -Int L)) ++ #range(M [ N := BUF ], N, K -Int minInt(K, N -Int L))
-      requires K >Int 0
+      requires 0 <Int K
        andBool L <Int N
       [simplification]
 
     rule #range(M [ N := BUF ], L, K) => BUF [ L -Int N .. minInt(K, #sizeByteArray(BUF) -Int (L -Int N)) ] ++ #range(M, N +Int #sizeByteArray(BUF), K -Int minInt(K, #sizeByteArray(BUF) -Int (L -Int N)))
-      requires K  >Int 0
-       andBool L >=Int N
+      requires 0  <Int K
+       andBool N <=Int L
        andBool L  <Int N +Int #sizeByteArray(BUF)
       [simplification]
 
     rule #range(M [ N := BUF ], L, K) => #range(M, L, K)
-      requires K  >Int 0
-       andBool L >=Int N +Int #sizeByteArray(BUF)
+      requires 0 <Int K
+       andBool N +Int #sizeByteArray(BUF) <=Int L
       [simplification]
 
     rule #buf(N, #asWord(WS)) => WS
-      requires #noOverflow(WS) andBool N ==Int #sizeByteArray(WS)
+      requires #noOverflow(WS)
+       andBool N ==Int #sizeByteArray(WS)
       [simplification]
 
 
-    rule BA:ByteArray        ==K #buf( 32, DATA )    => #buf( 32, DATA ) ==K   BA              requires #isConcrete(BA)             [simplification]
-    rule #buf( 32, DATA )    ==K BA:ByteArray        => DATA             ==Int #asInteger(BA)  requires #isConcrete(BA)
-                                                                                                andBool #sizeByteArray(BA) <=Int 32 [simplification]
+    rule BA:ByteArray     ==K #buf( 32, DATA ) => #buf( 32, DATA ) ==K   BA              requires #isConcrete(BA)             [simplification]
+    rule #buf( 32, DATA ) ==K BA:ByteArray     => DATA             ==Int #asInteger(BA)  requires #isConcrete(BA)
+                                                                                          andBool #sizeByteArray(BA) <=Int 32 [simplification]
 
   // ########################
   // Overflow
@@ -199,32 +198,37 @@ module LEMMAS-JAVA [symbolic, kast]
     rule _N &Int  0 => 0
     rule  N &Int  N => N
 
-    //orienting symbolic term to be first, converting -Int to +Int for concrete values.
-    rule I +Int B => B          +Int I when #isConcrete(I) andBool notBool #isConcrete(B) [simplification]
-    rule A -Int I => A +Int (0 -Int I) when notBool #isConcrete(A) andBool #isConcrete(I) [simplification]
+    // orienting symbolic term to be first, converting -Int to +Int for concrete values.
+    rule I +Int B => B         +Int I  requires #isConcrete(I) andBool notBool #isConcrete(B) [simplification]
+    rule A -Int I => A +Int (0 -Int I) requires #isConcrete(I) andBool notBool #isConcrete(A) [simplification]
+    // +-associativity
 
-    rule (A +Int I2) +Int I3 => A +Int (I2 +Int I3) when notBool #isConcrete(A) andBool #isConcrete(I2) andBool #isConcrete(I3) [simplification]
+ #isConcrete(I) andBool
+ #isConcrete(J) andBool
+ #isConcrete(K) andBool
 
-    rule I1 +Int (B +Int I3) => B +Int (I1 +Int I3) when #isConcrete(I1) andBool notBool #isConcrete(B) andBool #isConcrete(I3) [simplification]
-    rule I1 -Int (B +Int I3) => (I1 -Int I3) -Int B when #isConcrete(I1) andBool notBool #isConcrete(B) andBool #isConcrete(I3) [simplification]
-    rule (I1 -Int B) +Int I3 => (I1 +Int I3) -Int B when #isConcrete(I1) andBool notBool #isConcrete(B) andBool #isConcrete(I3) [simplification]
+ notBool #isConcrete(A) andBool
+ notBool #isConcrete(B) andBool
+ notBool #isConcrete(C) andBool
 
-    rule I1 +Int (I2 +Int C) => (I1 +Int I2) +Int C when #isConcrete(I1) andBool #isConcrete(I2) andBool notBool #isConcrete(C) [simplification]
-    rule I1 +Int (I2 -Int C) => (I1 +Int I2) -Int C when #isConcrete(I1) andBool #isConcrete(I2) andBool notBool #isConcrete(C) [simplification]
-    rule I1 -Int (I2 +Int C) => (I1 -Int I2) -Int C when #isConcrete(I1) andBool #isConcrete(I2) andBool notBool #isConcrete(C) [simplification]
-    rule I1 -Int (I2 -Int C) => (I1 -Int I2) +Int C when #isConcrete(I1) andBool #isConcrete(I2) andBool notBool #isConcrete(C) [simplification]
-
-    rule I1 &Int (I2 &Int C) => (I1 &Int I2) &Int C when #isConcrete(I1) andBool #isConcrete(I2) andBool notBool #isConcrete(C) [simplification]
+    // NEW
+    rule (A +Int J) +Int K => A +Int (J +Int K) requires #isConcrete(J) andBool #isConcrete(K) andBool notBool #isConcrete(A) [simplification]
+    rule I +Int (B +Int K) => B +Int (I +Int K) requires #isConcrete(I) andBool #isConcrete(K) andBool notBool #isConcrete(B) [simplification]
+    rule I -Int (B +Int K) => (I -Int K) -Int B requires #isConcrete(I) andBool #isConcrete(K) andBool notBool #isConcrete(B) [simplification]
+    rule (I -Int B) +Int K => (I +Int K) -Int B requires #isConcrete(I) andBool #isConcrete(K) andBool notBool #isConcrete(B) [simplification]
+    rule I +Int (J +Int C) => (I +Int J) +Int C requires #isConcrete(I) andBool #isConcrete(J) andBool notBool #isConcrete(C) [simplification]
+    rule I +Int (J -Int C) => (I +Int J) -Int C requires #isConcrete(I) andBool #isConcrete(J) andBool notBool #isConcrete(C) [simplification]
+    rule I -Int (J +Int C) => (I -Int J) -Int C requires #isConcrete(I) andBool #isConcrete(J) andBool notBool #isConcrete(C) [simplification]
+    rule I -Int (J -Int C) => (I -Int J) +Int C requires #isConcrete(I) andBool #isConcrete(J) andBool notBool #isConcrete(C) [simplification]
+    rule I &Int (J &Int C) => (I &Int J) &Int C requires #isConcrete(I) andBool #isConcrete(J) andBool notBool #isConcrete(C) [simplification]
 
     // 0xffff...f &Int N = N
-    rule MASK &Int N => N  requires MASK ==Int (2 ^Int (log2Int(MASK) +Int 1)) -Int 1 // MASK = 0xffff...f
-                            andBool 0 <=Int N andBool N <=Int MASK
-      [simplification]
+    // MASK = 0xffff...f
+    rule MASK &Int N    => N requires MASK ==Int (2 ^Int (log2Int(MASK) +Int 1)) -Int 1 andBool 0 <=Int N andBool N <=Int MASK [simplification]
 
     // N &Int 0xffff...f = N
-    rule N &Int MASK => N  requires MASK ==Int (2 ^Int (log2Int(MASK) +Int 1)) -Int 1 // MASK = 0xffff...f
-                            andBool 0 <=Int N andBool N <=Int MASK
-      [simplification]
+    // MASK = 0xffff...f
+    rule N    &Int MASK => N requires MASK ==Int (2 ^Int (log2Int(MASK) +Int 1)) -Int 1 andBool 0 <=Int N andBool N <=Int MASK [simplification]
 
     rule 0 <=Int X &Int Y             => true requires 0 <=Int X andBool X <Int pow256 andBool 0 <=Int Y andBool Y <Int pow256 [simplification]
     rule         X &Int Y <Int pow256 => true requires 0 <=Int X andBool X <Int pow256 andBool 0 <=Int Y andBool Y <Int pow256 [simplification]
@@ -312,10 +316,13 @@ module LEMMAS-HASKELL [symbolic, kore]
   // ########################
 
     rule N &Int maxUInt160 => N  requires #rangeUInt(160, N) [simplification]
+
     rule maxUInt160 &Int N => N  requires #rangeUInt(160, N) [simplification]
+
     rule N modInt pow160   => N  requires #rangeUInt(160, N) [simplification]
 
     rule N <=Int maxInt(P, Q) => true requires N <=Int P orBool N <=Int Q  [simplification]
+
     rule minInt(P, Q)         => P    requires P <=Int Q                   [simplification]
 
 
@@ -332,8 +339,8 @@ module LEMMAS-HASKELL [symbolic, kore]
 
     rule 0 <=Int lengthBytes ( _ ) => true [smt-lemma, simplification]
 
-    rule BA:ByteArray     ==K #buf( 32, DATA ) => #buf( 32, DATA ) ==K              BA                                       [simplification, concrete(BA)]
-    rule #buf( 32, DATA ) ==K BA:ByteArray     =>           DATA   ==Int #asInteger(BA) requires #sizeByteArray(BA) <=Int 32 [simplification, concrete(BA)]
+    rule BA:ByteArray   ==K #buf(32, DATA) => #buf(32, DATA) ==K              BA                                       [simplification, concrete(BA)]
+    rule #buf(32, DATA) ==K BA:ByteArray   =>          DATA  ==Int #asInteger(BA) requires #sizeByteArray(BA) <=Int 32 [simplification, concrete(BA)]
 
   // ########################
   // Boolean Logic

--- a/tests/specs/lemmas.k
+++ b/tests/specs/lemmas.k
@@ -201,26 +201,26 @@ module LEMMAS-JAVA [symbolic, kast]
     // orienting symbolic term to be first, converting -Int to +Int for concrete values.
     rule I +Int B => B         +Int I  requires #isConcrete(I) andBool notBool #isConcrete(B) [simplification]
     rule A -Int I => A +Int (0 -Int I) requires #isConcrete(I) andBool notBool #isConcrete(A) [simplification]
-    // +-associativity
 
- #isConcrete(I) andBool
- #isConcrete(J) andBool
- #isConcrete(K) andBool
+    // associate concrete terms to the left and symbolic terms to the right
+    
+    // // OLD
+    // rule (A  +Int  J) +Int  K  =>  A +Int (J  +Int K) requires #isConcrete(J) andBool #isConcrete(K) andBool notBool #isConcrete(A) [simplification]
+    // rule  I  +Int (B  +Int  K) =>  B +Int (I  +Int K) requires #isConcrete(I) andBool #isConcrete(K) andBool notBool #isConcrete(B) [simplification]
+    // NEW (moves symbolic terms to the fight)
+    rule (A  +Int  J) +Int  K  => (J +Int K) +Int A requires #isConcrete(J) andBool #isConcrete(K) andBool notBool #isConcrete(A) [simplification]
+    rule  I  +Int (B  +Int  K) => (I +Int K) +Int B requires #isConcrete(I) andBool #isConcrete(K) andBool notBool #isConcrete(B) [simplification]
 
- notBool #isConcrete(A) andBool
- notBool #isConcrete(B) andBool
- notBool #isConcrete(C) andBool
+    rule  I  -Int (B  +Int  K) => (I -Int K) -Int B requires #isConcrete(I) andBool #isConcrete(K) andBool notBool #isConcrete(B) [simplification]
+    rule (I  -Int  B) +Int  K  => (I +Int K) -Int B requires #isConcrete(I) andBool #isConcrete(K) andBool notBool #isConcrete(B) [simplification]
 
-    // NEW
-    rule (A +Int  J) +Int K  =>  A +Int (J  +Int K) requires #isConcrete(J) andBool #isConcrete(K) andBool notBool #isConcrete(A) [simplification]
-    rule  I +Int (B  +Int K) =>  B +Int (I  +Int K) requires #isConcrete(I) andBool #isConcrete(K) andBool notBool #isConcrete(B) [simplification]
-    rule  I -Int (B  +Int K) => (I -Int  K) -Int B  requires #isConcrete(I) andBool #isConcrete(K) andBool notBool #isConcrete(B) [simplification]
-    rule (I -Int  B) +Int K  => (I +Int  K) -Int B  requires #isConcrete(I) andBool #isConcrete(K) andBool notBool #isConcrete(B) [simplification]
-    rule  I +Int (J  +Int C) => (I +Int  J) +Int C  requires #isConcrete(I) andBool #isConcrete(J) andBool notBool #isConcrete(C) [simplification]
-    rule  I +Int (J  -Int C) => (I +Int  J) -Int C  requires #isConcrete(I) andBool #isConcrete(J) andBool notBool #isConcrete(C) [simplification]
-    rule  I -Int (J  +Int C) => (I -Int  J) -Int C  requires #isConcrete(I) andBool #isConcrete(J) andBool notBool #isConcrete(C) [simplification]
-    rule  I -Int (J  -Int C) => (I -Int  J) +Int C  requires #isConcrete(I) andBool #isConcrete(J) andBool notBool #isConcrete(C) [simplification]
-    rule  I &Int (J  &Int C) => (I &Int  J) &Int C  requires #isConcrete(I) andBool #isConcrete(J) andBool notBool #isConcrete(C) [simplification]
+    rule  I  +Int (J  +Int  C) => (I +Int J) +Int C requires #isConcrete(I) andBool #isConcrete(J) andBool notBool #isConcrete(C) [simplification]
+    rule  I  +Int (J  -Int  C) => (I +Int J) -Int C requires #isConcrete(I) andBool #isConcrete(J) andBool notBool #isConcrete(C) [simplification]
+
+    rule  I  -Int (J  +Int  C) => (I -Int J) -Int C requires #isConcrete(I) andBool #isConcrete(J) andBool notBool #isConcrete(C) [simplification]
+    rule  I  -Int (J  -Int  C) => (I -Int J) +Int C requires #isConcrete(I) andBool #isConcrete(J) andBool notBool #isConcrete(C) [simplification]
+
+    rule  I  &Int (J  &Int  C) => (I &Int J) &Int C requires #isConcrete(I) andBool #isConcrete(J) andBool notBool #isConcrete(C) [simplification]
 
     // 0xffff...f &Int N = N
     // MASK = 0xffff...f

--- a/tests/specs/lemmas.k
+++ b/tests/specs/lemmas.k
@@ -82,8 +82,9 @@ module LEMMAS
     rule MEM [ K1 := BUF1:ByteArray ] [ K2 := BUF2:ByteArray ] => MEM [ K2 := BUF2 ] [ K1 := BUF1 ]  requires         #sizeByteArray(BUF2) <=Int K1 -Int K2                   andBool K2  <Int K1 [simplification]
     // overwritten assignment
     rule MEM [ K1 := BUF1           ] [ K2 := BUF2           ] => MEM [ K2 := BUF2 ]                 requires K1 +Int #sizeByteArray(BUF1) <=Int K2 +Int #sizeByteArray(BUF2) andBool K2 <=Int K1 [simplification]
+    // TODO: tmp disable
     // redundant assignment
-    rule MEM [ K  := BUF1           ] [ K  := BUF2           ] => MEM [ K  := BUF2 ]                 requires         #sizeByteArray(BUF1) ==Int #sizeByteArray(BUF2)                             [simplification]
+    // rule MEM [ K  := BUF1           ] [ K  := BUF2           ] => MEM [ K  := BUF2 ]                 requires         #sizeByteArray(BUF1) ==Int #sizeByteArray(BUF2)                             [simplification]
 
     // lookup range in memory
     rule _MEM [ _ .. W ] => .ByteArray  requires W ==Int 0                    [simplification]

--- a/tests/specs/lemmas.k
+++ b/tests/specs/lemmas.k
@@ -40,8 +40,8 @@ module LEMMAS
   // Word Reasoning
   // ########################
 
-    rule 0 <=Int #sizeWordStack ( _ , N ) => true requires 0 <=Int N [smt-lemma, simplification]
-    rule 0 <=Int #sizeByteArray ( _ )     => true                    [smt-lemma, simplification]
+    rule 0 <=Int #sizeWordStack ( _ , N ) => true requires 0 <=Int N [simplification, smt-lemma]
+    rule 0 <=Int #sizeByteArray ( _ )     => true                    [simplification, smt-lemma]
 
     // bool2Word range & simplification
     rule 0 <=Int bool2Word(_B)             => true   [simplification]

--- a/tests/specs/lemmas.k
+++ b/tests/specs/lemmas.k
@@ -335,13 +335,8 @@ module LEMMAS-HASKELL [symbolic, kore]
 
     rule 0 <=Int lengthBytes ( _ ) => true [smt-lemma, simplification]
 
-    // TODO: tmp disabled to test generalization below
-    // // TODO: why do we need an explicit symmetry rule for `==K`? should this not happend automatically?
-    // // rule BA:ByteArray   ==K #buf(32, DATA) => #buf(32, DATA) ==K              BA                                       [simplification, concrete(BA)]
-    // // rule #buf(32, DATA) ==K BA:ByteArray   =>          DATA  ==Int #asInteger(BA) requires #sizeByteArray(BA) <=Int 32 [simplification, concrete(BA)]
-
-    // TODO: perhaps the above two rules can be combined:
-    rule BA:ByteArray ==K #buf(32, DATA) => #asInteger(BA) ==Int DATA requires #sizeByteArray(BA) <=Int 32 [simplification, concrete(BA)]
+    rule BA:ByteArray   ==K #buf(32, DATA) => #buf(32, DATA) ==K              BA                                       [simplification, concrete(BA)]
+    rule #buf(32, DATA) ==K BA:ByteArray   =>          DATA  ==Int #asInteger(BA) requires #sizeByteArray(BA) <=Int 32 [simplification, concrete(BA)]
 
   // ########################
   // Boolean Logic

--- a/tests/specs/lemmas.k
+++ b/tests/specs/lemmas.k
@@ -335,9 +335,10 @@ module LEMMAS-HASKELL [symbolic, kore]
 
     rule 0 <=Int lengthBytes ( _ ) => true [smt-lemma, simplification]
 
-    // TODO: why do we need an explicit symmetry rule for `==K`? should this not happend automatically?
-    rule BA:ByteArray   ==K #buf(32, DATA) => #buf(32, DATA) ==K              BA                                       [simplification, concrete(BA)]
-    rule #buf(32, DATA) ==K BA:ByteArray   =>          DATA  ==Int #asInteger(BA) requires #sizeByteArray(BA) <=Int 32 [simplification, concrete(BA)]
+    // TODO: tmp disabled to test generalization below
+    // // TODO: why do we need an explicit symmetry rule for `==K`? should this not happend automatically?
+    // // rule BA:ByteArray   ==K #buf(32, DATA) => #buf(32, DATA) ==K              BA                                       [simplification, concrete(BA)]
+    // // rule #buf(32, DATA) ==K BA:ByteArray   =>          DATA  ==Int #asInteger(BA) requires #sizeByteArray(BA) <=Int 32 [simplification, concrete(BA)]
 
     // TODO: perhaps the above two rules can be combined:
     rule BA:ByteArray ==K #buf(32, DATA) => #asInteger(BA) ==Int DATA requires #sizeByteArray(BA) <=Int 32 [simplification, concrete(BA)]

--- a/tests/specs/lemmas.k
+++ b/tests/specs/lemmas.k
@@ -10,8 +10,11 @@ module LEMMAS
   // ########################
 
     //For #bufStrict simplification in benchmarks
-    rule 0 <=Int #ceil32(I)        => true requires 0 <=Int I [simplification, smt-lemma]
-    rule 0 <=Int #ceil32(I) -Int I => true requires 0 <=Int I [simplification]
+    // // TODO: why does this need to be an `smt-lemma`?
+    // rule 0 <=Int #ceil32(I)        => true requires 0 <=Int I [simplification, smt-lemma]
+    // rule 0 <=Int #ceil32(I) -Int I => true requires 0 <=Int I [simplification]
+    // TODO: possibly generalizes the above two rules
+    rule 0 <=Int #ceil32(I) -Int J => true requires J <=Int I [simplification, smt-lemma]
 
     //Inequality sign normalization
     rule          X  >Int Y  => Y  <Int X            [simplification]

--- a/tests/specs/lemmas.k
+++ b/tests/specs/lemmas.k
@@ -54,16 +54,6 @@ module LEMMAS
     rule #isPrecompiledAccount(#newAddr(_, _), _) => false [simplification]
 
   // ########################
-  // Map Reasoning
-  // ########################
-
-    rule #lookup ( _M:Map [ K1 <- V1 ] , K2 ) => #lookup ( K1 |-> V1 , K1 )  requires K1 ==Int  K2 [simplification]
-    rule #lookup (  M:Map [ K1 <- _  ] , K2 ) => #lookup ( M         , K2 )  requires K1 =/=Int K2 [simplification]
-
-    rule 0 <=Int #lookup( _M:Map , _ )             => true [simplification, smt-lemma]
-    rule         #lookup( _M:Map , _ ) <Int pow256 => true [simplification, smt-lemma]
-
-  // ########################
   // Keccak
   // ########################
 
@@ -81,6 +71,12 @@ module LEMMAS
   // ########################
   // Map Reasoning
   // ########################
+
+    rule #lookup ( _M:Map [ K1 <- V1 ] , K2 ) => #lookup ( K1 |-> V1 , K1 )  requires K1 ==Int  K2 [simplification]
+    rule #lookup (  M:Map [ K1 <- _  ] , K2 ) => #lookup ( M         , K2 )  requires K1 =/=Int K2 [simplification]
+
+    rule 0 <=Int #lookup( _M:Map , _ )             => true [simplification, smt-lemma]
+    rule         #lookup( _M:Map , _ ) <Int pow256 => true [simplification, smt-lemma]
 
     // re-order assignments
     rule MEM [ K1 := BUF1:ByteArray ] [ K2 := BUF2:ByteArray ] => MEM [ K2 := BUF2 ] [ K1 := BUF1 ]  requires         #sizeByteArray(BUF2) <=Int K1 -Int K2                   andBool K2  <Int K1 [simplification]

--- a/tests/specs/lemmas.k
+++ b/tests/specs/lemmas.k
@@ -82,9 +82,6 @@ module LEMMAS
     rule MEM [ K1 := BUF1:ByteArray ] [ K2 := BUF2:ByteArray ] => MEM [ K2 := BUF2 ] [ K1 := BUF1 ]  requires         #sizeByteArray(BUF2) <=Int K1 -Int K2                   andBool K2  <Int K1 [simplification]
     // overwritten assignment
     rule MEM [ K1 := BUF1           ] [ K2 := BUF2           ] => MEM [ K2 := BUF2 ]                 requires K1 +Int #sizeByteArray(BUF1) <=Int K2 +Int #sizeByteArray(BUF2) andBool K2 <=Int K1 [simplification]
-    // TODO: tmp disable
-    // redundant assignment
-    // rule MEM [ K  := BUF1           ] [ K  := BUF2           ] => MEM [ K  := BUF2 ]                 requires         #sizeByteArray(BUF1) ==Int #sizeByteArray(BUF2)                             [simplification]
 
     // lookup range in memory
     rule _MEM [ _ .. W ] => .ByteArray  requires W ==Int 0                    [simplification]
@@ -205,7 +202,6 @@ module LEMMAS-JAVA [symbolic, kast]
     // 3 terms
 
     // symbolic first: A, J, K
-    //rule (A  +Int  J) +Int  K  =>  A  +Int (J  +Int  K) requires #isConcrete(J) andBool #isConcrete(K) andBool (notBool #isConcrete(A)) [simplification]
     rule (A  +Int  J) +Int  K  => (J +Int K) +Int A  requires #isConcrete(J) andBool #isConcrete(K) andBool (notBool #isConcrete(A)) [simplification]
     // symbolic second: I, B, K
     rule  I  +Int (B  +Int  K) => (I +Int K) +Int B  requires #isConcrete(I) andBool #isConcrete(K) andBool (notBool #isConcrete(B)) [simplification]

--- a/tests/specs/lemmas.k
+++ b/tests/specs/lemmas.k
@@ -338,8 +338,12 @@ module LEMMAS-HASKELL [symbolic, kore]
 
     rule 0 <=Int lengthBytes ( _ ) => true [smt-lemma, simplification]
 
+    // TODO: why do we need an explicit symmetry rule for `==K`? should this not happend automatically?
     rule BA:ByteArray   ==K #buf(32, DATA) => #buf(32, DATA) ==K              BA                                       [simplification, concrete(BA)]
     rule #buf(32, DATA) ==K BA:ByteArray   =>          DATA  ==Int #asInteger(BA) requires #sizeByteArray(BA) <=Int 32 [simplification, concrete(BA)]
+
+    // TODO: perhaps the above two rules can be combined:
+    rule BA:ByteArray ==K #buf(32, DATA) => #asInteger(BA) ==Int DATA requires #sizeByteArray(BA) <=Int 32 [simplification, concrete(BA)]
 
   // ########################
   // Boolean Logic

--- a/tests/specs/lemmas.k
+++ b/tests/specs/lemmas.k
@@ -10,11 +10,8 @@ module LEMMAS
   // ########################
 
     // For #bufStrict simplification in benchmarks
-    // TODO: why does this need to be an `smt-lemma`?
     rule 0 <=Int #ceil32(I)        => true requires 0 <=Int I [simplification, smt-lemma]
     rule 0 <=Int #ceil32(I) -Int I => true requires 0 <=Int I [simplification]
-    // // TODO: possibly generalizes the above two rules
-    // rule 0 <=Int #ceil32(I) -Int J => true requires J <=Int I [simplification, smt-lemma]
 
     //Inequality sign normalization
     rule          X  >Int Y  => Y  <Int X            [simplification]


### PR DESCRIPTION
Fixes #1024

In `tests/specs/lemmas.k` and `tests/specs/benchmarks/verification.k`:
- reformats and reorganizes some lemmas (only within files -- nothing is moved between files)
- removes unneeded lemmas
- removes lemmas in `tests/specs/benchmarks/verification.k` that are already covered by lemmas in `tests/specs/lemmas.k`