### PR TITLE
Remove precompile accounts from state of MCD proofs

### DIFF
--- a/evm.md
+++ b/evm.md
@@ -1170,9 +1170,6 @@ For now, I assume that they instantiate an empty account and use the empty data.
 
     syntax UnStackOp ::= "EXTCODEHASH"
  // ----------------------------------
-```
-
-```k
     rule <k> EXTCODEHASH ACCT => keccak(CODE) ~> #push ... </k>
          <account>
            <acctID> ACCT </acctID>

--- a/evm.md
+++ b/evm.md
@@ -2154,15 +2154,9 @@ There are several helpers for calculating gas (most of them also specified in th
     syntax KResult ::= Bool
     syntax BExp ::= #accountNonexistent ( Int )
  // -------------------------------------------
-    rule <k> #accountNonexistent(ACCT) => Gemptyisnonexistent << SCHED >> ... </k>
-         <schedule> SCHED </schedule>
-      requires #isPrecompiledAccount(ACCT, SCHED)
-
     rule <k> #accountNonexistent(ACCT) => true ... </k>
-         <schedule> SCHED </schedule>
          <activeAccounts> ACCTS </activeAccounts>
-      requires (notBool #isPrecompiledAccount(ACCT, SCHED))
-       andBool (notBool ACCT in ACCTS)
+      requires notBool ACCT in ACCTS
 
     rule <k> #accountNonexistent(ACCT) => #accountEmpty(CODE, NONCE, BAL) andBool Gemptyisnonexistent << SCHED >> ... </k>
          <schedule> SCHED </schedule>
@@ -2173,7 +2167,6 @@ There are several helpers for calculating gas (most of them also specified in th
            <code>    CODE  </code>
            ...
          </account>
-      requires notBool #isPrecompiledAccount(ACCT, SCHED)
 
     syntax Bool ::= #accountEmpty ( AccountCode , Int , Int ) [function, klabel(accountEmpty), symbol]
  // --------------------------------------------------------------------------------------------------

--- a/evm.md
+++ b/evm.md
@@ -2157,9 +2157,15 @@ There are several helpers for calculating gas (most of them also specified in th
     syntax KResult ::= Bool
     syntax BExp ::= #accountNonexistent ( Int )
  // -------------------------------------------
+    rule <k> #accountNonexistent(ACCT) => Gemptyisnonexistent << SCHED >> ... </k>
+         <schedule> SCHED </schedule>
+      requires #isPrecompiledAccount(ACCT, SCHED)
+
     rule <k> #accountNonexistent(ACCT) => true ... </k>
+         <schedule> SCHED </schedule>
          <activeAccounts> ACCTS </activeAccounts>
-      requires notBool ACCT in ACCTS
+      requires (notBool #isPrecompiledAccount(ACCT, SCHED))
+       andBool (notBool ACCT in ACCTS)
 
     rule <k> #accountNonexistent(ACCT) => #accountEmpty(CODE, NONCE, BAL) andBool Gemptyisnonexistent << SCHED >> ... </k>
          <schedule> SCHED </schedule>
@@ -2170,6 +2176,7 @@ There are several helpers for calculating gas (most of them also specified in th
            <code>    CODE  </code>
            ...
          </account>
+      requires notBool #isPrecompiledAccount(ACCT, SCHED)
 
     syntax Bool ::= #accountEmpty ( AccountCode , Int , Int ) [function, klabel(accountEmpty), symbol]
  // --------------------------------------------------------------------------------------------------

--- a/serialization.md
+++ b/serialization.md
@@ -700,25 +700,6 @@ Tree Root Helper Functions
     rule #storageRoot( STORAGE ) => MerkleUpdateMap( .MerkleTree, #intMap2StorageMap( STORAGE ) )
 ```
 
-### State Root
-
 ```k
-    syntax Map ::= #precompiledAccountsMap   ( Set )       [function]
-                 | #precompiledAccountsMapAux( List, Map ) [function]
- // -----------------------------------------------------------------
-    rule #precompiledAccountsMap( ACCTS ) => #precompiledAccountsMapAux( Set2List( ACCTS ), .Map )
-
-    rule #precompiledAccountsMapAux( .List, M ) => M
-    rule #precompiledAccountsMapAux( (ListItem( ACCT ) => .List) _, M => M[#parseByteStackRaw( Hex2Raw( #unparseData( ACCT, 20 ) ) ) <- #emptyContractRLP] )
-
-    syntax String ::= "#emptyContractRLP" [function]
- // ------------------------------------------------
-    rule #emptyContractRLP => #rlpEncodeLength(         #rlpEncodeWord(0)
-                                                +String #rlpEncodeWord(0)
-                                                +String #rlpEncodeString( Hex2Raw( Keccak256("\x80") ) )
-                                                +String #rlpEncodeString( Hex2Raw( Keccak256("") ) )
-                                              , 192
-                                              )
-
 endmodule
 ```

--- a/serialization.md
+++ b/serialization.md
@@ -700,6 +700,25 @@ Tree Root Helper Functions
     rule #storageRoot( STORAGE ) => MerkleUpdateMap( .MerkleTree, #intMap2StorageMap( STORAGE ) )
 ```
 
+### State Root
+
 ```k
+    syntax Map ::= #precompiledAccountsMap   ( Set )       [function]
+                 | #precompiledAccountsMapAux( List, Map ) [function]
+ // -----------------------------------------------------------------
+    rule #precompiledAccountsMap( ACCTS ) => #precompiledAccountsMapAux( Set2List( ACCTS ), .Map )
+
+    rule #precompiledAccountsMapAux( .List, M ) => M
+    rule #precompiledAccountsMapAux( (ListItem( ACCT ) => .List) _, M => M[#parseByteStackRaw( Hex2Raw( #unparseData( ACCT, 20 ) ) ) <- #emptyContractRLP] )
+
+    syntax String ::= "#emptyContractRLP" [function]
+ // ------------------------------------------------
+    rule #emptyContractRLP => #rlpEncodeLength(         #rlpEncodeWord(0)
+                                                +String #rlpEncodeWord(0)
+                                                +String #rlpEncodeString( Hex2Raw( Keccak256("\x80") ) )
+                                                +String #rlpEncodeString( Hex2Raw( Keccak256("") ) )
+                                              , 192
+                                              )
+
 endmodule
 ```

--- a/tests/specs/mcd/cat-file-addr-pass-rough-spec.k
+++ b/tests/specs/mcd/cat-file-addr-pass-rough-spec.k
@@ -72,78 +72,6 @@ module CAT-FILE-ADDR-PASS-ROUGH-SPEC
               <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_Cat => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -158,15 +86,6 @@ module CAT-FILE-ADDR-PASS-ROUGH-SPEC
        andBool #rangeAddress(ORIGIN_ID)
        andBool #rangeUInt(256, TIME)
        andBool #rangeUInt(256, ACCT_ID_balance)
-       andBool #rangeUInt(256, ECREC_BAL)
-       andBool #rangeUInt(256, SHA256_BAL)
-       andBool #rangeUInt(256, RIP160_BAL)
-       andBool #rangeUInt(256, ID_BAL)
-       andBool #rangeUInt(256, MODEXP_BAL)
-       andBool #rangeUInt(256, ECADD_BAL)
-       andBool #rangeUInt(256, ECMUL_BAL)
-       andBool #rangeUInt(256, ECPAIRING_BAL)
-       andBool #rangeUInt(256, BLAKE2_BAL)
        andBool VCallDepth <=Int 1024
        andBool #rangeUInt(256, VCallValue)
        andBool #rangeUInt(256, VChainId)

--- a/tests/specs/mcd/cat-file-addr-pass-rough-spec.k
+++ b/tests/specs/mcd/cat-file-addr-pass-rough-spec.k
@@ -62,16 +62,7 @@ module CAT-FILE-ADDR-PASS-ROUGH-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>

--- a/tests/specs/mcd/dai-adduu-fail-rough-spec.k
+++ b/tests/specs/mcd/dai-adduu-fail-rough-spec.k
@@ -62,16 +62,7 @@ module DAI-ADDUU-FAIL-ROUGH-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>

--- a/tests/specs/mcd/dai-adduu-fail-rough-spec.k
+++ b/tests/specs/mcd/dai-adduu-fail-rough-spec.k
@@ -72,78 +72,6 @@ module DAI-ADDUU-FAIL-ROUGH-SPEC
               <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_Dai => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -158,15 +86,6 @@ module DAI-ADDUU-FAIL-ROUGH-SPEC
        andBool #rangeAddress(ORIGIN_ID)
        andBool #rangeUInt(256, TIME)
        andBool #rangeUInt(256, ACCT_ID_balance)
-       andBool #rangeUInt(256, ECREC_BAL)
-       andBool #rangeUInt(256, SHA256_BAL)
-       andBool #rangeUInt(256, RIP160_BAL)
-       andBool #rangeUInt(256, ID_BAL)
-       andBool #rangeUInt(256, MODEXP_BAL)
-       andBool #rangeUInt(256, ECADD_BAL)
-       andBool #rangeUInt(256, ECMUL_BAL)
-       andBool #rangeUInt(256, ECPAIRING_BAL)
-       andBool #rangeUInt(256, BLAKE2_BAL)
        andBool VCallDepth <=Int 1024
        andBool #rangeUInt(256, VCallValue)
        andBool #rangeUInt(256, VChainId)

--- a/tests/specs/mcd/dai-symbol-pass-spec.k
+++ b/tests/specs/mcd/dai-symbol-pass-spec.k
@@ -62,16 +62,7 @@ module DAI-SYMBOL-PASS-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>

--- a/tests/specs/mcd/dai-symbol-pass-spec.k
+++ b/tests/specs/mcd/dai-symbol-pass-spec.k
@@ -72,78 +72,6 @@ module DAI-SYMBOL-PASS-SPEC
               <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_Dai => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -158,15 +86,6 @@ module DAI-SYMBOL-PASS-SPEC
        andBool #rangeAddress(ORIGIN_ID)
        andBool #rangeUInt(256, TIME)
        andBool #rangeUInt(256, ACCT_ID_balance)
-       andBool #rangeUInt(256, ECREC_BAL)
-       andBool #rangeUInt(256, SHA256_BAL)
-       andBool #rangeUInt(256, RIP160_BAL)
-       andBool #rangeUInt(256, ID_BAL)
-       andBool #rangeUInt(256, MODEXP_BAL)
-       andBool #rangeUInt(256, ECADD_BAL)
-       andBool #rangeUInt(256, ECMUL_BAL)
-       andBool #rangeUInt(256, ECPAIRING_BAL)
-       andBool #rangeUInt(256, BLAKE2_BAL)
        andBool VCallDepth <=Int 1024
        andBool #rangeUInt(256, VCallValue)
        andBool #rangeUInt(256, VChainId)

--- a/tests/specs/mcd/dstoken-approve-fail-rough-spec.k
+++ b/tests/specs/mcd/dstoken-approve-fail-rough-spec.k
@@ -72,78 +72,6 @@ module DSTOKEN-APPROVE-FAIL-ROUGH-SPEC
               <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_DSToken => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -158,15 +86,6 @@ module DSTOKEN-APPROVE-FAIL-ROUGH-SPEC
        andBool #rangeAddress(ORIGIN_ID)
        andBool #rangeUInt(256, TIME)
        andBool #rangeUInt(256, ACCT_ID_balance)
-       andBool #rangeUInt(256, ECREC_BAL)
-       andBool #rangeUInt(256, SHA256_BAL)
-       andBool #rangeUInt(256, RIP160_BAL)
-       andBool #rangeUInt(256, ID_BAL)
-       andBool #rangeUInt(256, MODEXP_BAL)
-       andBool #rangeUInt(256, ECADD_BAL)
-       andBool #rangeUInt(256, ECMUL_BAL)
-       andBool #rangeUInt(256, ECPAIRING_BAL)
-       andBool #rangeUInt(256, BLAKE2_BAL)
        andBool VCallDepth <=Int 1024
        andBool #rangeUInt(256, VCallValue)
        andBool #rangeUInt(256, VChainId)

--- a/tests/specs/mcd/dstoken-approve-fail-rough-spec.k
+++ b/tests/specs/mcd/dstoken-approve-fail-rough-spec.k
@@ -62,16 +62,7 @@ module DSTOKEN-APPROVE-FAIL-ROUGH-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>

--- a/tests/specs/mcd/dstoken-burn-self-fail-rough-spec.k
+++ b/tests/specs/mcd/dstoken-burn-self-fail-rough-spec.k
@@ -62,16 +62,7 @@ module DSTOKEN-BURN-SELF-FAIL-ROUGH-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>

--- a/tests/specs/mcd/dstoken-burn-self-fail-rough-spec.k
+++ b/tests/specs/mcd/dstoken-burn-self-fail-rough-spec.k
@@ -72,78 +72,6 @@ module DSTOKEN-BURN-SELF-FAIL-ROUGH-SPEC
               <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_DSToken => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -158,15 +86,6 @@ module DSTOKEN-BURN-SELF-FAIL-ROUGH-SPEC
        andBool #rangeAddress(ORIGIN_ID)
        andBool #rangeUInt(256, TIME)
        andBool #rangeUInt(256, ACCT_ID_balance)
-       andBool #rangeUInt(256, ECREC_BAL)
-       andBool #rangeUInt(256, SHA256_BAL)
-       andBool #rangeUInt(256, RIP160_BAL)
-       andBool #rangeUInt(256, ID_BAL)
-       andBool #rangeUInt(256, MODEXP_BAL)
-       andBool #rangeUInt(256, ECADD_BAL)
-       andBool #rangeUInt(256, ECMUL_BAL)
-       andBool #rangeUInt(256, ECPAIRING_BAL)
-       andBool #rangeUInt(256, BLAKE2_BAL)
        andBool VCallDepth <=Int 1024
        andBool #rangeUInt(256, VCallValue)
        andBool #rangeUInt(256, VChainId)

--- a/tests/specs/mcd/dstoken-transferfrom-fail-rough-spec.k
+++ b/tests/specs/mcd/dstoken-transferfrom-fail-rough-spec.k
@@ -62,16 +62,7 @@ module DSTOKEN-TRANSFERFROM-FAIL-ROUGH-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>

--- a/tests/specs/mcd/dstoken-transferfrom-fail-rough-spec.k
+++ b/tests/specs/mcd/dstoken-transferfrom-fail-rough-spec.k
@@ -72,78 +72,6 @@ module DSTOKEN-TRANSFERFROM-FAIL-ROUGH-SPEC
               <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_DSToken => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -158,15 +86,6 @@ module DSTOKEN-TRANSFERFROM-FAIL-ROUGH-SPEC
        andBool #rangeAddress(ORIGIN_ID)
        andBool #rangeUInt(256, TIME)
        andBool #rangeUInt(256, ACCT_ID_balance)
-       andBool #rangeUInt(256, ECREC_BAL)
-       andBool #rangeUInt(256, SHA256_BAL)
-       andBool #rangeUInt(256, RIP160_BAL)
-       andBool #rangeUInt(256, ID_BAL)
-       andBool #rangeUInt(256, MODEXP_BAL)
-       andBool #rangeUInt(256, ECADD_BAL)
-       andBool #rangeUInt(256, ECMUL_BAL)
-       andBool #rangeUInt(256, ECPAIRING_BAL)
-       andBool #rangeUInt(256, BLAKE2_BAL)
        andBool VCallDepth <=Int 1024
        andBool #rangeUInt(256, VCallValue)
        andBool #rangeUInt(256, VChainId)

--- a/tests/specs/mcd/dsvalue-peek-pass-rough-spec.k
+++ b/tests/specs/mcd/dsvalue-peek-pass-rough-spec.k
@@ -62,16 +62,7 @@ module DSVALUE-PEEK-PASS-ROUGH-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>

--- a/tests/specs/mcd/dsvalue-peek-pass-rough-spec.k
+++ b/tests/specs/mcd/dsvalue-peek-pass-rough-spec.k
@@ -72,78 +72,6 @@ module DSVALUE-PEEK-PASS-ROUGH-SPEC
               <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_DSValue => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -158,15 +86,6 @@ module DSVALUE-PEEK-PASS-ROUGH-SPEC
        andBool #rangeAddress(ORIGIN_ID)
        andBool #rangeUInt(256, TIME)
        andBool #rangeUInt(256, ACCT_ID_balance)
-       andBool #rangeUInt(256, ECREC_BAL)
-       andBool #rangeUInt(256, SHA256_BAL)
-       andBool #rangeUInt(256, RIP160_BAL)
-       andBool #rangeUInt(256, ID_BAL)
-       andBool #rangeUInt(256, MODEXP_BAL)
-       andBool #rangeUInt(256, ECADD_BAL)
-       andBool #rangeUInt(256, ECMUL_BAL)
-       andBool #rangeUInt(256, ECPAIRING_BAL)
-       andBool #rangeUInt(256, BLAKE2_BAL)
        andBool VCallDepth <=Int 1024
        andBool #rangeUInt(256, VCallValue)
        andBool #rangeUInt(256, VChainId)

--- a/tests/specs/mcd/dsvalue-read-pass-spec.k
+++ b/tests/specs/mcd/dsvalue-read-pass-spec.k
@@ -72,78 +72,6 @@ module DSVALUE-READ-PASS-SPEC
               <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_DSValue => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -158,15 +86,6 @@ module DSVALUE-READ-PASS-SPEC
        andBool #rangeAddress(ORIGIN_ID)
        andBool #rangeUInt(256, TIME)
        andBool #rangeUInt(256, ACCT_ID_balance)
-       andBool #rangeUInt(256, ECREC_BAL)
-       andBool #rangeUInt(256, SHA256_BAL)
-       andBool #rangeUInt(256, RIP160_BAL)
-       andBool #rangeUInt(256, ID_BAL)
-       andBool #rangeUInt(256, MODEXP_BAL)
-       andBool #rangeUInt(256, ECADD_BAL)
-       andBool #rangeUInt(256, ECMUL_BAL)
-       andBool #rangeUInt(256, ECPAIRING_BAL)
-       andBool #rangeUInt(256, BLAKE2_BAL)
        andBool VCallDepth <=Int 1024
        andBool #rangeUInt(256, VCallValue)
        andBool #rangeUInt(256, VChainId)

--- a/tests/specs/mcd/dsvalue-read-pass-spec.k
+++ b/tests/specs/mcd/dsvalue-read-pass-spec.k
@@ -62,16 +62,7 @@ module DSVALUE-READ-PASS-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>

--- a/tests/specs/mcd/end-cash-pass-rough-spec.k
+++ b/tests/specs/mcd/end-cash-pass-rough-spec.k
@@ -80,78 +80,6 @@ module END-CASH-PASS-ROUGH-SPEC
               <origStorage> Vat_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_Vat => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -166,15 +94,6 @@ module END-CASH-PASS-ROUGH-SPEC
        andBool #rangeAddress(ORIGIN_ID)
        andBool #rangeUInt(256, TIME)
        andBool #rangeUInt(256, ACCT_ID_balance)
-       andBool #rangeUInt(256, ECREC_BAL)
-       andBool #rangeUInt(256, SHA256_BAL)
-       andBool #rangeUInt(256, RIP160_BAL)
-       andBool #rangeUInt(256, ID_BAL)
-       andBool #rangeUInt(256, MODEXP_BAL)
-       andBool #rangeUInt(256, ECADD_BAL)
-       andBool #rangeUInt(256, ECMUL_BAL)
-       andBool #rangeUInt(256, ECPAIRING_BAL)
-       andBool #rangeUInt(256, BLAKE2_BAL)
        andBool VCallDepth <=Int 1024
        andBool #rangeUInt(256, VCallValue)
        andBool #rangeUInt(256, VChainId)
@@ -302,78 +221,6 @@ module END-CASH-PASS-ROUGH-SPEC
               <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_End => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -388,15 +235,6 @@ module END-CASH-PASS-ROUGH-SPEC
        andBool #rangeAddress(ORIGIN_ID)
        andBool #rangeUInt(256, TIME)
        andBool #rangeUInt(256, ACCT_ID_balance)
-       andBool #rangeUInt(256, ECREC_BAL)
-       andBool #rangeUInt(256, SHA256_BAL)
-       andBool #rangeUInt(256, RIP160_BAL)
-       andBool #rangeUInt(256, ID_BAL)
-       andBool #rangeUInt(256, MODEXP_BAL)
-       andBool #rangeUInt(256, ECADD_BAL)
-       andBool #rangeUInt(256, ECMUL_BAL)
-       andBool #rangeUInt(256, ECPAIRING_BAL)
-       andBool #rangeUInt(256, BLAKE2_BAL)
        andBool VCallDepth <=Int 1024
        andBool #rangeUInt(256, VCallValue)
        andBool #rangeUInt(256, VChainId)
@@ -483,78 +321,6 @@ module END-CASH-PASS-ROUGH-SPEC
               <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_End => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -569,15 +335,6 @@ module END-CASH-PASS-ROUGH-SPEC
        andBool #rangeAddress(ORIGIN_ID)
        andBool #rangeUInt(256, TIME)
        andBool #rangeUInt(256, ACCT_ID_balance)
-       andBool #rangeUInt(256, ECREC_BAL)
-       andBool #rangeUInt(256, SHA256_BAL)
-       andBool #rangeUInt(256, RIP160_BAL)
-       andBool #rangeUInt(256, ID_BAL)
-       andBool #rangeUInt(256, MODEXP_BAL)
-       andBool #rangeUInt(256, ECADD_BAL)
-       andBool #rangeUInt(256, ECMUL_BAL)
-       andBool #rangeUInt(256, ECPAIRING_BAL)
-       andBool #rangeUInt(256, BLAKE2_BAL)
        andBool VCallDepth <=Int 1024
        andBool #rangeUInt(256, VCallValue)
        andBool #rangeUInt(256, VChainId)
@@ -661,78 +418,6 @@ module END-CASH-PASS-ROUGH-SPEC
               <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_Vat => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -747,15 +432,6 @@ module END-CASH-PASS-ROUGH-SPEC
        andBool #rangeAddress(ORIGIN_ID)
        andBool #rangeUInt(256, TIME)
        andBool #rangeUInt(256, ACCT_ID_balance)
-       andBool #rangeUInt(256, ECREC_BAL)
-       andBool #rangeUInt(256, SHA256_BAL)
-       andBool #rangeUInt(256, RIP160_BAL)
-       andBool #rangeUInt(256, ID_BAL)
-       andBool #rangeUInt(256, MODEXP_BAL)
-       andBool #rangeUInt(256, ECADD_BAL)
-       andBool #rangeUInt(256, ECMUL_BAL)
-       andBool #rangeUInt(256, ECPAIRING_BAL)
-       andBool #rangeUInt(256, BLAKE2_BAL)
        andBool VCallDepth <=Int 1024
        andBool #rangeUInt(256, VCallValue)
        andBool #rangeUInt(256, VChainId)

--- a/tests/specs/mcd/end-cash-pass-rough-spec.k
+++ b/tests/specs/mcd/end-cash-pass-rough-spec.k
@@ -62,17 +62,7 @@ module END-CASH-PASS-ROUGH-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(Vat)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) SetItem(Vat) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>
@@ -302,16 +292,7 @@ module END-CASH-PASS-ROUGH-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>
@@ -492,16 +473,7 @@ module END-CASH-PASS-ROUGH-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>
@@ -679,16 +651,7 @@ module END-CASH-PASS-ROUGH-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>

--- a/tests/specs/mcd/end-pack-pass-rough-spec.k
+++ b/tests/specs/mcd/end-pack-pass-rough-spec.k
@@ -62,17 +62,7 @@ module END-PACK-PASS-ROUGH-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(Vat)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) SetItem(Vat) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>
@@ -307,16 +297,7 @@ module END-PACK-PASS-ROUGH-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>
@@ -494,16 +475,7 @@ module END-PACK-PASS-ROUGH-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>
@@ -681,16 +653,7 @@ module END-PACK-PASS-ROUGH-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>

--- a/tests/specs/mcd/end-pack-pass-rough-spec.k
+++ b/tests/specs/mcd/end-pack-pass-rough-spec.k
@@ -80,78 +80,6 @@ module END-PACK-PASS-ROUGH-SPEC
               <origStorage> Vat_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_Vat => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -166,15 +94,6 @@ module END-PACK-PASS-ROUGH-SPEC
        andBool #rangeAddress(ORIGIN_ID)
        andBool #rangeUInt(256, TIME)
        andBool #rangeUInt(256, ACCT_ID_balance)
-       andBool #rangeUInt(256, ECREC_BAL)
-       andBool #rangeUInt(256, SHA256_BAL)
-       andBool #rangeUInt(256, RIP160_BAL)
-       andBool #rangeUInt(256, ID_BAL)
-       andBool #rangeUInt(256, MODEXP_BAL)
-       andBool #rangeUInt(256, ECADD_BAL)
-       andBool #rangeUInt(256, ECMUL_BAL)
-       andBool #rangeUInt(256, ECPAIRING_BAL)
-       andBool #rangeUInt(256, BLAKE2_BAL)
        andBool VCallDepth <=Int 1024
        andBool #rangeUInt(256, VCallValue)
        andBool #rangeUInt(256, VChainId)
@@ -307,78 +226,6 @@ module END-PACK-PASS-ROUGH-SPEC
               <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_End => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -393,15 +240,6 @@ module END-PACK-PASS-ROUGH-SPEC
        andBool #rangeAddress(ORIGIN_ID)
        andBool #rangeUInt(256, TIME)
        andBool #rangeUInt(256, ACCT_ID_balance)
-       andBool #rangeUInt(256, ECREC_BAL)
-       andBool #rangeUInt(256, SHA256_BAL)
-       andBool #rangeUInt(256, RIP160_BAL)
-       andBool #rangeUInt(256, ID_BAL)
-       andBool #rangeUInt(256, MODEXP_BAL)
-       andBool #rangeUInt(256, ECADD_BAL)
-       andBool #rangeUInt(256, ECMUL_BAL)
-       andBool #rangeUInt(256, ECPAIRING_BAL)
-       andBool #rangeUInt(256, BLAKE2_BAL)
        andBool VCallDepth <=Int 1024
        andBool #rangeUInt(256, VCallValue)
        andBool #rangeUInt(256, VChainId)
@@ -485,78 +323,6 @@ module END-PACK-PASS-ROUGH-SPEC
               <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_End => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -571,15 +337,6 @@ module END-PACK-PASS-ROUGH-SPEC
        andBool #rangeAddress(ORIGIN_ID)
        andBool #rangeUInt(256, TIME)
        andBool #rangeUInt(256, ACCT_ID_balance)
-       andBool #rangeUInt(256, ECREC_BAL)
-       andBool #rangeUInt(256, SHA256_BAL)
-       andBool #rangeUInt(256, RIP160_BAL)
-       andBool #rangeUInt(256, ID_BAL)
-       andBool #rangeUInt(256, MODEXP_BAL)
-       andBool #rangeUInt(256, ECADD_BAL)
-       andBool #rangeUInt(256, ECMUL_BAL)
-       andBool #rangeUInt(256, ECPAIRING_BAL)
-       andBool #rangeUInt(256, BLAKE2_BAL)
        andBool VCallDepth <=Int 1024
        andBool #rangeUInt(256, VCallValue)
        andBool #rangeUInt(256, VChainId)
@@ -663,78 +420,6 @@ module END-PACK-PASS-ROUGH-SPEC
               <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_Vat => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -749,15 +434,6 @@ module END-PACK-PASS-ROUGH-SPEC
        andBool #rangeAddress(ORIGIN_ID)
        andBool #rangeUInt(256, TIME)
        andBool #rangeUInt(256, ACCT_ID_balance)
-       andBool #rangeUInt(256, ECREC_BAL)
-       andBool #rangeUInt(256, SHA256_BAL)
-       andBool #rangeUInt(256, RIP160_BAL)
-       andBool #rangeUInt(256, ID_BAL)
-       andBool #rangeUInt(256, MODEXP_BAL)
-       andBool #rangeUInt(256, ECADD_BAL)
-       andBool #rangeUInt(256, ECMUL_BAL)
-       andBool #rangeUInt(256, ECPAIRING_BAL)
-       andBool #rangeUInt(256, BLAKE2_BAL)
        andBool VCallDepth <=Int 1024
        andBool #rangeUInt(256, VCallValue)
        andBool #rangeUInt(256, VChainId)

--- a/tests/specs/mcd/end-subuu-pass-spec.k
+++ b/tests/specs/mcd/end-subuu-pass-spec.k
@@ -62,16 +62,7 @@ module END-SUBUU-PASS-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>

--- a/tests/specs/mcd/end-subuu-pass-spec.k
+++ b/tests/specs/mcd/end-subuu-pass-spec.k
@@ -72,78 +72,6 @@ module END-SUBUU-PASS-SPEC
               <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_End => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -158,15 +86,6 @@ module END-SUBUU-PASS-SPEC
        andBool #rangeAddress(ORIGIN_ID)
        andBool #rangeUInt(256, TIME)
        andBool #rangeUInt(256, ACCT_ID_balance)
-       andBool #rangeUInt(256, ECREC_BAL)
-       andBool #rangeUInt(256, SHA256_BAL)
-       andBool #rangeUInt(256, RIP160_BAL)
-       andBool #rangeUInt(256, ID_BAL)
-       andBool #rangeUInt(256, MODEXP_BAL)
-       andBool #rangeUInt(256, ECADD_BAL)
-       andBool #rangeUInt(256, ECMUL_BAL)
-       andBool #rangeUInt(256, ECPAIRING_BAL)
-       andBool #rangeUInt(256, BLAKE2_BAL)
        andBool VCallDepth <=Int 1024
        andBool #rangeUInt(256, VCallValue)
        andBool #rangeUInt(256, VChainId)

--- a/tests/specs/mcd/flapper-tend-guy-diff-pass-rough-spec.k
+++ b/tests/specs/mcd/flapper-tend-guy-diff-pass-rough-spec.k
@@ -62,17 +62,7 @@ module FLAPPER-TEND-GUY-DIFF-PASS-ROUGH-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(DSToken)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) SetItem(DSToken) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>
@@ -363,16 +353,7 @@ module FLAPPER-TEND-GUY-DIFF-PASS-ROUGH-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>
@@ -553,16 +534,7 @@ module FLAPPER-TEND-GUY-DIFF-PASS-ROUGH-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>
@@ -743,16 +715,7 @@ module FLAPPER-TEND-GUY-DIFF-PASS-ROUGH-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>

--- a/tests/specs/mcd/flapper-tend-guy-diff-pass-rough-spec.k
+++ b/tests/specs/mcd/flapper-tend-guy-diff-pass-rough-spec.k
@@ -80,78 +80,6 @@ module FLAPPER-TEND-GUY-DIFF-PASS-ROUGH-SPEC
               <origStorage> DSToken_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_DSToken => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -166,15 +94,6 @@ module FLAPPER-TEND-GUY-DIFF-PASS-ROUGH-SPEC
        andBool #rangeAddress(ORIGIN_ID)
        andBool #rangeUInt(256, TIME)
        andBool #rangeUInt(256, ACCT_ID_balance)
-       andBool #rangeUInt(256, ECREC_BAL)
-       andBool #rangeUInt(256, SHA256_BAL)
-       andBool #rangeUInt(256, RIP160_BAL)
-       andBool #rangeUInt(256, ID_BAL)
-       andBool #rangeUInt(256, MODEXP_BAL)
-       andBool #rangeUInt(256, ECADD_BAL)
-       andBool #rangeUInt(256, ECMUL_BAL)
-       andBool #rangeUInt(256, ECPAIRING_BAL)
-       andBool #rangeUInt(256, BLAKE2_BAL)
        andBool VCallDepth <=Int 1024
        andBool #rangeUInt(256, VCallValue)
        andBool #rangeUInt(256, VChainId)
@@ -363,78 +282,6 @@ module FLAPPER-TEND-GUY-DIFF-PASS-ROUGH-SPEC
               <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_Flapper => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -449,15 +296,6 @@ module FLAPPER-TEND-GUY-DIFF-PASS-ROUGH-SPEC
        andBool #rangeAddress(ORIGIN_ID)
        andBool #rangeUInt(256, TIME)
        andBool #rangeUInt(256, ACCT_ID_balance)
-       andBool #rangeUInt(256, ECREC_BAL)
-       andBool #rangeUInt(256, SHA256_BAL)
-       andBool #rangeUInt(256, RIP160_BAL)
-       andBool #rangeUInt(256, ID_BAL)
-       andBool #rangeUInt(256, MODEXP_BAL)
-       andBool #rangeUInt(256, ECADD_BAL)
-       andBool #rangeUInt(256, ECMUL_BAL)
-       andBool #rangeUInt(256, ECPAIRING_BAL)
-       andBool #rangeUInt(256, BLAKE2_BAL)
        andBool VCallDepth <=Int 1024
        andBool #rangeUInt(256, VCallValue)
        andBool #rangeUInt(256, VChainId)
@@ -544,78 +382,6 @@ module FLAPPER-TEND-GUY-DIFF-PASS-ROUGH-SPEC
               <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_Flapper => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -630,15 +396,6 @@ module FLAPPER-TEND-GUY-DIFF-PASS-ROUGH-SPEC
        andBool #rangeAddress(ORIGIN_ID)
        andBool #rangeUInt(256, TIME)
        andBool #rangeUInt(256, ACCT_ID_balance)
-       andBool #rangeUInt(256, ECREC_BAL)
-       andBool #rangeUInt(256, SHA256_BAL)
-       andBool #rangeUInt(256, RIP160_BAL)
-       andBool #rangeUInt(256, ID_BAL)
-       andBool #rangeUInt(256, MODEXP_BAL)
-       andBool #rangeUInt(256, ECADD_BAL)
-       andBool #rangeUInt(256, ECMUL_BAL)
-       andBool #rangeUInt(256, ECPAIRING_BAL)
-       andBool #rangeUInt(256, BLAKE2_BAL)
        andBool VCallDepth <=Int 1024
        andBool #rangeUInt(256, VCallValue)
        andBool #rangeUInt(256, VChainId)
@@ -725,78 +482,6 @@ module FLAPPER-TEND-GUY-DIFF-PASS-ROUGH-SPEC
               <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_DSToken => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -811,15 +496,6 @@ module FLAPPER-TEND-GUY-DIFF-PASS-ROUGH-SPEC
        andBool #rangeAddress(ORIGIN_ID)
        andBool #rangeUInt(256, TIME)
        andBool #rangeUInt(256, ACCT_ID_balance)
-       andBool #rangeUInt(256, ECREC_BAL)
-       andBool #rangeUInt(256, SHA256_BAL)
-       andBool #rangeUInt(256, RIP160_BAL)
-       andBool #rangeUInt(256, ID_BAL)
-       andBool #rangeUInt(256, MODEXP_BAL)
-       andBool #rangeUInt(256, ECADD_BAL)
-       andBool #rangeUInt(256, ECMUL_BAL)
-       andBool #rangeUInt(256, ECPAIRING_BAL)
-       andBool #rangeUInt(256, BLAKE2_BAL)
        andBool VCallDepth <=Int 1024
        andBool #rangeUInt(256, VCallValue)
        andBool #rangeUInt(256, VChainId)

--- a/tests/specs/mcd/flapper-yank-pass-rough-spec.k
+++ b/tests/specs/mcd/flapper-yank-pass-rough-spec.k
@@ -80,78 +80,6 @@ module FLAPPER-YANK-PASS-ROUGH-SPEC
               <origStorage> DSToken_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_DSToken => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -166,15 +94,6 @@ module FLAPPER-YANK-PASS-ROUGH-SPEC
        andBool #rangeAddress(ORIGIN_ID)
        andBool #rangeUInt(256, TIME)
        andBool #rangeUInt(256, ACCT_ID_balance)
-       andBool #rangeUInt(256, ECREC_BAL)
-       andBool #rangeUInt(256, SHA256_BAL)
-       andBool #rangeUInt(256, RIP160_BAL)
-       andBool #rangeUInt(256, ID_BAL)
-       andBool #rangeUInt(256, MODEXP_BAL)
-       andBool #rangeUInt(256, ECADD_BAL)
-       andBool #rangeUInt(256, ECMUL_BAL)
-       andBool #rangeUInt(256, ECPAIRING_BAL)
-       andBool #rangeUInt(256, BLAKE2_BAL)
        andBool VCallDepth <=Int 1024
        andBool #rangeUInt(256, VCallValue)
        andBool #rangeUInt(256, VChainId)
@@ -317,78 +236,6 @@ module FLAPPER-YANK-PASS-ROUGH-SPEC
               <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_DSToken => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -403,15 +250,6 @@ module FLAPPER-YANK-PASS-ROUGH-SPEC
        andBool #rangeAddress(ORIGIN_ID)
        andBool #rangeUInt(256, TIME)
        andBool #rangeUInt(256, ACCT_ID_balance)
-       andBool #rangeUInt(256, ECREC_BAL)
-       andBool #rangeUInt(256, SHA256_BAL)
-       andBool #rangeUInt(256, RIP160_BAL)
-       andBool #rangeUInt(256, ID_BAL)
-       andBool #rangeUInt(256, MODEXP_BAL)
-       andBool #rangeUInt(256, ECADD_BAL)
-       andBool #rangeUInt(256, ECMUL_BAL)
-       andBool #rangeUInt(256, ECPAIRING_BAL)
-       andBool #rangeUInt(256, BLAKE2_BAL)
        andBool VCallDepth <=Int 1024
        andBool #rangeUInt(256, VCallValue)
        andBool #rangeUInt(256, VChainId)

--- a/tests/specs/mcd/flapper-yank-pass-rough-spec.k
+++ b/tests/specs/mcd/flapper-yank-pass-rough-spec.k
@@ -62,17 +62,7 @@ module FLAPPER-YANK-PASS-ROUGH-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(DSToken)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) SetItem(DSToken) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>
@@ -317,16 +307,7 @@ module FLAPPER-YANK-PASS-ROUGH-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>

--- a/tests/specs/mcd/flipper-addu48u48-fail-rough-spec.k
+++ b/tests/specs/mcd/flipper-addu48u48-fail-rough-spec.k
@@ -62,16 +62,7 @@ module FLIPPER-ADDU48U48-FAIL-ROUGH-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>

--- a/tests/specs/mcd/flipper-addu48u48-fail-rough-spec.k
+++ b/tests/specs/mcd/flipper-addu48u48-fail-rough-spec.k
@@ -72,78 +72,6 @@ module FLIPPER-ADDU48U48-FAIL-ROUGH-SPEC
               <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_Flipper => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -158,15 +86,6 @@ module FLIPPER-ADDU48U48-FAIL-ROUGH-SPEC
        andBool #rangeAddress(ORIGIN_ID)
        andBool #rangeUInt(256, TIME)
        andBool #rangeUInt(256, ACCT_ID_balance)
-       andBool #rangeUInt(256, ECREC_BAL)
-       andBool #rangeUInt(256, SHA256_BAL)
-       andBool #rangeUInt(256, RIP160_BAL)
-       andBool #rangeUInt(256, ID_BAL)
-       andBool #rangeUInt(256, MODEXP_BAL)
-       andBool #rangeUInt(256, ECADD_BAL)
-       andBool #rangeUInt(256, ECMUL_BAL)
-       andBool #rangeUInt(256, ECPAIRING_BAL)
-       andBool #rangeUInt(256, BLAKE2_BAL)
        andBool VCallDepth <=Int 1024
        andBool #rangeUInt(256, VCallValue)
        andBool #rangeUInt(256, VChainId)

--- a/tests/specs/mcd/flipper-bids-pass-rough-spec.k
+++ b/tests/specs/mcd/flipper-bids-pass-rough-spec.k
@@ -72,78 +72,6 @@ module FLIPPER-BIDS-PASS-ROUGH-SPEC
               <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_Flipper => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -158,15 +86,6 @@ module FLIPPER-BIDS-PASS-ROUGH-SPEC
        andBool #rangeAddress(ORIGIN_ID)
        andBool #rangeUInt(256, TIME)
        andBool #rangeUInt(256, ACCT_ID_balance)
-       andBool #rangeUInt(256, ECREC_BAL)
-       andBool #rangeUInt(256, SHA256_BAL)
-       andBool #rangeUInt(256, RIP160_BAL)
-       andBool #rangeUInt(256, ID_BAL)
-       andBool #rangeUInt(256, MODEXP_BAL)
-       andBool #rangeUInt(256, ECADD_BAL)
-       andBool #rangeUInt(256, ECMUL_BAL)
-       andBool #rangeUInt(256, ECPAIRING_BAL)
-       andBool #rangeUInt(256, BLAKE2_BAL)
        andBool VCallDepth <=Int 1024
        andBool #rangeUInt(256, VCallValue)
        andBool #rangeUInt(256, VChainId)

--- a/tests/specs/mcd/flipper-bids-pass-rough-spec.k
+++ b/tests/specs/mcd/flipper-bids-pass-rough-spec.k
@@ -62,16 +62,7 @@ module FLIPPER-BIDS-PASS-ROUGH-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>

--- a/tests/specs/mcd/flipper-tau-pass-spec.k
+++ b/tests/specs/mcd/flipper-tau-pass-spec.k
@@ -72,78 +72,6 @@ module FLIPPER-TAU-PASS-SPEC
               <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_Flipper => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -158,15 +86,6 @@ module FLIPPER-TAU-PASS-SPEC
        andBool #rangeAddress(ORIGIN_ID)
        andBool #rangeUInt(256, TIME)
        andBool #rangeUInt(256, ACCT_ID_balance)
-       andBool #rangeUInt(256, ECREC_BAL)
-       andBool #rangeUInt(256, SHA256_BAL)
-       andBool #rangeUInt(256, RIP160_BAL)
-       andBool #rangeUInt(256, ID_BAL)
-       andBool #rangeUInt(256, MODEXP_BAL)
-       andBool #rangeUInt(256, ECADD_BAL)
-       andBool #rangeUInt(256, ECMUL_BAL)
-       andBool #rangeUInt(256, ECPAIRING_BAL)
-       andBool #rangeUInt(256, BLAKE2_BAL)
        andBool VCallDepth <=Int 1024
        andBool #rangeUInt(256, VCallValue)
        andBool #rangeUInt(256, VChainId)

--- a/tests/specs/mcd/flipper-tau-pass-spec.k
+++ b/tests/specs/mcd/flipper-tau-pass-spec.k
@@ -62,16 +62,7 @@ module FLIPPER-TAU-PASS-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>

--- a/tests/specs/mcd/flipper-ttl-pass-spec.k
+++ b/tests/specs/mcd/flipper-ttl-pass-spec.k
@@ -62,16 +62,7 @@ module FLIPPER-TTL-PASS-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>

--- a/tests/specs/mcd/flipper-ttl-pass-spec.k
+++ b/tests/specs/mcd/flipper-ttl-pass-spec.k
@@ -72,78 +72,6 @@ module FLIPPER-TTL-PASS-SPEC
               <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_Flipper => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -158,15 +86,6 @@ module FLIPPER-TTL-PASS-SPEC
        andBool #rangeAddress(ORIGIN_ID)
        andBool #rangeUInt(256, TIME)
        andBool #rangeUInt(256, ACCT_ID_balance)
-       andBool #rangeUInt(256, ECREC_BAL)
-       andBool #rangeUInt(256, SHA256_BAL)
-       andBool #rangeUInt(256, RIP160_BAL)
-       andBool #rangeUInt(256, ID_BAL)
-       andBool #rangeUInt(256, MODEXP_BAL)
-       andBool #rangeUInt(256, ECADD_BAL)
-       andBool #rangeUInt(256, ECMUL_BAL)
-       andBool #rangeUInt(256, ECPAIRING_BAL)
-       andBool #rangeUInt(256, BLAKE2_BAL)
        andBool VCallDepth <=Int 1024
        andBool #rangeUInt(256, VCallValue)
        andBool #rangeUInt(256, VChainId)

--- a/tests/specs/mcd/flopper-cage-pass-spec.k
+++ b/tests/specs/mcd/flopper-cage-pass-spec.k
@@ -72,78 +72,6 @@ module FLOPPER-CAGE-PASS-SPEC
               <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_Flopper => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -158,15 +86,6 @@ module FLOPPER-CAGE-PASS-SPEC
        andBool #rangeAddress(ORIGIN_ID)
        andBool #rangeUInt(256, TIME)
        andBool #rangeUInt(256, ACCT_ID_balance)
-       andBool #rangeUInt(256, ECREC_BAL)
-       andBool #rangeUInt(256, SHA256_BAL)
-       andBool #rangeUInt(256, RIP160_BAL)
-       andBool #rangeUInt(256, ID_BAL)
-       andBool #rangeUInt(256, MODEXP_BAL)
-       andBool #rangeUInt(256, ECADD_BAL)
-       andBool #rangeUInt(256, ECMUL_BAL)
-       andBool #rangeUInt(256, ECPAIRING_BAL)
-       andBool #rangeUInt(256, BLAKE2_BAL)
        andBool VCallDepth <=Int 1024
        andBool #rangeUInt(256, VCallValue)
        andBool #rangeUInt(256, VChainId)

--- a/tests/specs/mcd/flopper-cage-pass-spec.k
+++ b/tests/specs/mcd/flopper-cage-pass-spec.k
@@ -62,16 +62,7 @@ module FLOPPER-CAGE-PASS-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>

--- a/tests/specs/mcd/flopper-dent-guy-diff-tic-not-0-pass-rough-spec.k
+++ b/tests/specs/mcd/flopper-dent-guy-diff-tic-not-0-pass-rough-spec.k
@@ -62,17 +62,7 @@ module FLOPPER-DENT-GUY-DIFF-TIC-NOT-0-PASS-ROUGH-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(Vat)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) SetItem(Vat) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>
@@ -347,16 +337,7 @@ module FLOPPER-DENT-GUY-DIFF-TIC-NOT-0-PASS-ROUGH-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>
@@ -534,16 +515,7 @@ module FLOPPER-DENT-GUY-DIFF-TIC-NOT-0-PASS-ROUGH-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>
@@ -721,16 +693,7 @@ module FLOPPER-DENT-GUY-DIFF-TIC-NOT-0-PASS-ROUGH-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>

--- a/tests/specs/mcd/flopper-dent-guy-diff-tic-not-0-pass-rough-spec.k
+++ b/tests/specs/mcd/flopper-dent-guy-diff-tic-not-0-pass-rough-spec.k
@@ -80,78 +80,6 @@ module FLOPPER-DENT-GUY-DIFF-TIC-NOT-0-PASS-ROUGH-SPEC
               <origStorage> Vat_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_Vat => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -166,15 +94,6 @@ module FLOPPER-DENT-GUY-DIFF-TIC-NOT-0-PASS-ROUGH-SPEC
        andBool #rangeAddress(ORIGIN_ID)
        andBool #rangeUInt(256, TIME)
        andBool #rangeUInt(256, ACCT_ID_balance)
-       andBool #rangeUInt(256, ECREC_BAL)
-       andBool #rangeUInt(256, SHA256_BAL)
-       andBool #rangeUInt(256, RIP160_BAL)
-       andBool #rangeUInt(256, ID_BAL)
-       andBool #rangeUInt(256, MODEXP_BAL)
-       andBool #rangeUInt(256, ECADD_BAL)
-       andBool #rangeUInt(256, ECMUL_BAL)
-       andBool #rangeUInt(256, ECPAIRING_BAL)
-       andBool #rangeUInt(256, BLAKE2_BAL)
        andBool VCallDepth <=Int 1024
        andBool #rangeUInt(256, VCallValue)
        andBool #rangeUInt(256, VChainId)
@@ -347,78 +266,6 @@ module FLOPPER-DENT-GUY-DIFF-TIC-NOT-0-PASS-ROUGH-SPEC
               <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_Flopper => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -433,15 +280,6 @@ module FLOPPER-DENT-GUY-DIFF-TIC-NOT-0-PASS-ROUGH-SPEC
        andBool #rangeAddress(ORIGIN_ID)
        andBool #rangeUInt(256, TIME)
        andBool #rangeUInt(256, ACCT_ID_balance)
-       andBool #rangeUInt(256, ECREC_BAL)
-       andBool #rangeUInt(256, SHA256_BAL)
-       andBool #rangeUInt(256, RIP160_BAL)
-       andBool #rangeUInt(256, ID_BAL)
-       andBool #rangeUInt(256, MODEXP_BAL)
-       andBool #rangeUInt(256, ECADD_BAL)
-       andBool #rangeUInt(256, ECMUL_BAL)
-       andBool #rangeUInt(256, ECPAIRING_BAL)
-       andBool #rangeUInt(256, BLAKE2_BAL)
        andBool VCallDepth <=Int 1024
        andBool #rangeUInt(256, VCallValue)
        andBool #rangeUInt(256, VChainId)
@@ -525,78 +363,6 @@ module FLOPPER-DENT-GUY-DIFF-TIC-NOT-0-PASS-ROUGH-SPEC
               <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_Flopper => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -611,15 +377,6 @@ module FLOPPER-DENT-GUY-DIFF-TIC-NOT-0-PASS-ROUGH-SPEC
        andBool #rangeAddress(ORIGIN_ID)
        andBool #rangeUInt(256, TIME)
        andBool #rangeUInt(256, ACCT_ID_balance)
-       andBool #rangeUInt(256, ECREC_BAL)
-       andBool #rangeUInt(256, SHA256_BAL)
-       andBool #rangeUInt(256, RIP160_BAL)
-       andBool #rangeUInt(256, ID_BAL)
-       andBool #rangeUInt(256, MODEXP_BAL)
-       andBool #rangeUInt(256, ECADD_BAL)
-       andBool #rangeUInt(256, ECMUL_BAL)
-       andBool #rangeUInt(256, ECPAIRING_BAL)
-       andBool #rangeUInt(256, BLAKE2_BAL)
        andBool VCallDepth <=Int 1024
        andBool #rangeUInt(256, VCallValue)
        andBool #rangeUInt(256, VChainId)
@@ -703,78 +460,6 @@ module FLOPPER-DENT-GUY-DIFF-TIC-NOT-0-PASS-ROUGH-SPEC
               <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_Vat => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -789,15 +474,6 @@ module FLOPPER-DENT-GUY-DIFF-TIC-NOT-0-PASS-ROUGH-SPEC
        andBool #rangeAddress(ORIGIN_ID)
        andBool #rangeUInt(256, TIME)
        andBool #rangeUInt(256, ACCT_ID_balance)
-       andBool #rangeUInt(256, ECREC_BAL)
-       andBool #rangeUInt(256, SHA256_BAL)
-       andBool #rangeUInt(256, RIP160_BAL)
-       andBool #rangeUInt(256, ID_BAL)
-       andBool #rangeUInt(256, MODEXP_BAL)
-       andBool #rangeUInt(256, ECADD_BAL)
-       andBool #rangeUInt(256, ECMUL_BAL)
-       andBool #rangeUInt(256, ECPAIRING_BAL)
-       andBool #rangeUInt(256, BLAKE2_BAL)
        andBool VCallDepth <=Int 1024
        andBool #rangeUInt(256, VCallValue)
        andBool #rangeUInt(256, VChainId)

--- a/tests/specs/mcd/flopper-dent-guy-same-pass-rough-spec.k
+++ b/tests/specs/mcd/flopper-dent-guy-same-pass-rough-spec.k
@@ -72,78 +72,6 @@ module FLOPPER-DENT-GUY-SAME-PASS-ROUGH-SPEC
               <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_Flopper => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -158,15 +86,6 @@ module FLOPPER-DENT-GUY-SAME-PASS-ROUGH-SPEC
        andBool #rangeAddress(ORIGIN_ID)
        andBool #rangeUInt(256, TIME)
        andBool #rangeUInt(256, ACCT_ID_balance)
-       andBool #rangeUInt(256, ECREC_BAL)
-       andBool #rangeUInt(256, SHA256_BAL)
-       andBool #rangeUInt(256, RIP160_BAL)
-       andBool #rangeUInt(256, ID_BAL)
-       andBool #rangeUInt(256, MODEXP_BAL)
-       andBool #rangeUInt(256, ECADD_BAL)
-       andBool #rangeUInt(256, ECMUL_BAL)
-       andBool #rangeUInt(256, ECPAIRING_BAL)
-       andBool #rangeUInt(256, BLAKE2_BAL)
        andBool VCallDepth <=Int 1024
        andBool #rangeUInt(256, VCallValue)
        andBool #rangeUInt(256, VChainId)
@@ -316,78 +235,6 @@ module FLOPPER-DENT-GUY-SAME-PASS-ROUGH-SPEC
               <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_Flopper => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -402,15 +249,6 @@ module FLOPPER-DENT-GUY-SAME-PASS-ROUGH-SPEC
        andBool #rangeAddress(ORIGIN_ID)
        andBool #rangeUInt(256, TIME)
        andBool #rangeUInt(256, ACCT_ID_balance)
-       andBool #rangeUInt(256, ECREC_BAL)
-       andBool #rangeUInt(256, SHA256_BAL)
-       andBool #rangeUInt(256, RIP160_BAL)
-       andBool #rangeUInt(256, ID_BAL)
-       andBool #rangeUInt(256, MODEXP_BAL)
-       andBool #rangeUInt(256, ECADD_BAL)
-       andBool #rangeUInt(256, ECMUL_BAL)
-       andBool #rangeUInt(256, ECPAIRING_BAL)
-       andBool #rangeUInt(256, BLAKE2_BAL)
        andBool VCallDepth <=Int 1024
        andBool #rangeUInt(256, VCallValue)
        andBool #rangeUInt(256, VChainId)
@@ -494,78 +332,6 @@ module FLOPPER-DENT-GUY-SAME-PASS-ROUGH-SPEC
               <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_Flopper => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -580,15 +346,6 @@ module FLOPPER-DENT-GUY-SAME-PASS-ROUGH-SPEC
        andBool #rangeAddress(ORIGIN_ID)
        andBool #rangeUInt(256, TIME)
        andBool #rangeUInt(256, ACCT_ID_balance)
-       andBool #rangeUInt(256, ECREC_BAL)
-       andBool #rangeUInt(256, SHA256_BAL)
-       andBool #rangeUInt(256, RIP160_BAL)
-       andBool #rangeUInt(256, ID_BAL)
-       andBool #rangeUInt(256, MODEXP_BAL)
-       andBool #rangeUInt(256, ECADD_BAL)
-       andBool #rangeUInt(256, ECMUL_BAL)
-       andBool #rangeUInt(256, ECPAIRING_BAL)
-       andBool #rangeUInt(256, BLAKE2_BAL)
        andBool VCallDepth <=Int 1024
        andBool #rangeUInt(256, VCallValue)
        andBool #rangeUInt(256, VChainId)

--- a/tests/specs/mcd/flopper-dent-guy-same-pass-rough-spec.k
+++ b/tests/specs/mcd/flopper-dent-guy-same-pass-rough-spec.k
@@ -62,16 +62,7 @@ module FLOPPER-DENT-GUY-SAME-PASS-ROUGH-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>
@@ -315,16 +306,7 @@ module FLOPPER-DENT-GUY-SAME-PASS-ROUGH-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>
@@ -502,16 +484,7 @@ module FLOPPER-DENT-GUY-SAME-PASS-ROUGH-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>

--- a/tests/specs/mcd/flopper-file-pass-rough-spec.k
+++ b/tests/specs/mcd/flopper-file-pass-rough-spec.k
@@ -72,78 +72,6 @@ module FLOPPER-FILE-PASS-ROUGH-SPEC
               <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_Flopper => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -158,15 +86,6 @@ module FLOPPER-FILE-PASS-ROUGH-SPEC
        andBool #rangeAddress(ORIGIN_ID)
        andBool #rangeUInt(256, TIME)
        andBool #rangeUInt(256, ACCT_ID_balance)
-       andBool #rangeUInt(256, ECREC_BAL)
-       andBool #rangeUInt(256, SHA256_BAL)
-       andBool #rangeUInt(256, RIP160_BAL)
-       andBool #rangeUInt(256, ID_BAL)
-       andBool #rangeUInt(256, MODEXP_BAL)
-       andBool #rangeUInt(256, ECADD_BAL)
-       andBool #rangeUInt(256, ECMUL_BAL)
-       andBool #rangeUInt(256, ECPAIRING_BAL)
-       andBool #rangeUInt(256, BLAKE2_BAL)
        andBool VCallDepth <=Int 1024
        andBool #rangeUInt(256, VCallValue)
        andBool #rangeUInt(256, VChainId)

--- a/tests/specs/mcd/flopper-file-pass-rough-spec.k
+++ b/tests/specs/mcd/flopper-file-pass-rough-spec.k
@@ -62,16 +62,7 @@ module FLOPPER-FILE-PASS-ROUGH-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>

--- a/tests/specs/mcd/flopper-kick-pass-rough-spec.k
+++ b/tests/specs/mcd/flopper-kick-pass-rough-spec.k
@@ -62,16 +62,7 @@ module FLOPPER-KICK-PASS-ROUGH-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>
@@ -304,16 +295,7 @@ module FLOPPER-KICK-PASS-ROUGH-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>

--- a/tests/specs/mcd/flopper-kick-pass-rough-spec.k
+++ b/tests/specs/mcd/flopper-kick-pass-rough-spec.k
@@ -72,78 +72,6 @@ module FLOPPER-KICK-PASS-ROUGH-SPEC
               <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_Flopper => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -158,15 +86,6 @@ module FLOPPER-KICK-PASS-ROUGH-SPEC
        andBool #rangeAddress(ORIGIN_ID)
        andBool #rangeUInt(256, TIME)
        andBool #rangeUInt(256, ACCT_ID_balance)
-       andBool #rangeUInt(256, ECREC_BAL)
-       andBool #rangeUInt(256, SHA256_BAL)
-       andBool #rangeUInt(256, RIP160_BAL)
-       andBool #rangeUInt(256, ID_BAL)
-       andBool #rangeUInt(256, MODEXP_BAL)
-       andBool #rangeUInt(256, ECADD_BAL)
-       andBool #rangeUInt(256, ECMUL_BAL)
-       andBool #rangeUInt(256, ECPAIRING_BAL)
-       andBool #rangeUInt(256, BLAKE2_BAL)
        andBool VCallDepth <=Int 1024
        andBool #rangeUInt(256, VCallValue)
        andBool #rangeUInt(256, VChainId)
@@ -305,78 +224,6 @@ module FLOPPER-KICK-PASS-ROUGH-SPEC
               <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_Flopper => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -391,15 +238,6 @@ module FLOPPER-KICK-PASS-ROUGH-SPEC
        andBool #rangeAddress(ORIGIN_ID)
        andBool #rangeUInt(256, TIME)
        andBool #rangeUInt(256, ACCT_ID_balance)
-       andBool #rangeUInt(256, ECREC_BAL)
-       andBool #rangeUInt(256, SHA256_BAL)
-       andBool #rangeUInt(256, RIP160_BAL)
-       andBool #rangeUInt(256, ID_BAL)
-       andBool #rangeUInt(256, MODEXP_BAL)
-       andBool #rangeUInt(256, ECADD_BAL)
-       andBool #rangeUInt(256, ECMUL_BAL)
-       andBool #rangeUInt(256, ECPAIRING_BAL)
-       andBool #rangeUInt(256, BLAKE2_BAL)
        andBool VCallDepth <=Int 1024
        andBool #rangeUInt(256, VCallValue)
        andBool #rangeUInt(256, VChainId)

--- a/tests/specs/mcd/flopper-tick-pass-rough-spec.k
+++ b/tests/specs/mcd/flopper-tick-pass-rough-spec.k
@@ -72,78 +72,6 @@ module FLOPPER-TICK-PASS-ROUGH-SPEC
               <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_Flopper => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -158,15 +86,6 @@ module FLOPPER-TICK-PASS-ROUGH-SPEC
        andBool #rangeAddress(ORIGIN_ID)
        andBool #rangeUInt(256, TIME)
        andBool #rangeUInt(256, ACCT_ID_balance)
-       andBool #rangeUInt(256, ECREC_BAL)
-       andBool #rangeUInt(256, SHA256_BAL)
-       andBool #rangeUInt(256, RIP160_BAL)
-       andBool #rangeUInt(256, ID_BAL)
-       andBool #rangeUInt(256, MODEXP_BAL)
-       andBool #rangeUInt(256, ECADD_BAL)
-       andBool #rangeUInt(256, ECMUL_BAL)
-       andBool #rangeUInt(256, ECPAIRING_BAL)
-       andBool #rangeUInt(256, BLAKE2_BAL)
        andBool VCallDepth <=Int 1024
        andBool #rangeUInt(256, VCallValue)
        andBool #rangeUInt(256, VChainId)
@@ -276,78 +195,6 @@ module FLOPPER-TICK-PASS-ROUGH-SPEC
               <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_Flopper => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -362,15 +209,6 @@ module FLOPPER-TICK-PASS-ROUGH-SPEC
        andBool #rangeAddress(ORIGIN_ID)
        andBool #rangeUInt(256, TIME)
        andBool #rangeUInt(256, ACCT_ID_balance)
-       andBool #rangeUInt(256, ECREC_BAL)
-       andBool #rangeUInt(256, SHA256_BAL)
-       andBool #rangeUInt(256, RIP160_BAL)
-       andBool #rangeUInt(256, ID_BAL)
-       andBool #rangeUInt(256, MODEXP_BAL)
-       andBool #rangeUInt(256, ECADD_BAL)
-       andBool #rangeUInt(256, ECMUL_BAL)
-       andBool #rangeUInt(256, ECPAIRING_BAL)
-       andBool #rangeUInt(256, BLAKE2_BAL)
        andBool VCallDepth <=Int 1024
        andBool #rangeUInt(256, VCallValue)
        andBool #rangeUInt(256, VChainId)

--- a/tests/specs/mcd/flopper-tick-pass-rough-spec.k
+++ b/tests/specs/mcd/flopper-tick-pass-rough-spec.k
@@ -62,16 +62,7 @@ module FLOPPER-TICK-PASS-ROUGH-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>
@@ -275,16 +266,7 @@ module FLOPPER-TICK-PASS-ROUGH-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>

--- a/tests/specs/mcd/gemjoin-exit-pass-rough-spec.k
+++ b/tests/specs/mcd/gemjoin-exit-pass-rough-spec.k
@@ -88,78 +88,6 @@ module GEMJOIN-EXIT-PASS-ROUGH-SPEC
               <origStorage> DSToken_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_DSToken => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -174,15 +102,6 @@ module GEMJOIN-EXIT-PASS-ROUGH-SPEC
        andBool #rangeAddress(ORIGIN_ID)
        andBool #rangeUInt(256, TIME)
        andBool #rangeUInt(256, ACCT_ID_balance)
-       andBool #rangeUInt(256, ECREC_BAL)
-       andBool #rangeUInt(256, SHA256_BAL)
-       andBool #rangeUInt(256, RIP160_BAL)
-       andBool #rangeUInt(256, ID_BAL)
-       andBool #rangeUInt(256, MODEXP_BAL)
-       andBool #rangeUInt(256, ECADD_BAL)
-       andBool #rangeUInt(256, ECMUL_BAL)
-       andBool #rangeUInt(256, ECPAIRING_BAL)
-       andBool #rangeUInt(256, BLAKE2_BAL)
        andBool VCallDepth <=Int 1024
        andBool #rangeUInt(256, VCallValue)
        andBool #rangeUInt(256, VChainId)
@@ -325,78 +244,6 @@ module GEMJOIN-EXIT-PASS-ROUGH-SPEC
               <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_Vat => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -411,15 +258,6 @@ module GEMJOIN-EXIT-PASS-ROUGH-SPEC
        andBool #rangeAddress(ORIGIN_ID)
        andBool #rangeUInt(256, TIME)
        andBool #rangeUInt(256, ACCT_ID_balance)
-       andBool #rangeUInt(256, ECREC_BAL)
-       andBool #rangeUInt(256, SHA256_BAL)
-       andBool #rangeUInt(256, RIP160_BAL)
-       andBool #rangeUInt(256, ID_BAL)
-       andBool #rangeUInt(256, MODEXP_BAL)
-       andBool #rangeUInt(256, ECADD_BAL)
-       andBool #rangeUInt(256, ECMUL_BAL)
-       andBool #rangeUInt(256, ECPAIRING_BAL)
-       andBool #rangeUInt(256, BLAKE2_BAL)
        andBool VCallDepth <=Int 1024
        andBool #rangeUInt(256, VCallValue)
        andBool #rangeUInt(256, VChainId)
@@ -513,78 +351,6 @@ module GEMJOIN-EXIT-PASS-ROUGH-SPEC
               <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_DSToken => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -599,15 +365,6 @@ module GEMJOIN-EXIT-PASS-ROUGH-SPEC
        andBool #rangeAddress(ORIGIN_ID)
        andBool #rangeUInt(256, TIME)
        andBool #rangeUInt(256, ACCT_ID_balance)
-       andBool #rangeUInt(256, ECREC_BAL)
-       andBool #rangeUInt(256, SHA256_BAL)
-       andBool #rangeUInt(256, RIP160_BAL)
-       andBool #rangeUInt(256, ID_BAL)
-       andBool #rangeUInt(256, MODEXP_BAL)
-       andBool #rangeUInt(256, ECADD_BAL)
-       andBool #rangeUInt(256, ECMUL_BAL)
-       andBool #rangeUInt(256, ECPAIRING_BAL)
-       andBool #rangeUInt(256, BLAKE2_BAL)
        andBool VCallDepth <=Int 1024
        andBool #rangeUInt(256, VCallValue)
        andBool #rangeUInt(256, VChainId)

--- a/tests/specs/mcd/gemjoin-exit-pass-rough-spec.k
+++ b/tests/specs/mcd/gemjoin-exit-pass-rough-spec.k
@@ -62,18 +62,7 @@ module GEMJOIN-EXIT-PASS-ROUGH-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(Vat)
-          SetItem(DSToken)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) SetItem(Vat) SetItem(DSToken) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>
@@ -326,16 +315,7 @@ module GEMJOIN-EXIT-PASS-ROUGH-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>
@@ -523,16 +503,7 @@ module GEMJOIN-EXIT-PASS-ROUGH-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>

--- a/tests/specs/mcd/pot-join-pass-rough-spec.k
+++ b/tests/specs/mcd/pot-join-pass-rough-spec.k
@@ -62,17 +62,7 @@ module POT-JOIN-PASS-ROUGH-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(Vat)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) SetItem(Vat) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>
@@ -311,16 +301,7 @@ module POT-JOIN-PASS-ROUGH-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>
@@ -501,16 +482,7 @@ module POT-JOIN-PASS-ROUGH-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>
@@ -688,16 +660,7 @@ module POT-JOIN-PASS-ROUGH-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>

--- a/tests/specs/mcd/pot-join-pass-rough-spec.k
+++ b/tests/specs/mcd/pot-join-pass-rough-spec.k
@@ -80,78 +80,6 @@ module POT-JOIN-PASS-ROUGH-SPEC
               <origStorage> Vat_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_Vat => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -166,15 +94,6 @@ module POT-JOIN-PASS-ROUGH-SPEC
        andBool #rangeAddress(ORIGIN_ID)
        andBool #rangeUInt(256, TIME)
        andBool #rangeUInt(256, ACCT_ID_balance)
-       andBool #rangeUInt(256, ECREC_BAL)
-       andBool #rangeUInt(256, SHA256_BAL)
-       andBool #rangeUInt(256, RIP160_BAL)
-       andBool #rangeUInt(256, ID_BAL)
-       andBool #rangeUInt(256, MODEXP_BAL)
-       andBool #rangeUInt(256, ECADD_BAL)
-       andBool #rangeUInt(256, ECMUL_BAL)
-       andBool #rangeUInt(256, ECPAIRING_BAL)
-       andBool #rangeUInt(256, BLAKE2_BAL)
        andBool VCallDepth <=Int 1024
        andBool #rangeUInt(256, VCallValue)
        andBool #rangeUInt(256, VChainId)
@@ -311,78 +230,6 @@ module POT-JOIN-PASS-ROUGH-SPEC
               <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_Pot => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -397,15 +244,6 @@ module POT-JOIN-PASS-ROUGH-SPEC
        andBool #rangeAddress(ORIGIN_ID)
        andBool #rangeUInt(256, TIME)
        andBool #rangeUInt(256, ACCT_ID_balance)
-       andBool #rangeUInt(256, ECREC_BAL)
-       andBool #rangeUInt(256, SHA256_BAL)
-       andBool #rangeUInt(256, RIP160_BAL)
-       andBool #rangeUInt(256, ID_BAL)
-       andBool #rangeUInt(256, MODEXP_BAL)
-       andBool #rangeUInt(256, ECADD_BAL)
-       andBool #rangeUInt(256, ECMUL_BAL)
-       andBool #rangeUInt(256, ECPAIRING_BAL)
-       andBool #rangeUInt(256, BLAKE2_BAL)
        andBool VCallDepth <=Int 1024
        andBool #rangeUInt(256, VCallValue)
        andBool #rangeUInt(256, VChainId)
@@ -492,78 +330,6 @@ module POT-JOIN-PASS-ROUGH-SPEC
               <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_Pot => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -578,15 +344,6 @@ module POT-JOIN-PASS-ROUGH-SPEC
        andBool #rangeAddress(ORIGIN_ID)
        andBool #rangeUInt(256, TIME)
        andBool #rangeUInt(256, ACCT_ID_balance)
-       andBool #rangeUInt(256, ECREC_BAL)
-       andBool #rangeUInt(256, SHA256_BAL)
-       andBool #rangeUInt(256, RIP160_BAL)
-       andBool #rangeUInt(256, ID_BAL)
-       andBool #rangeUInt(256, MODEXP_BAL)
-       andBool #rangeUInt(256, ECADD_BAL)
-       andBool #rangeUInt(256, ECMUL_BAL)
-       andBool #rangeUInt(256, ECPAIRING_BAL)
-       andBool #rangeUInt(256, BLAKE2_BAL)
        andBool VCallDepth <=Int 1024
        andBool #rangeUInt(256, VCallValue)
        andBool #rangeUInt(256, VChainId)
@@ -670,78 +427,6 @@ module POT-JOIN-PASS-ROUGH-SPEC
               <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_Vat => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -756,15 +441,6 @@ module POT-JOIN-PASS-ROUGH-SPEC
        andBool #rangeAddress(ORIGIN_ID)
        andBool #rangeUInt(256, TIME)
        andBool #rangeUInt(256, ACCT_ID_balance)
-       andBool #rangeUInt(256, ECREC_BAL)
-       andBool #rangeUInt(256, SHA256_BAL)
-       andBool #rangeUInt(256, RIP160_BAL)
-       andBool #rangeUInt(256, ID_BAL)
-       andBool #rangeUInt(256, MODEXP_BAL)
-       andBool #rangeUInt(256, ECADD_BAL)
-       andBool #rangeUInt(256, ECMUL_BAL)
-       andBool #rangeUInt(256, ECPAIRING_BAL)
-       andBool #rangeUInt(256, BLAKE2_BAL)
        andBool VCallDepth <=Int 1024
        andBool #rangeUInt(256, VCallValue)
        andBool #rangeUInt(256, VChainId)

--- a/tests/specs/mcd/vat-addui-fail-rough-spec.k
+++ b/tests/specs/mcd/vat-addui-fail-rough-spec.k
@@ -72,78 +72,6 @@ module VAT-ADDUI-FAIL-ROUGH-SPEC
               <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_Vat => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -158,15 +86,6 @@ module VAT-ADDUI-FAIL-ROUGH-SPEC
        andBool #rangeAddress(ORIGIN_ID)
        andBool #rangeUInt(256, TIME)
        andBool #rangeUInt(256, ACCT_ID_balance)
-       andBool #rangeUInt(256, ECREC_BAL)
-       andBool #rangeUInt(256, SHA256_BAL)
-       andBool #rangeUInt(256, RIP160_BAL)
-       andBool #rangeUInt(256, ID_BAL)
-       andBool #rangeUInt(256, MODEXP_BAL)
-       andBool #rangeUInt(256, ECADD_BAL)
-       andBool #rangeUInt(256, ECMUL_BAL)
-       andBool #rangeUInt(256, ECPAIRING_BAL)
-       andBool #rangeUInt(256, BLAKE2_BAL)
        andBool VCallDepth <=Int 1024
        andBool #rangeUInt(256, VCallValue)
        andBool #rangeUInt(256, VChainId)

--- a/tests/specs/mcd/vat-addui-fail-rough-spec.k
+++ b/tests/specs/mcd/vat-addui-fail-rough-spec.k
@@ -62,16 +62,7 @@ module VAT-ADDUI-FAIL-ROUGH-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>

--- a/tests/specs/mcd/vat-deny-diff-fail-rough-spec.k
+++ b/tests/specs/mcd/vat-deny-diff-fail-rough-spec.k
@@ -72,78 +72,6 @@ module VAT-DENY-DIFF-FAIL-ROUGH-SPEC
               <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_Vat => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -158,15 +86,6 @@ module VAT-DENY-DIFF-FAIL-ROUGH-SPEC
        andBool #rangeAddress(ORIGIN_ID)
        andBool #rangeUInt(256, TIME)
        andBool #rangeUInt(256, ACCT_ID_balance)
-       andBool #rangeUInt(256, ECREC_BAL)
-       andBool #rangeUInt(256, SHA256_BAL)
-       andBool #rangeUInt(256, RIP160_BAL)
-       andBool #rangeUInt(256, ID_BAL)
-       andBool #rangeUInt(256, MODEXP_BAL)
-       andBool #rangeUInt(256, ECADD_BAL)
-       andBool #rangeUInt(256, ECMUL_BAL)
-       andBool #rangeUInt(256, ECPAIRING_BAL)
-       andBool #rangeUInt(256, BLAKE2_BAL)
        andBool VCallDepth <=Int 1024
        andBool #rangeUInt(256, VCallValue)
        andBool #rangeUInt(256, VChainId)

--- a/tests/specs/mcd/vat-deny-diff-fail-rough-spec.k
+++ b/tests/specs/mcd/vat-deny-diff-fail-rough-spec.k
@@ -62,16 +62,7 @@ module VAT-DENY-DIFF-FAIL-ROUGH-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>

--- a/tests/specs/mcd/vat-flux-diff-pass-rough-spec.k
+++ b/tests/specs/mcd/vat-flux-diff-pass-rough-spec.k
@@ -72,78 +72,6 @@ module VAT-FLUX-DIFF-PASS-ROUGH-SPEC
               <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_Vat => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -158,15 +86,6 @@ module VAT-FLUX-DIFF-PASS-ROUGH-SPEC
        andBool #rangeAddress(ORIGIN_ID)
        andBool #rangeUInt(256, TIME)
        andBool #rangeUInt(256, ACCT_ID_balance)
-       andBool #rangeUInt(256, ECREC_BAL)
-       andBool #rangeUInt(256, SHA256_BAL)
-       andBool #rangeUInt(256, RIP160_BAL)
-       andBool #rangeUInt(256, ID_BAL)
-       andBool #rangeUInt(256, MODEXP_BAL)
-       andBool #rangeUInt(256, ECADD_BAL)
-       andBool #rangeUInt(256, ECMUL_BAL)
-       andBool #rangeUInt(256, ECPAIRING_BAL)
-       andBool #rangeUInt(256, BLAKE2_BAL)
        andBool VCallDepth <=Int 1024
        andBool #rangeUInt(256, VCallValue)
        andBool #rangeUInt(256, VChainId)
@@ -267,78 +186,6 @@ module VAT-FLUX-DIFF-PASS-ROUGH-SPEC
               <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_Vat => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -353,15 +200,6 @@ module VAT-FLUX-DIFF-PASS-ROUGH-SPEC
        andBool #rangeAddress(ORIGIN_ID)
        andBool #rangeUInt(256, TIME)
        andBool #rangeUInt(256, ACCT_ID_balance)
-       andBool #rangeUInt(256, ECREC_BAL)
-       andBool #rangeUInt(256, SHA256_BAL)
-       andBool #rangeUInt(256, RIP160_BAL)
-       andBool #rangeUInt(256, ID_BAL)
-       andBool #rangeUInt(256, MODEXP_BAL)
-       andBool #rangeUInt(256, ECADD_BAL)
-       andBool #rangeUInt(256, ECMUL_BAL)
-       andBool #rangeUInt(256, ECPAIRING_BAL)
-       andBool #rangeUInt(256, BLAKE2_BAL)
        andBool VCallDepth <=Int 1024
        andBool #rangeUInt(256, VCallValue)
        andBool #rangeUInt(256, VChainId)
@@ -445,78 +283,6 @@ module VAT-FLUX-DIFF-PASS-ROUGH-SPEC
               <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_Vat => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -531,15 +297,6 @@ module VAT-FLUX-DIFF-PASS-ROUGH-SPEC
        andBool #rangeAddress(ORIGIN_ID)
        andBool #rangeUInt(256, TIME)
        andBool #rangeUInt(256, ACCT_ID_balance)
-       andBool #rangeUInt(256, ECREC_BAL)
-       andBool #rangeUInt(256, SHA256_BAL)
-       andBool #rangeUInt(256, RIP160_BAL)
-       andBool #rangeUInt(256, ID_BAL)
-       andBool #rangeUInt(256, MODEXP_BAL)
-       andBool #rangeUInt(256, ECADD_BAL)
-       andBool #rangeUInt(256, ECMUL_BAL)
-       andBool #rangeUInt(256, ECPAIRING_BAL)
-       andBool #rangeUInt(256, BLAKE2_BAL)
        andBool VCallDepth <=Int 1024
        andBool #rangeUInt(256, VCallValue)
        andBool #rangeUInt(256, VChainId)

--- a/tests/specs/mcd/vat-flux-diff-pass-rough-spec.k
+++ b/tests/specs/mcd/vat-flux-diff-pass-rough-spec.k
@@ -62,16 +62,7 @@ module VAT-FLUX-DIFF-PASS-ROUGH-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>
@@ -266,16 +257,7 @@ module VAT-FLUX-DIFF-PASS-ROUGH-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>
@@ -453,16 +435,7 @@ module VAT-FLUX-DIFF-PASS-ROUGH-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>

--- a/tests/specs/mcd/vat-fold-pass-rough-spec.k
+++ b/tests/specs/mcd/vat-fold-pass-rough-spec.k
@@ -72,78 +72,6 @@ module VAT-FOLD-PASS-ROUGH-SPEC
               <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_Vat => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -158,15 +86,6 @@ module VAT-FOLD-PASS-ROUGH-SPEC
        andBool #rangeAddress(ORIGIN_ID)
        andBool #rangeUInt(256, TIME)
        andBool #rangeUInt(256, ACCT_ID_balance)
-       andBool #rangeUInt(256, ECREC_BAL)
-       andBool #rangeUInt(256, SHA256_BAL)
-       andBool #rangeUInt(256, RIP160_BAL)
-       andBool #rangeUInt(256, ID_BAL)
-       andBool #rangeUInt(256, MODEXP_BAL)
-       andBool #rangeUInt(256, ECADD_BAL)
-       andBool #rangeUInt(256, ECMUL_BAL)
-       andBool #rangeUInt(256, ECPAIRING_BAL)
-       andBool #rangeUInt(256, BLAKE2_BAL)
        andBool VCallDepth <=Int 1024
        andBool #rangeUInt(256, VCallValue)
        andBool #rangeUInt(256, VChainId)
@@ -298,78 +217,6 @@ module VAT-FOLD-PASS-ROUGH-SPEC
               <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_Vat => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -384,15 +231,6 @@ module VAT-FOLD-PASS-ROUGH-SPEC
        andBool #rangeAddress(ORIGIN_ID)
        andBool #rangeUInt(256, TIME)
        andBool #rangeUInt(256, ACCT_ID_balance)
-       andBool #rangeUInt(256, ECREC_BAL)
-       andBool #rangeUInt(256, SHA256_BAL)
-       andBool #rangeUInt(256, RIP160_BAL)
-       andBool #rangeUInt(256, ID_BAL)
-       andBool #rangeUInt(256, MODEXP_BAL)
-       andBool #rangeUInt(256, ECADD_BAL)
-       andBool #rangeUInt(256, ECMUL_BAL)
-       andBool #rangeUInt(256, ECPAIRING_BAL)
-       andBool #rangeUInt(256, BLAKE2_BAL)
        andBool VCallDepth <=Int 1024
        andBool #rangeUInt(256, VCallValue)
        andBool #rangeUInt(256, VChainId)
@@ -479,78 +317,6 @@ module VAT-FOLD-PASS-ROUGH-SPEC
               <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_Vat => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -565,15 +331,6 @@ module VAT-FOLD-PASS-ROUGH-SPEC
        andBool #rangeAddress(ORIGIN_ID)
        andBool #rangeUInt(256, TIME)
        andBool #rangeUInt(256, ACCT_ID_balance)
-       andBool #rangeUInt(256, ECREC_BAL)
-       andBool #rangeUInt(256, SHA256_BAL)
-       andBool #rangeUInt(256, RIP160_BAL)
-       andBool #rangeUInt(256, ID_BAL)
-       andBool #rangeUInt(256, MODEXP_BAL)
-       andBool #rangeUInt(256, ECADD_BAL)
-       andBool #rangeUInt(256, ECMUL_BAL)
-       andBool #rangeUInt(256, ECPAIRING_BAL)
-       andBool #rangeUInt(256, BLAKE2_BAL)
        andBool VCallDepth <=Int 1024
        andBool #rangeUInt(256, VCallValue)
        andBool #rangeUInt(256, VChainId)

--- a/tests/specs/mcd/vat-fold-pass-rough-spec.k
+++ b/tests/specs/mcd/vat-fold-pass-rough-spec.k
@@ -62,16 +62,7 @@ module VAT-FOLD-PASS-ROUGH-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>
@@ -297,16 +288,7 @@ module VAT-FOLD-PASS-ROUGH-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>
@@ -487,16 +469,7 @@ module VAT-FOLD-PASS-ROUGH-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>

--- a/tests/specs/mcd/vat-fork-diff-pass-rough-spec.k
+++ b/tests/specs/mcd/vat-fork-diff-pass-rough-spec.k
@@ -72,78 +72,6 @@ module VAT-FORK-DIFF-PASS-ROUGH-SPEC
               <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_Vat => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -158,15 +86,6 @@ module VAT-FORK-DIFF-PASS-ROUGH-SPEC
        andBool #rangeAddress(ORIGIN_ID)
        andBool #rangeUInt(256, TIME)
        andBool #rangeUInt(256, ACCT_ID_balance)
-       andBool #rangeUInt(256, ECREC_BAL)
-       andBool #rangeUInt(256, SHA256_BAL)
-       andBool #rangeUInt(256, RIP160_BAL)
-       andBool #rangeUInt(256, ID_BAL)
-       andBool #rangeUInt(256, MODEXP_BAL)
-       andBool #rangeUInt(256, ECADD_BAL)
-       andBool #rangeUInt(256, ECMUL_BAL)
-       andBool #rangeUInt(256, ECPAIRING_BAL)
-       andBool #rangeUInt(256, BLAKE2_BAL)
        andBool VCallDepth <=Int 1024
        andBool #rangeUInt(256, VCallValue)
        andBool #rangeUInt(256, VChainId)
@@ -340,78 +259,6 @@ module VAT-FORK-DIFF-PASS-ROUGH-SPEC
               <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_Vat => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -426,15 +273,6 @@ module VAT-FORK-DIFF-PASS-ROUGH-SPEC
        andBool #rangeAddress(ORIGIN_ID)
        andBool #rangeUInt(256, TIME)
        andBool #rangeUInt(256, ACCT_ID_balance)
-       andBool #rangeUInt(256, ECREC_BAL)
-       andBool #rangeUInt(256, SHA256_BAL)
-       andBool #rangeUInt(256, RIP160_BAL)
-       andBool #rangeUInt(256, ID_BAL)
-       andBool #rangeUInt(256, MODEXP_BAL)
-       andBool #rangeUInt(256, ECADD_BAL)
-       andBool #rangeUInt(256, ECMUL_BAL)
-       andBool #rangeUInt(256, ECPAIRING_BAL)
-       andBool #rangeUInt(256, BLAKE2_BAL)
        andBool VCallDepth <=Int 1024
        andBool #rangeUInt(256, VCallValue)
        andBool #rangeUInt(256, VChainId)
@@ -524,78 +362,6 @@ module VAT-FORK-DIFF-PASS-ROUGH-SPEC
               <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_Vat => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -610,15 +376,6 @@ module VAT-FORK-DIFF-PASS-ROUGH-SPEC
        andBool #rangeAddress(ORIGIN_ID)
        andBool #rangeUInt(256, TIME)
        andBool #rangeUInt(256, ACCT_ID_balance)
-       andBool #rangeUInt(256, ECREC_BAL)
-       andBool #rangeUInt(256, SHA256_BAL)
-       andBool #rangeUInt(256, RIP160_BAL)
-       andBool #rangeUInt(256, ID_BAL)
-       andBool #rangeUInt(256, MODEXP_BAL)
-       andBool #rangeUInt(256, ECADD_BAL)
-       andBool #rangeUInt(256, ECMUL_BAL)
-       andBool #rangeUInt(256, ECPAIRING_BAL)
-       andBool #rangeUInt(256, BLAKE2_BAL)
        andBool VCallDepth <=Int 1024
        andBool #rangeUInt(256, VCallValue)
        andBool #rangeUInt(256, VChainId)
@@ -705,78 +462,6 @@ module VAT-FORK-DIFF-PASS-ROUGH-SPEC
               <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_Vat => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -791,15 +476,6 @@ module VAT-FORK-DIFF-PASS-ROUGH-SPEC
        andBool #rangeAddress(ORIGIN_ID)
        andBool #rangeUInt(256, TIME)
        andBool #rangeUInt(256, ACCT_ID_balance)
-       andBool #rangeUInt(256, ECREC_BAL)
-       andBool #rangeUInt(256, SHA256_BAL)
-       andBool #rangeUInt(256, RIP160_BAL)
-       andBool #rangeUInt(256, ID_BAL)
-       andBool #rangeUInt(256, MODEXP_BAL)
-       andBool #rangeUInt(256, ECADD_BAL)
-       andBool #rangeUInt(256, ECMUL_BAL)
-       andBool #rangeUInt(256, ECPAIRING_BAL)
-       andBool #rangeUInt(256, BLAKE2_BAL)
        andBool VCallDepth <=Int 1024
        andBool #rangeUInt(256, VCallValue)
        andBool #rangeUInt(256, VChainId)

--- a/tests/specs/mcd/vat-fork-diff-pass-rough-spec.k
+++ b/tests/specs/mcd/vat-fork-diff-pass-rough-spec.k
@@ -62,16 +62,7 @@ module VAT-FORK-DIFF-PASS-ROUGH-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>
@@ -339,16 +330,7 @@ module VAT-FORK-DIFF-PASS-ROUGH-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>
@@ -532,16 +514,7 @@ module VAT-FORK-DIFF-PASS-ROUGH-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>
@@ -722,16 +695,7 @@ module VAT-FORK-DIFF-PASS-ROUGH-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>

--- a/tests/specs/mcd/vat-frob-diff-zero-dart-pass-rough-spec.k
+++ b/tests/specs/mcd/vat-frob-diff-zero-dart-pass-rough-spec.k
@@ -62,16 +62,7 @@ module VAT-FROB-DIFF-ZERO-DART-PASS-ROUGH-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>
@@ -434,16 +425,7 @@ module VAT-FROB-DIFF-ZERO-DART-PASS-ROUGH-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>

--- a/tests/specs/mcd/vat-frob-diff-zero-dart-pass-rough-spec.k
+++ b/tests/specs/mcd/vat-frob-diff-zero-dart-pass-rough-spec.k
@@ -72,78 +72,6 @@ module VAT-FROB-DIFF-ZERO-DART-PASS-ROUGH-SPEC
               <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_Vat => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -158,15 +86,6 @@ module VAT-FROB-DIFF-ZERO-DART-PASS-ROUGH-SPEC
        andBool #rangeAddress(ORIGIN_ID)
        andBool #rangeUInt(256, TIME)
        andBool #rangeUInt(256, ACCT_ID_balance)
-       andBool #rangeUInt(256, ECREC_BAL)
-       andBool #rangeUInt(256, SHA256_BAL)
-       andBool #rangeUInt(256, RIP160_BAL)
-       andBool #rangeUInt(256, ID_BAL)
-       andBool #rangeUInt(256, MODEXP_BAL)
-       andBool #rangeUInt(256, ECADD_BAL)
-       andBool #rangeUInt(256, ECMUL_BAL)
-       andBool #rangeUInt(256, ECPAIRING_BAL)
-       andBool #rangeUInt(256, BLAKE2_BAL)
        andBool VCallDepth <=Int 1024
        andBool #rangeUInt(256, VCallValue)
        andBool #rangeUInt(256, VChainId)
@@ -435,78 +354,6 @@ module VAT-FROB-DIFF-ZERO-DART-PASS-ROUGH-SPEC
               <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_Vat => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -521,15 +368,6 @@ module VAT-FROB-DIFF-ZERO-DART-PASS-ROUGH-SPEC
        andBool #rangeAddress(ORIGIN_ID)
        andBool #rangeUInt(256, TIME)
        andBool #rangeUInt(256, ACCT_ID_balance)
-       andBool #rangeUInt(256, ECREC_BAL)
-       andBool #rangeUInt(256, SHA256_BAL)
-       andBool #rangeUInt(256, RIP160_BAL)
-       andBool #rangeUInt(256, ID_BAL)
-       andBool #rangeUInt(256, MODEXP_BAL)
-       andBool #rangeUInt(256, ECADD_BAL)
-       andBool #rangeUInt(256, ECMUL_BAL)
-       andBool #rangeUInt(256, ECPAIRING_BAL)
-       andBool #rangeUInt(256, BLAKE2_BAL)
        andBool VCallDepth <=Int 1024
        andBool #rangeUInt(256, VCallValue)
        andBool #rangeUInt(256, VChainId)

--- a/tests/specs/mcd/vat-move-diff-rough-spec.k
+++ b/tests/specs/mcd/vat-move-diff-rough-spec.k
@@ -62,16 +62,7 @@ module VAT-MOVE-DIFF-ROUGH-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>
@@ -265,16 +256,7 @@ module VAT-MOVE-DIFF-ROUGH-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>
@@ -450,16 +432,7 @@ module VAT-MOVE-DIFF-ROUGH-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>

--- a/tests/specs/mcd/vat-move-diff-rough-spec.k
+++ b/tests/specs/mcd/vat-move-diff-rough-spec.k
@@ -72,78 +72,6 @@ module VAT-MOVE-DIFF-ROUGH-SPEC
               <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_Vat => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -158,15 +86,6 @@ module VAT-MOVE-DIFF-ROUGH-SPEC
      andBool #rangeAddress(ORIGIN_ID)
      andBool #rangeUInt(256, TIME)
      andBool #rangeUInt(256, ACCT_ID_balance)
-     andBool #rangeUInt(256, ECREC_BAL)
-     andBool #rangeUInt(256, SHA256_BAL)
-     andBool #rangeUInt(256, RIP160_BAL)
-     andBool #rangeUInt(256, ID_BAL)
-     andBool #rangeUInt(256, MODEXP_BAL)
-     andBool #rangeUInt(256, ECADD_BAL)
-     andBool #rangeUInt(256, ECMUL_BAL)
-     andBool #rangeUInt(256, ECPAIRING_BAL)
-     andBool #rangeUInt(256, BLAKE2_BAL)
      andBool VCallDepth <=Int 1024
      andBool #rangeUInt(256, VCallValue)
      andBool #rangeUInt(256, VChainId)
@@ -266,78 +185,6 @@ module VAT-MOVE-DIFF-ROUGH-SPEC
               <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_Vat => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -352,15 +199,6 @@ module VAT-MOVE-DIFF-ROUGH-SPEC
      andBool #rangeAddress(ORIGIN_ID)
      andBool #rangeUInt(256, TIME)
      andBool #rangeUInt(256, ACCT_ID_balance)
-     andBool #rangeUInt(256, ECREC_BAL)
-     andBool #rangeUInt(256, SHA256_BAL)
-     andBool #rangeUInt(256, RIP160_BAL)
-     andBool #rangeUInt(256, ID_BAL)
-     andBool #rangeUInt(256, MODEXP_BAL)
-     andBool #rangeUInt(256, ECADD_BAL)
-     andBool #rangeUInt(256, ECMUL_BAL)
-     andBool #rangeUInt(256, ECPAIRING_BAL)
-     andBool #rangeUInt(256, BLAKE2_BAL)
      andBool VCallDepth <=Int 1024
      andBool #rangeUInt(256, VCallValue)
      andBool #rangeUInt(256, VChainId)
@@ -442,78 +280,6 @@ module VAT-MOVE-DIFF-ROUGH-SPEC
               <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_Vat => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -528,15 +294,6 @@ module VAT-MOVE-DIFF-ROUGH-SPEC
      andBool #rangeAddress(ORIGIN_ID)
      andBool #rangeUInt(256, TIME)
      andBool #rangeUInt(256, ACCT_ID_balance)
-     andBool #rangeUInt(256, ECREC_BAL)
-     andBool #rangeUInt(256, SHA256_BAL)
-     andBool #rangeUInt(256, RIP160_BAL)
-     andBool #rangeUInt(256, ID_BAL)
-     andBool #rangeUInt(256, MODEXP_BAL)
-     andBool #rangeUInt(256, ECADD_BAL)
-     andBool #rangeUInt(256, ECMUL_BAL)
-     andBool #rangeUInt(256, ECPAIRING_BAL)
-     andBool #rangeUInt(256, BLAKE2_BAL)
      andBool VCallDepth <=Int 1024
      andBool #rangeUInt(256, VCallValue)
      andBool #rangeUInt(256, VChainId)

--- a/tests/specs/mcd/vat-mului-pass-spec.k
+++ b/tests/specs/mcd/vat-mului-pass-spec.k
@@ -65,16 +65,7 @@ module VAT-MULUI-PASS-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>

--- a/tests/specs/mcd/vat-mului-pass-spec.k
+++ b/tests/specs/mcd/vat-mului-pass-spec.k
@@ -75,78 +75,6 @@ module VAT-MULUI-PASS-SPEC
               <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_Vat => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -161,15 +89,6 @@ module VAT-MULUI-PASS-SPEC
        andBool #rangeAddress(ORIGIN_ID)
        andBool #rangeUInt(256, TIME)
        andBool #rangeUInt(256, ACCT_ID_balance)
-       andBool #rangeUInt(256, ECREC_BAL)
-       andBool #rangeUInt(256, SHA256_BAL)
-       andBool #rangeUInt(256, RIP160_BAL)
-       andBool #rangeUInt(256, ID_BAL)
-       andBool #rangeUInt(256, MODEXP_BAL)
-       andBool #rangeUInt(256, ECADD_BAL)
-       andBool #rangeUInt(256, ECMUL_BAL)
-       andBool #rangeUInt(256, ECPAIRING_BAL)
-       andBool #rangeUInt(256, BLAKE2_BAL)
        andBool VCallDepth <=Int 1024
        andBool #rangeUInt(256, VCallValue)
        andBool #rangeUInt(256, VChainId)

--- a/tests/specs/mcd/vat-slip-pass-rough-spec.k
+++ b/tests/specs/mcd/vat-slip-pass-rough-spec.k
@@ -72,78 +72,6 @@ module VAT-SLIP-PASS-ROUGH-SPEC
               <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_Vat => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -158,15 +86,6 @@ module VAT-SLIP-PASS-ROUGH-SPEC
        andBool #rangeAddress(ORIGIN_ID)
        andBool #rangeUInt(256, TIME)
        andBool #rangeUInt(256, ACCT_ID_balance)
-       andBool #rangeUInt(256, ECREC_BAL)
-       andBool #rangeUInt(256, SHA256_BAL)
-       andBool #rangeUInt(256, RIP160_BAL)
-       andBool #rangeUInt(256, ID_BAL)
-       andBool #rangeUInt(256, MODEXP_BAL)
-       andBool #rangeUInt(256, ECADD_BAL)
-       andBool #rangeUInt(256, ECMUL_BAL)
-       andBool #rangeUInt(256, ECPAIRING_BAL)
-       andBool #rangeUInt(256, BLAKE2_BAL)
        andBool VCallDepth <=Int 1024
        andBool #rangeUInt(256, VCallValue)
        andBool #rangeUInt(256, VChainId)
@@ -264,78 +183,6 @@ module VAT-SLIP-PASS-ROUGH-SPEC
               <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_Vat => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -350,15 +197,6 @@ module VAT-SLIP-PASS-ROUGH-SPEC
        andBool #rangeAddress(ORIGIN_ID)
        andBool #rangeUInt(256, TIME)
        andBool #rangeUInt(256, ACCT_ID_balance)
-       andBool #rangeUInt(256, ECREC_BAL)
-       andBool #rangeUInt(256, SHA256_BAL)
-       andBool #rangeUInt(256, RIP160_BAL)
-       andBool #rangeUInt(256, ID_BAL)
-       andBool #rangeUInt(256, MODEXP_BAL)
-       andBool #rangeUInt(256, ECADD_BAL)
-       andBool #rangeUInt(256, ECMUL_BAL)
-       andBool #rangeUInt(256, ECPAIRING_BAL)
-       andBool #rangeUInt(256, BLAKE2_BAL)
        andBool VCallDepth <=Int 1024
        andBool #rangeUInt(256, VCallValue)
        andBool #rangeUInt(256, VChainId)

--- a/tests/specs/mcd/vat-slip-pass-rough-spec.k
+++ b/tests/specs/mcd/vat-slip-pass-rough-spec.k
@@ -62,16 +62,7 @@ module VAT-SLIP-PASS-ROUGH-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>
@@ -263,16 +254,7 @@ module VAT-SLIP-PASS-ROUGH-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>

--- a/tests/specs/mcd/vat-subui-fail-rough-spec.k
+++ b/tests/specs/mcd/vat-subui-fail-rough-spec.k
@@ -62,16 +62,7 @@ module VAT-SUBUI-FAIL-ROUGH-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>

--- a/tests/specs/mcd/vat-subui-fail-rough-spec.k
+++ b/tests/specs/mcd/vat-subui-fail-rough-spec.k
@@ -72,78 +72,6 @@ module VAT-SUBUI-FAIL-ROUGH-SPEC
               <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_Vat => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -158,15 +86,6 @@ module VAT-SUBUI-FAIL-ROUGH-SPEC
        andBool #rangeAddress(ORIGIN_ID)
        andBool #rangeUInt(256, TIME)
        andBool #rangeUInt(256, ACCT_ID_balance)
-       andBool #rangeUInt(256, ECREC_BAL)
-       andBool #rangeUInt(256, SHA256_BAL)
-       andBool #rangeUInt(256, RIP160_BAL)
-       andBool #rangeUInt(256, ID_BAL)
-       andBool #rangeUInt(256, MODEXP_BAL)
-       andBool #rangeUInt(256, ECADD_BAL)
-       andBool #rangeUInt(256, ECMUL_BAL)
-       andBool #rangeUInt(256, ECPAIRING_BAL)
-       andBool #rangeUInt(256, BLAKE2_BAL)
        andBool VCallDepth <=Int 1024
        andBool #rangeUInt(256, VCallValue)
        andBool #rangeUInt(256, VChainId)

--- a/tests/specs/mcd/vat-subui-pass-rough-spec.k
+++ b/tests/specs/mcd/vat-subui-pass-rough-spec.k
@@ -72,78 +72,6 @@ module VAT-SUBUI-PASS-ROUGH-SPEC
               <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_Vat => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -158,15 +86,6 @@ module VAT-SUBUI-PASS-ROUGH-SPEC
        andBool #rangeAddress(ORIGIN_ID)
        andBool #rangeUInt(256, TIME)
        andBool #rangeUInt(256, ACCT_ID_balance)
-       andBool #rangeUInt(256, ECREC_BAL)
-       andBool #rangeUInt(256, SHA256_BAL)
-       andBool #rangeUInt(256, RIP160_BAL)
-       andBool #rangeUInt(256, ID_BAL)
-       andBool #rangeUInt(256, MODEXP_BAL)
-       andBool #rangeUInt(256, ECADD_BAL)
-       andBool #rangeUInt(256, ECMUL_BAL)
-       andBool #rangeUInt(256, ECPAIRING_BAL)
-       andBool #rangeUInt(256, BLAKE2_BAL)
        andBool VCallDepth <=Int 1024
        andBool #rangeUInt(256, VCallValue)
        andBool #rangeUInt(256, VChainId)

--- a/tests/specs/mcd/vat-subui-pass-rough-spec.k
+++ b/tests/specs/mcd/vat-subui-pass-rough-spec.k
@@ -62,16 +62,7 @@ module VAT-SUBUI-PASS-ROUGH-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>

--- a/tests/specs/mcd/vat-subui-pass-spec.k
+++ b/tests/specs/mcd/vat-subui-pass-spec.k
@@ -68,16 +68,7 @@ module VAT-SUBUI-PASS-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>

--- a/tests/specs/mcd/vat-subui-pass-spec.k
+++ b/tests/specs/mcd/vat-subui-pass-spec.k
@@ -78,78 +78,6 @@ module VAT-SUBUI-PASS-SPEC
               <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_Vat => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -164,15 +92,6 @@ module VAT-SUBUI-PASS-SPEC
        andBool #rangeAddress(ORIGIN_ID)
        andBool #rangeUInt(256, TIME)
        andBool #rangeUInt(256, ACCT_ID_balance)
-       andBool #rangeUInt(256, ECREC_BAL)
-       andBool #rangeUInt(256, SHA256_BAL)
-       andBool #rangeUInt(256, RIP160_BAL)
-       andBool #rangeUInt(256, ID_BAL)
-       andBool #rangeUInt(256, MODEXP_BAL)
-       andBool #rangeUInt(256, ECADD_BAL)
-       andBool #rangeUInt(256, ECMUL_BAL)
-       andBool #rangeUInt(256, ECPAIRING_BAL)
-       andBool #rangeUInt(256, BLAKE2_BAL)
        andBool VCallDepth <=Int 1024
        andBool #rangeUInt(256, VCallValue)
        andBool #rangeUInt(256, VChainId)

--- a/tests/specs/mcd/vow-cage-deficit-pass-rough-spec.k
+++ b/tests/specs/mcd/vow-cage-deficit-pass-rough-spec.k
@@ -96,78 +96,6 @@ module VOW-CAGE-DEFICIT-PASS-ROUGH-SPEC
               <origStorage> Flopper_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_Flopper => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -182,15 +110,6 @@ module VOW-CAGE-DEFICIT-PASS-ROUGH-SPEC
        andBool #rangeAddress(ORIGIN_ID)
        andBool #rangeUInt(256, TIME)
        andBool #rangeUInt(256, ACCT_ID_balance)
-       andBool #rangeUInt(256, ECREC_BAL)
-       andBool #rangeUInt(256, SHA256_BAL)
-       andBool #rangeUInt(256, RIP160_BAL)
-       andBool #rangeUInt(256, ID_BAL)
-       andBool #rangeUInt(256, MODEXP_BAL)
-       andBool #rangeUInt(256, ECADD_BAL)
-       andBool #rangeUInt(256, ECMUL_BAL)
-       andBool #rangeUInt(256, ECPAIRING_BAL)
-       andBool #rangeUInt(256, BLAKE2_BAL)
        andBool VCallDepth <=Int 1024
        andBool #rangeUInt(256, VCallValue)
        andBool #rangeUInt(256, VChainId)
@@ -416,78 +335,6 @@ module VOW-CAGE-DEFICIT-PASS-ROUGH-SPEC
               <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_Vow => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -502,15 +349,6 @@ module VOW-CAGE-DEFICIT-PASS-ROUGH-SPEC
        andBool #rangeAddress(ORIGIN_ID)
        andBool #rangeUInt(256, TIME)
        andBool #rangeUInt(256, ACCT_ID_balance)
-       andBool #rangeUInt(256, ECREC_BAL)
-       andBool #rangeUInt(256, SHA256_BAL)
-       andBool #rangeUInt(256, RIP160_BAL)
-       andBool #rangeUInt(256, ID_BAL)
-       andBool #rangeUInt(256, MODEXP_BAL)
-       andBool #rangeUInt(256, ECADD_BAL)
-       andBool #rangeUInt(256, ECMUL_BAL)
-       andBool #rangeUInt(256, ECPAIRING_BAL)
-       andBool #rangeUInt(256, BLAKE2_BAL)
        andBool VCallDepth <=Int 1024
        andBool #rangeUInt(256, VCallValue)
        andBool #rangeUInt(256, VChainId)
@@ -593,78 +431,6 @@ module VOW-CAGE-DEFICIT-PASS-ROUGH-SPEC
               <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_Vat => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -679,15 +445,6 @@ module VOW-CAGE-DEFICIT-PASS-ROUGH-SPEC
        andBool #rangeAddress(ORIGIN_ID)
        andBool #rangeUInt(256, TIME)
        andBool #rangeUInt(256, ACCT_ID_balance)
-       andBool #rangeUInt(256, ECREC_BAL)
-       andBool #rangeUInt(256, SHA256_BAL)
-       andBool #rangeUInt(256, RIP160_BAL)
-       andBool #rangeUInt(256, ID_BAL)
-       andBool #rangeUInt(256, MODEXP_BAL)
-       andBool #rangeUInt(256, ECADD_BAL)
-       andBool #rangeUInt(256, ECMUL_BAL)
-       andBool #rangeUInt(256, ECPAIRING_BAL)
-       andBool #rangeUInt(256, BLAKE2_BAL)
        andBool VCallDepth <=Int 1024
        andBool #rangeUInt(256, VCallValue)
        andBool #rangeUInt(256, VChainId)
@@ -772,78 +529,6 @@ module VOW-CAGE-DEFICIT-PASS-ROUGH-SPEC
               <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_Vat => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -858,15 +543,6 @@ module VOW-CAGE-DEFICIT-PASS-ROUGH-SPEC
        andBool #rangeAddress(ORIGIN_ID)
        andBool #rangeUInt(256, TIME)
        andBool #rangeUInt(256, ACCT_ID_balance)
-       andBool #rangeUInt(256, ECREC_BAL)
-       andBool #rangeUInt(256, SHA256_BAL)
-       andBool #rangeUInt(256, RIP160_BAL)
-       andBool #rangeUInt(256, ID_BAL)
-       andBool #rangeUInt(256, MODEXP_BAL)
-       andBool #rangeUInt(256, ECADD_BAL)
-       andBool #rangeUInt(256, ECMUL_BAL)
-       andBool #rangeUInt(256, ECPAIRING_BAL)
-       andBool #rangeUInt(256, BLAKE2_BAL)
        andBool VCallDepth <=Int 1024
        andBool #rangeUInt(256, VCallValue)
        andBool #rangeUInt(256, VChainId)
@@ -951,78 +627,6 @@ module VOW-CAGE-DEFICIT-PASS-ROUGH-SPEC
               <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_Vat => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -1037,15 +641,6 @@ module VOW-CAGE-DEFICIT-PASS-ROUGH-SPEC
        andBool #rangeAddress(ORIGIN_ID)
        andBool #rangeUInt(256, TIME)
        andBool #rangeUInt(256, ACCT_ID_balance)
-       andBool #rangeUInt(256, ECREC_BAL)
-       andBool #rangeUInt(256, SHA256_BAL)
-       andBool #rangeUInt(256, RIP160_BAL)
-       andBool #rangeUInt(256, ID_BAL)
-       andBool #rangeUInt(256, MODEXP_BAL)
-       andBool #rangeUInt(256, ECADD_BAL)
-       andBool #rangeUInt(256, ECMUL_BAL)
-       andBool #rangeUInt(256, ECPAIRING_BAL)
-       andBool #rangeUInt(256, BLAKE2_BAL)
        andBool VCallDepth <=Int 1024
        andBool #rangeUInt(256, VCallValue)
        andBool #rangeUInt(256, VChainId)
@@ -1160,78 +755,6 @@ module VOW-CAGE-DEFICIT-PASS-ROUGH-SPEC
               <origStorage> Vat_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_Vat => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -1246,15 +769,6 @@ module VOW-CAGE-DEFICIT-PASS-ROUGH-SPEC
        andBool #rangeAddress(ORIGIN_ID)
        andBool #rangeUInt(256, TIME)
        andBool #rangeUInt(256, ACCT_ID_balance)
-       andBool #rangeUInt(256, ECREC_BAL)
-       andBool #rangeUInt(256, SHA256_BAL)
-       andBool #rangeUInt(256, RIP160_BAL)
-       andBool #rangeUInt(256, ID_BAL)
-       andBool #rangeUInt(256, MODEXP_BAL)
-       andBool #rangeUInt(256, ECADD_BAL)
-       andBool #rangeUInt(256, ECMUL_BAL)
-       andBool #rangeUInt(256, ECPAIRING_BAL)
-       andBool #rangeUInt(256, BLAKE2_BAL)
        andBool VCallDepth <=Int 1024
        andBool #rangeUInt(256, VCallValue)
        andBool #rangeUInt(256, VChainId)
@@ -1374,78 +888,6 @@ module VOW-CAGE-DEFICIT-PASS-ROUGH-SPEC
               <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_Flopper => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -1460,15 +902,6 @@ module VOW-CAGE-DEFICIT-PASS-ROUGH-SPEC
        andBool #rangeAddress(ORIGIN_ID)
        andBool #rangeUInt(256, TIME)
        andBool #rangeUInt(256, ACCT_ID_balance)
-       andBool #rangeUInt(256, ECREC_BAL)
-       andBool #rangeUInt(256, SHA256_BAL)
-       andBool #rangeUInt(256, RIP160_BAL)
-       andBool #rangeUInt(256, ID_BAL)
-       andBool #rangeUInt(256, MODEXP_BAL)
-       andBool #rangeUInt(256, ECADD_BAL)
-       andBool #rangeUInt(256, ECMUL_BAL)
-       andBool #rangeUInt(256, ECPAIRING_BAL)
-       andBool #rangeUInt(256, BLAKE2_BAL)
        andBool VCallDepth <=Int 1024
        andBool #rangeUInt(256, VCallValue)
        andBool #rangeUInt(256, VChainId)

--- a/tests/specs/mcd/vow-cage-deficit-pass-rough-spec.k
+++ b/tests/specs/mcd/vow-cage-deficit-pass-rough-spec.k
@@ -62,19 +62,7 @@ module VOW-CAGE-DEFICIT-PASS-ROUGH-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(Vat)
-          SetItem(Flapper)
-          SetItem(Flopper)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) SetItem(Vat) SetItem(Flapper) SetItem(Flopper) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>
@@ -418,16 +406,7 @@ module VOW-CAGE-DEFICIT-PASS-ROUGH-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>
@@ -604,16 +583,7 @@ module VOW-CAGE-DEFICIT-PASS-ROUGH-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>
@@ -792,16 +762,7 @@ module VOW-CAGE-DEFICIT-PASS-ROUGH-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>
@@ -980,16 +941,7 @@ module VOW-CAGE-DEFICIT-PASS-ROUGH-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>
@@ -1190,17 +1142,7 @@ module VOW-CAGE-DEFICIT-PASS-ROUGH-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(Vat)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) SetItem(Vat) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>
@@ -1422,16 +1364,7 @@ module VOW-CAGE-DEFICIT-PASS-ROUGH-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>

--- a/tests/specs/mcd/vow-cage-surplus-pass-rough-spec.k
+++ b/tests/specs/mcd/vow-cage-surplus-pass-rough-spec.k
@@ -62,19 +62,7 @@ module VOW-CAGE-SURPLUS-PASS-ROUGH-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(Vat)
-          SetItem(Flapper)
-          SetItem(Flopper)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) SetItem(Vat) SetItem(Flapper) SetItem(Flopper) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>
@@ -419,16 +407,7 @@ module VOW-CAGE-SURPLUS-PASS-ROUGH-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>
@@ -605,16 +584,7 @@ module VOW-CAGE-SURPLUS-PASS-ROUGH-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>
@@ -793,16 +763,7 @@ module VOW-CAGE-SURPLUS-PASS-ROUGH-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>
@@ -981,16 +942,7 @@ module VOW-CAGE-SURPLUS-PASS-ROUGH-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>
@@ -1191,17 +1143,7 @@ module VOW-CAGE-SURPLUS-PASS-ROUGH-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(Vat)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) SetItem(Vat) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>
@@ -1423,16 +1365,7 @@ module VOW-CAGE-SURPLUS-PASS-ROUGH-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>

--- a/tests/specs/mcd/vow-cage-surplus-pass-rough-spec.k
+++ b/tests/specs/mcd/vow-cage-surplus-pass-rough-spec.k
@@ -96,78 +96,6 @@ module VOW-CAGE-SURPLUS-PASS-ROUGH-SPEC
               <origStorage> Flopper_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_Flopper => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -182,15 +110,6 @@ module VOW-CAGE-SURPLUS-PASS-ROUGH-SPEC
        andBool #rangeAddress(ORIGIN_ID)
        andBool #rangeUInt(256, TIME)
        andBool #rangeUInt(256, ACCT_ID_balance)
-       andBool #rangeUInt(256, ECREC_BAL)
-       andBool #rangeUInt(256, SHA256_BAL)
-       andBool #rangeUInt(256, RIP160_BAL)
-       andBool #rangeUInt(256, ID_BAL)
-       andBool #rangeUInt(256, MODEXP_BAL)
-       andBool #rangeUInt(256, ECADD_BAL)
-       andBool #rangeUInt(256, ECMUL_BAL)
-       andBool #rangeUInt(256, ECPAIRING_BAL)
-       andBool #rangeUInt(256, BLAKE2_BAL)
        andBool VCallDepth <=Int 1024
        andBool #rangeUInt(256, VCallValue)
        andBool #rangeUInt(256, VChainId)
@@ -417,78 +336,6 @@ module VOW-CAGE-SURPLUS-PASS-ROUGH-SPEC
               <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_Vow => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -503,15 +350,6 @@ module VOW-CAGE-SURPLUS-PASS-ROUGH-SPEC
        andBool #rangeAddress(ORIGIN_ID)
        andBool #rangeUInt(256, TIME)
        andBool #rangeUInt(256, ACCT_ID_balance)
-       andBool #rangeUInt(256, ECREC_BAL)
-       andBool #rangeUInt(256, SHA256_BAL)
-       andBool #rangeUInt(256, RIP160_BAL)
-       andBool #rangeUInt(256, ID_BAL)
-       andBool #rangeUInt(256, MODEXP_BAL)
-       andBool #rangeUInt(256, ECADD_BAL)
-       andBool #rangeUInt(256, ECMUL_BAL)
-       andBool #rangeUInt(256, ECPAIRING_BAL)
-       andBool #rangeUInt(256, BLAKE2_BAL)
        andBool VCallDepth <=Int 1024
        andBool #rangeUInt(256, VCallValue)
        andBool #rangeUInt(256, VChainId)
@@ -594,78 +432,6 @@ module VOW-CAGE-SURPLUS-PASS-ROUGH-SPEC
               <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_Vat => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -680,15 +446,6 @@ module VOW-CAGE-SURPLUS-PASS-ROUGH-SPEC
        andBool #rangeAddress(ORIGIN_ID)
        andBool #rangeUInt(256, TIME)
        andBool #rangeUInt(256, ACCT_ID_balance)
-       andBool #rangeUInt(256, ECREC_BAL)
-       andBool #rangeUInt(256, SHA256_BAL)
-       andBool #rangeUInt(256, RIP160_BAL)
-       andBool #rangeUInt(256, ID_BAL)
-       andBool #rangeUInt(256, MODEXP_BAL)
-       andBool #rangeUInt(256, ECADD_BAL)
-       andBool #rangeUInt(256, ECMUL_BAL)
-       andBool #rangeUInt(256, ECPAIRING_BAL)
-       andBool #rangeUInt(256, BLAKE2_BAL)
        andBool VCallDepth <=Int 1024
        andBool #rangeUInt(256, VCallValue)
        andBool #rangeUInt(256, VChainId)
@@ -773,78 +530,6 @@ module VOW-CAGE-SURPLUS-PASS-ROUGH-SPEC
               <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_Vat => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -859,15 +544,6 @@ module VOW-CAGE-SURPLUS-PASS-ROUGH-SPEC
        andBool #rangeAddress(ORIGIN_ID)
        andBool #rangeUInt(256, TIME)
        andBool #rangeUInt(256, ACCT_ID_balance)
-       andBool #rangeUInt(256, ECREC_BAL)
-       andBool #rangeUInt(256, SHA256_BAL)
-       andBool #rangeUInt(256, RIP160_BAL)
-       andBool #rangeUInt(256, ID_BAL)
-       andBool #rangeUInt(256, MODEXP_BAL)
-       andBool #rangeUInt(256, ECADD_BAL)
-       andBool #rangeUInt(256, ECMUL_BAL)
-       andBool #rangeUInt(256, ECPAIRING_BAL)
-       andBool #rangeUInt(256, BLAKE2_BAL)
        andBool VCallDepth <=Int 1024
        andBool #rangeUInt(256, VCallValue)
        andBool #rangeUInt(256, VChainId)
@@ -952,78 +628,6 @@ module VOW-CAGE-SURPLUS-PASS-ROUGH-SPEC
               <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_Vat => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -1038,15 +642,6 @@ module VOW-CAGE-SURPLUS-PASS-ROUGH-SPEC
        andBool #rangeAddress(ORIGIN_ID)
        andBool #rangeUInt(256, TIME)
        andBool #rangeUInt(256, ACCT_ID_balance)
-       andBool #rangeUInt(256, ECREC_BAL)
-       andBool #rangeUInt(256, SHA256_BAL)
-       andBool #rangeUInt(256, RIP160_BAL)
-       andBool #rangeUInt(256, ID_BAL)
-       andBool #rangeUInt(256, MODEXP_BAL)
-       andBool #rangeUInt(256, ECADD_BAL)
-       andBool #rangeUInt(256, ECMUL_BAL)
-       andBool #rangeUInt(256, ECPAIRING_BAL)
-       andBool #rangeUInt(256, BLAKE2_BAL)
        andBool VCallDepth <=Int 1024
        andBool #rangeUInt(256, VCallValue)
        andBool #rangeUInt(256, VChainId)
@@ -1161,78 +756,6 @@ module VOW-CAGE-SURPLUS-PASS-ROUGH-SPEC
               <origStorage> Vat_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_Vat => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -1247,15 +770,6 @@ module VOW-CAGE-SURPLUS-PASS-ROUGH-SPEC
        andBool #rangeAddress(ORIGIN_ID)
        andBool #rangeUInt(256, TIME)
        andBool #rangeUInt(256, ACCT_ID_balance)
-       andBool #rangeUInt(256, ECREC_BAL)
-       andBool #rangeUInt(256, SHA256_BAL)
-       andBool #rangeUInt(256, RIP160_BAL)
-       andBool #rangeUInt(256, ID_BAL)
-       andBool #rangeUInt(256, MODEXP_BAL)
-       andBool #rangeUInt(256, ECADD_BAL)
-       andBool #rangeUInt(256, ECMUL_BAL)
-       andBool #rangeUInt(256, ECPAIRING_BAL)
-       andBool #rangeUInt(256, BLAKE2_BAL)
        andBool VCallDepth <=Int 1024
        andBool #rangeUInt(256, VCallValue)
        andBool #rangeUInt(256, VChainId)
@@ -1375,78 +889,6 @@ module VOW-CAGE-SURPLUS-PASS-ROUGH-SPEC
               <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_Flopper => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -1461,15 +903,6 @@ module VOW-CAGE-SURPLUS-PASS-ROUGH-SPEC
        andBool #rangeAddress(ORIGIN_ID)
        andBool #rangeUInt(256, TIME)
        andBool #rangeUInt(256, ACCT_ID_balance)
-       andBool #rangeUInt(256, ECREC_BAL)
-       andBool #rangeUInt(256, SHA256_BAL)
-       andBool #rangeUInt(256, RIP160_BAL)
-       andBool #rangeUInt(256, ID_BAL)
-       andBool #rangeUInt(256, MODEXP_BAL)
-       andBool #rangeUInt(256, ECADD_BAL)
-       andBool #rangeUInt(256, ECMUL_BAL)
-       andBool #rangeUInt(256, ECPAIRING_BAL)
-       andBool #rangeUInt(256, BLAKE2_BAL)
        andBool VCallDepth <=Int 1024
        andBool #rangeUInt(256, VCallValue)
        andBool #rangeUInt(256, VChainId)

--- a/tests/specs/mcd/vow-fess-fail-rough-spec.k
+++ b/tests/specs/mcd/vow-fess-fail-rough-spec.k
@@ -62,16 +62,7 @@ module VOW-FESS-FAIL-ROUGH-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>
@@ -266,16 +257,7 @@ module VOW-FESS-FAIL-ROUGH-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>

--- a/tests/specs/mcd/vow-fess-fail-rough-spec.k
+++ b/tests/specs/mcd/vow-fess-fail-rough-spec.k
@@ -72,78 +72,6 @@ module VOW-FESS-FAIL-ROUGH-SPEC
               <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_Vow => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -158,15 +86,6 @@ module VOW-FESS-FAIL-ROUGH-SPEC
        andBool #rangeAddress(ORIGIN_ID)
        andBool #rangeUInt(256, TIME)
        andBool #rangeUInt(256, ACCT_ID_balance)
-       andBool #rangeUInt(256, ECREC_BAL)
-       andBool #rangeUInt(256, SHA256_BAL)
-       andBool #rangeUInt(256, RIP160_BAL)
-       andBool #rangeUInt(256, ID_BAL)
-       andBool #rangeUInt(256, MODEXP_BAL)
-       andBool #rangeUInt(256, ECADD_BAL)
-       andBool #rangeUInt(256, ECMUL_BAL)
-       andBool #rangeUInt(256, ECPAIRING_BAL)
-       andBool #rangeUInt(256, BLAKE2_BAL)
        andBool VCallDepth <=Int 1024
        andBool #rangeUInt(256, VCallValue)
        andBool #rangeUInt(256, VChainId)
@@ -267,78 +186,6 @@ module VOW-FESS-FAIL-ROUGH-SPEC
               <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_Vow => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -353,15 +200,6 @@ module VOW-FESS-FAIL-ROUGH-SPEC
        andBool #rangeAddress(ORIGIN_ID)
        andBool #rangeUInt(256, TIME)
        andBool #rangeUInt(256, ACCT_ID_balance)
-       andBool #rangeUInt(256, ECREC_BAL)
-       andBool #rangeUInt(256, SHA256_BAL)
-       andBool #rangeUInt(256, RIP160_BAL)
-       andBool #rangeUInt(256, ID_BAL)
-       andBool #rangeUInt(256, MODEXP_BAL)
-       andBool #rangeUInt(256, ECADD_BAL)
-       andBool #rangeUInt(256, ECMUL_BAL)
-       andBool #rangeUInt(256, ECPAIRING_BAL)
-       andBool #rangeUInt(256, BLAKE2_BAL)
        andBool VCallDepth <=Int 1024
        andBool #rangeUInt(256, VCallValue)
        andBool #rangeUInt(256, VChainId)

--- a/tests/specs/mcd/vow-flog-fail-rough-spec.k
+++ b/tests/specs/mcd/vow-flog-fail-rough-spec.k
@@ -62,16 +62,7 @@ module VOW-FLOG-FAIL-ROUGH-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>
@@ -266,16 +257,7 @@ module VOW-FLOG-FAIL-ROUGH-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>
@@ -453,16 +435,7 @@ module VOW-FLOG-FAIL-ROUGH-SPEC
         </evm>
         <network>
           <chainID> VChainId </chainID>
-          <activeAccounts> SetItem(ACCT_ID)
-          SetItem(1)
-          SetItem(2)
-          SetItem(3)
-          SetItem(4)
-          SetItem(5)
-          SetItem(6)
-          SetItem(7)
-          SetItem(8)
-          SetItem(9) _ </activeAccounts>
+          <activeAccounts> SetItem(ACCT_ID) _ </activeAccounts>
           <accounts>
             <account>
               <acctID> ACCT_ID </acctID>

--- a/tests/specs/mcd/vow-flog-fail-rough-spec.k
+++ b/tests/specs/mcd/vow-flog-fail-rough-spec.k
@@ -72,78 +72,6 @@ module VOW-FLOG-FAIL-ROUGH-SPEC
               <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_Vow => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -158,15 +86,6 @@ module VOW-FLOG-FAIL-ROUGH-SPEC
        andBool #rangeAddress(ORIGIN_ID)
        andBool #rangeUInt(256, TIME)
        andBool #rangeUInt(256, ACCT_ID_balance)
-       andBool #rangeUInt(256, ECREC_BAL)
-       andBool #rangeUInt(256, SHA256_BAL)
-       andBool #rangeUInt(256, RIP160_BAL)
-       andBool #rangeUInt(256, ID_BAL)
-       andBool #rangeUInt(256, MODEXP_BAL)
-       andBool #rangeUInt(256, ECADD_BAL)
-       andBool #rangeUInt(256, ECMUL_BAL)
-       andBool #rangeUInt(256, ECPAIRING_BAL)
-       andBool #rangeUInt(256, BLAKE2_BAL)
        andBool VCallDepth <=Int 1024
        andBool #rangeUInt(256, VCallValue)
        andBool #rangeUInt(256, VChainId)
@@ -267,78 +186,6 @@ module VOW-FLOG-FAIL-ROUGH-SPEC
               <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_Vow => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -353,15 +200,6 @@ module VOW-FLOG-FAIL-ROUGH-SPEC
        andBool #rangeAddress(ORIGIN_ID)
        andBool #rangeUInt(256, TIME)
        andBool #rangeUInt(256, ACCT_ID_balance)
-       andBool #rangeUInt(256, ECREC_BAL)
-       andBool #rangeUInt(256, SHA256_BAL)
-       andBool #rangeUInt(256, RIP160_BAL)
-       andBool #rangeUInt(256, ID_BAL)
-       andBool #rangeUInt(256, MODEXP_BAL)
-       andBool #rangeUInt(256, ECADD_BAL)
-       andBool #rangeUInt(256, ECMUL_BAL)
-       andBool #rangeUInt(256, ECPAIRING_BAL)
-       andBool #rangeUInt(256, BLAKE2_BAL)
        andBool VCallDepth <=Int 1024
        andBool #rangeUInt(256, VCallValue)
        andBool #rangeUInt(256, VChainId)
@@ -445,78 +283,6 @@ module VOW-FLOG-FAIL-ROUGH-SPEC
               <origStorage> ACCT_ID_ORIG_STORAGE </origStorage>
               <nonce> _Nonce_Vow => ?_ </nonce>
             </account>
-            <account>
-              <acctID> 1 </acctID>
-              <balance> ECREC_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 2 </acctID>
-              <balance> SHA256_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 3 </acctID>
-              <balance> RIP160_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 4 </acctID>
-              <balance> ID_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 5 </acctID>
-              <balance> MODEXP_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 6 </acctID>
-              <balance> ECADD_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 7 </acctID>
-              <balance> ECMUL_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 8 </acctID>
-              <balance> ECPAIRING_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
-            <account>
-              <acctID> 9 </acctID>
-              <balance> BLAKE2_BAL </balance>
-              <code> .ByteArray </code>
-              <storage> _:Map </storage>
-              <origStorage> _ </origStorage>
-              <nonce> _ </nonce>
-            </account>
            ...
           </accounts>
           <txOrder> _ </txOrder>
@@ -531,15 +297,6 @@ module VOW-FLOG-FAIL-ROUGH-SPEC
        andBool #rangeAddress(ORIGIN_ID)
        andBool #rangeUInt(256, TIME)
        andBool #rangeUInt(256, ACCT_ID_balance)
-       andBool #rangeUInt(256, ECREC_BAL)
-       andBool #rangeUInt(256, SHA256_BAL)
-       andBool #rangeUInt(256, RIP160_BAL)
-       andBool #rangeUInt(256, ID_BAL)
-       andBool #rangeUInt(256, MODEXP_BAL)
-       andBool #rangeUInt(256, ECADD_BAL)
-       andBool #rangeUInt(256, ECMUL_BAL)
-       andBool #rangeUInt(256, ECPAIRING_BAL)
-       andBool #rangeUInt(256, BLAKE2_BAL)
        andBool VCallDepth <=Int 1024
        andBool #rangeUInt(256, VCallValue)
        andBool #rangeUInt(256, VChainId)


### PR DESCRIPTION
Currently, for the MCD proofs, we put in "mock" accounts as precompile accounts, so that the `#accountNonexistent` and `#accountEmpty` are affected. This just removes mentions of the precompiles, so that we don't worry about them for the proofs at all (proofs are done independent of precompile account status).