### PR TITLE
Allow concurrent builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 pipeline {
-  agent { label 'docker && !smol' }
+  agent { label 'docker' }
   environment {
     GITHUB_TOKEN     = credentials('rv-jenkins')
     VERSION          = '1.0.1'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,9 +27,9 @@ pipeline {
           failFast true
           options { timeout(time: 90, unit: 'MINUTES') }
           parallel {
-            stage('Conformance (LLVM)') { steps {                                    sh 'make test-conformance -j8 TEST_CONCRETE_BACKEND=llvm'      } }
-            stage('Proofs (Java)')      { steps { lock("heavy-1-${env.NODE_NAME}") { sh 'make test-prove       -j5 TEST_SYMBOLIC_BACKEND=java'    } } }
-            stage('Proofs (Haskell)')   { steps { lock("heavy-2-${env.NODE_NAME}") { sh 'make test-prove       -j4 TEST_SYMBOLIC_BACKEND=haskell' } } }
+            stage('Conformance (LLVM)') { steps {                                         sh 'make test-conformance -j8 TEST_CONCRETE_BACKEND=llvm'      } }
+            stage('Proofs (Java)')      { steps { lock("kevm-java-${env.NODE_NAME}")    { sh 'make test-prove       -j5 TEST_SYMBOLIC_BACKEND=java'    } } }
+            stage('Proofs (Haskell)')   { steps { lock("kevm-haskell-${env.NODE_NAME}") { sh 'make test-prove       -j4 TEST_SYMBOLIC_BACKEND=haskell' } } }
           }
         }
         stage('Test Interactive') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,9 +27,9 @@ pipeline {
           failFast true
           options { timeout(time: 90, unit: 'MINUTES') }
           parallel {
-            stage('Conformance (LLVM)') { steps { sh 'make test-conformance -j8 TEST_CONCRETE_BACKEND=llvm' } }
-            stage('Proofs (Java)')      { steps { sh 'make test-prove -j5 TEST_SYMBOLIC_BACKEND=java'       } }
-            stage('Proofs (Haskell)')   { steps { sh 'make test-prove -j4 TEST_SYMBOLIC_BACKEND=haskell'    } }
+            stage('Conformance (LLVM)') { steps {                                               sh 'make test-conformance -j8 TEST_CONCRETE_BACKEND=llvm'      } }
+            stage('Proofs (Java)')      { steps { lock("kevm-prove-java-${env.NODE_NAME}")    { sh 'make test-prove       -j5 TEST_SYMBOLIC_BACKEND=java'    } } }
+            stage('Proofs (Haskell)')   { steps { lock("kevm-prove-haskell-${env.NODE_NAME}") { sh 'make test-prove       -j4 TEST_SYMBOLIC_BACKEND=haskell' } } }
           }
         }
         stage('Test Interactive') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
   }
   options {
     ansiColor('xterm')
-    throttleJobProperty(categories: [], limitOneJobWithMatchingParams: false, maxConcurrentPerNode: 1, maxConcurrentTotal: 0, paramsToUseForLimit: '', throttleEnabled: true, throttleOption: 'project')
+    throttleJobProperty(categories: ['heavy'], throttleEnabled: true, throttleOption: 'category')
   }
   stages {
     stage('Init title') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,14 +25,11 @@ pipeline {
         stage('Build') { steps { sh 'make build RELEASE=true -j6' } }
         stage('Test') {
           failFast true
-          options {
-            timeout(time: 90, unit: 'MINUTES')
-            lock("heavy-${env.NODE_NAME}")
-          }
+          options { timeout(time: 90, unit: 'MINUTES') }
           parallel {
-            stage('Conformance (LLVM)') { steps { sh 'make test-conformance -j8 TEST_CONCRETE_BACKEND=llvm'    } }
-            stage('Proofs (Java)')      { steps { sh 'make test-prove       -j5 TEST_SYMBOLIC_BACKEND=java'    } }
-            stage('Proofs (Haskell)')   { steps { sh 'make test-prove       -j4 TEST_SYMBOLIC_BACKEND=haskell' } }
+            stage('Conformance (LLVM)') { steps {                                    sh 'make test-conformance -j8 TEST_CONCRETE_BACKEND=llvm'      } }
+            stage('Proofs (Java)')      { steps { lock("heavy-1-${env.NODE_NAME}") { sh 'make test-prove       -j5 TEST_SYMBOLIC_BACKEND=java'    } } }
+            stage('Proofs (Haskell)')   { steps { lock("heavy-2-${env.NODE_NAME}") { sh 'make test-prove       -j4 TEST_SYMBOLIC_BACKEND=haskell' } } }
           }
         }
         stage('Test Interactive') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,10 +8,7 @@ pipeline {
     KEVM_RELEASE_TAG = "v${env.VERSION}-${env.SHORT_REV}"
     K_VERSION        = """${sh(returnStdout: true, script: 'cd deps/k && git tag --points-at HEAD | cut --characters=2-').trim()}"""
   }
-  options {
-    ansiColor('xterm')
-    lock("heavy-${env.NODE_NAME}")
-  }
+  options { ansiColor('xterm') }
   stages {
     stage('Init title') {
       when { changeRequest() }
@@ -28,7 +25,10 @@ pipeline {
         stage('Build') { steps { sh 'make build RELEASE=true -j6' } }
         stage('Test') {
           failFast true
-          options { timeout(time: 90, unit: 'MINUTES') }
+          options {
+            timeout(time: 90, unit: 'MINUTES')
+            lock("heavy-${env.NODE_NAME}")
+          }
           parallel {
             stage('Conformance (LLVM)') { steps { sh 'make test-conformance -j8 TEST_CONCRETE_BACKEND=llvm'    } }
             stage('Proofs (Java)')      { steps { sh 'make test-prove       -j5 TEST_SYMBOLIC_BACKEND=java'    } }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,10 +25,7 @@ pipeline {
         stage('Build') { steps { sh 'make build RELEASE=true -j6' } }
         stage('Test') {
           failFast true
-          options {
-            lock("proofs-${env.NODE_NAME}")
-            timeout(time: 150, unit: 'MINUTES')
-          }
+          options { timeout(time: 150, unit: 'MINUTES') }
           parallel {
             stage('Conformance (LLVM)')         { steps { sh 'make test-conformance -j8 TEST_CONCRETE_BACKEND=llvm' } }
             stage('Proofs (Java)')              { steps { sh 'make test-prove -j5 TEST_SYMBOLIC_BACKEND=java'       } }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
   }
   options {
     ansiColor('xterm')
-    throttle(categories: ['heavy'])
+    throttleJobProperty(categories: [], limitOneJobWithMatchingParams: false, maxConcurrentPerNode: 1, maxConcurrentTotal: 0, paramsToUseForLimit: '', throttleEnabled: true, throttleOption: 'project')
   }
   stages {
     stage('Init title') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,7 +25,10 @@ pipeline {
         stage('Build') { steps { sh 'make build RELEASE=true -j6' } }
         stage('Test') {
           failFast true
-          options { timeout(time: 150, unit: 'MINUTES') }
+          options {
+            timeout(time: 90, unit: 'MINUTES')
+            throttleJobProperty(categories: ['heavy'], throttleEnabled: true, throttleOption: 'category')
+          }
           parallel {
             stage('Conformance (LLVM)')         { steps { sh 'make test-conformance -j8 TEST_CONCRETE_BACKEND=llvm' } }
             stage('Proofs (Java)')              { steps { sh 'make test-prove -j5 TEST_SYMBOLIC_BACKEND=java'       } }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,9 +27,9 @@ pipeline {
           failFast true
           options { timeout(time: 90, unit: 'MINUTES') }
           parallel {
-            stage('Conformance (LLVM)') { steps {                                               sh 'make test-conformance -j8 TEST_CONCRETE_BACKEND=llvm'      } }
-            stage('Proofs (Java)')      { steps { lock("kevm-prove-java-${env.NODE_NAME}")    { sh 'make test-prove       -j5 TEST_SYMBOLIC_BACKEND=java'    } } }
-            stage('Proofs (Haskell)')   { steps { lock("kevm-prove-haskell-${env.NODE_NAME}") { sh 'make test-prove       -j4 TEST_SYMBOLIC_BACKEND=haskell' } } }
+            stage('Conformance (LLVM)') { steps {                                  sh 'make test-conformance -j8 TEST_CONCRETE_BACKEND=llvm'      } }
+            stage('Proofs (Java)')      { steps { lock("heavy-${env.NODE_NAME}") { sh 'make test-prove       -j5 TEST_SYMBOLIC_BACKEND=java'    } } }
+            stage('Proofs (Haskell)')   { steps { lock("heavy-${env.NODE_NAME}") { sh 'make test-prove       -j4 TEST_SYMBOLIC_BACKEND=haskell' } } }
           }
         }
         stage('Test Interactive') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,10 @@ pipeline {
     KEVM_RELEASE_TAG = "v${env.VERSION}-${env.SHORT_REV}"
     K_VERSION        = """${sh(returnStdout: true, script: 'cd deps/k && git tag --points-at HEAD | cut --characters=2-').trim()}"""
   }
-  options { ansiColor('xterm') }
+  options {
+    ansiColor('xterm')
+    throttle(categories: ['heavy'])
+  }
   stages {
     stage('Init title') {
       when { changeRequest() }
@@ -25,10 +28,7 @@ pipeline {
         stage('Build') { steps { sh 'make build RELEASE=true -j6' } }
         stage('Test') {
           failFast true
-          options {
-            timeout(time: 90, unit: 'MINUTES')
-            throttle(categories: ['heavy'])
-          }
+          options { timeout(time: 90, unit: 'MINUTES') }
           parallel {
             stage('Conformance (LLVM)') { steps { sh 'make test-conformance -j8 TEST_CONCRETE_BACKEND=llvm' } }
             stage('Proofs (Java)')      { steps { sh 'make test-prove -j5 TEST_SYMBOLIC_BACKEND=java'       } }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,7 +27,7 @@ pipeline {
           failFast true
           options {
             timeout(time: 90, unit: 'MINUTES')
-            throttleJobProperty(categories: ['heavy'], throttleEnabled: true, throttleOption: 'category')
+            throttle(categories: ['heavy'], throttleEnabled: true, throttleOption: 'category')
           }
           parallel {
             stage('Conformance (LLVM)') { steps { sh 'make test-conformance -j8 TEST_CONCRETE_BACKEND=llvm' } }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,10 @@ pipeline {
     KEVM_RELEASE_TAG = "v${env.VERSION}-${env.SHORT_REV}"
     K_VERSION        = """${sh(returnStdout: true, script: 'cd deps/k && git tag --points-at HEAD | cut --characters=2-').trim()}"""
   }
-  options { ansiColor('xterm') }
+  options {
+    ansiColor('xterm')
+    lock("heavy-${env.NODE_NAME}")
+  }
   stages {
     stage('Init title') {
       when { changeRequest() }
@@ -27,9 +30,9 @@ pipeline {
           failFast true
           options { timeout(time: 90, unit: 'MINUTES') }
           parallel {
-            stage('Conformance (LLVM)') { steps {                                    sh 'make test-conformance -j8 TEST_CONCRETE_BACKEND=llvm'      } }
-            stage('Proofs (Java)')      { steps { lock("heavy-1-${env.NODE_NAME}") { sh 'make test-prove       -j5 TEST_SYMBOLIC_BACKEND=java'    } } }
-            stage('Proofs (Haskell)')   { steps { lock("heavy-2-${env.NODE_NAME}") { sh 'make test-prove       -j4 TEST_SYMBOLIC_BACKEND=haskell' } } }
+            stage('Conformance (LLVM)') { steps { sh 'make test-conformance -j8 TEST_CONCRETE_BACKEND=llvm'    } }
+            stage('Proofs (Java)')      { steps { sh 'make test-prove       -j5 TEST_SYMBOLIC_BACKEND=java'    } }
+            stage('Proofs (Haskell)')   { steps { sh 'make test-prove       -j4 TEST_SYMBOLIC_BACKEND=haskell' } }
           }
         }
         stage('Test Interactive') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,14 +1,3 @@
-properties([ [ $class: 'ThrottleJobProperty'
-             , categories: ['heavy'],
-             , limitOneJobWithMatchingParams: false
-             , maxConcurrentPerNode: 1
-             , maxConcurrentTotal: 0
-             , paramsToUseForLimit: ''
-             , throttleEnabled: true
-             , throttleOption: 'category'
-             ]
-           ]
-          )
 pipeline {
   agent { label 'docker' }
   environment {
@@ -36,11 +25,14 @@ pipeline {
         stage('Build') { steps { sh 'make build RELEASE=true -j6' } }
         stage('Test') {
           failFast true
-          options { timeout(time: 90, unit: 'MINUTES') }
+          options {
+            timeout(time: 90, unit: 'MINUTES')
+            throttleJobProperty(categories: ['heavy'], throttleEnabled: true, throttleOption: 'category')
+          }
           parallel {
-            stage('Conformance (LLVM)')         { steps { sh 'make test-conformance -j8 TEST_CONCRETE_BACKEND=llvm' } }
-            stage('Proofs (Java)')              { steps { sh 'make test-prove -j5 TEST_SYMBOLIC_BACKEND=java'       } }
-            stage('Proofs (Haskell)')           { steps { sh 'make test-prove -j4 TEST_SYMBOLIC_BACKEND=haskell'    } }
+            stage('Conformance (LLVM)') { steps { sh 'make test-conformance -j8 TEST_CONCRETE_BACKEND=llvm' } }
+            stage('Proofs (Java)')      { steps { sh 'make test-prove -j5 TEST_SYMBOLIC_BACKEND=java'       } }
+            stage('Proofs (Haskell)')   { steps { sh 'make test-prove -j4 TEST_SYMBOLIC_BACKEND=haskell'    } }
           }
         }
         stage('Test Interactive') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,10 +8,7 @@ pipeline {
     KEVM_RELEASE_TAG = "v${env.VERSION}-${env.SHORT_REV}"
     K_VERSION        = """${sh(returnStdout: true, script: 'cd deps/k && git tag --points-at HEAD | cut --characters=2-').trim()}"""
   }
-  options {
-    ansiColor('xterm')
-    throttleJobProperty(categories: ['heavy'], throttleEnabled: true, throttleOption: 'category')
-  }
+  options { ansiColor('xterm') }
   stages {
     stage('Init title') {
       when { changeRequest() }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,14 @@
+properties([ [ $class: 'ThrottleJobProperty'
+             , categories: ['heavy'],
+             , limitOneJobWithMatchingParams: false
+             , maxConcurrentPerNode: 1
+             , maxConcurrentTotal: 0
+             , paramsToUseForLimit: ''
+             , throttleEnabled: true
+             , throttleOption: 'category'
+             ]
+           ]
+          )
 pipeline {
   agent { label 'docker' }
   environment {
@@ -25,10 +36,7 @@ pipeline {
         stage('Build') { steps { sh 'make build RELEASE=true -j6' } }
         stage('Test') {
           failFast true
-          options {
-            timeout(time: 90, unit: 'MINUTES')
-            throttleJobProperty(categories: ['heavy'], throttleEnabled: true, throttleOption: 'category')
-          }
+          options { timeout(time: 90, unit: 'MINUTES') }
           parallel {
             stage('Conformance (LLVM)')         { steps { sh 'make test-conformance -j8 TEST_CONCRETE_BACKEND=llvm' } }
             stage('Proofs (Java)')              { steps { sh 'make test-prove -j5 TEST_SYMBOLIC_BACKEND=java'       } }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,7 +27,7 @@ pipeline {
           failFast true
           options {
             timeout(time: 90, unit: 'MINUTES')
-            throttle(categories: ['heavy'], throttleEnabled: true, throttleOption: 'category')
+            throttle(categories: ['heavy'])
           }
           parallel {
             stage('Conformance (LLVM)') { steps { sh 'make test-conformance -j8 TEST_CONCRETE_BACKEND=llvm' } }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,9 +27,9 @@ pipeline {
           failFast true
           options { timeout(time: 90, unit: 'MINUTES') }
           parallel {
-            stage('Conformance (LLVM)') { steps {                                  sh 'make test-conformance -j8 TEST_CONCRETE_BACKEND=llvm'      } }
-            stage('Proofs (Java)')      { steps { lock("heavy-${env.NODE_NAME}") { sh 'make test-prove       -j5 TEST_SYMBOLIC_BACKEND=java'    } } }
-            stage('Proofs (Haskell)')   { steps { lock("heavy-${env.NODE_NAME}") { sh 'make test-prove       -j4 TEST_SYMBOLIC_BACKEND=haskell' } } }
+            stage('Conformance (LLVM)') { steps {                                    sh 'make test-conformance -j8 TEST_CONCRETE_BACKEND=llvm'      } }
+            stage('Proofs (Java)')      { steps { lock("heavy-1-${env.NODE_NAME}") { sh 'make test-prove       -j5 TEST_SYMBOLIC_BACKEND=java'    } } }
+            stage('Proofs (Haskell)')   { steps { lock("heavy-2-${env.NODE_NAME}") { sh 'make test-prove       -j4 TEST_SYMBOLIC_BACKEND=haskell' } } }
           }
         }
         stage('Test Interactive') {


### PR DESCRIPTION
Currently, we only allow one KEVM build in the test phase at a time, across _all_ executors. This lists that restriction, as all the remaining CI servers are big servers anymore, so it should be safe to run multiple KEVMs at the same time on each machine.