### PR TITLE
Fix release process, uniform use of --debugger

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,10 +49,10 @@ pipeline {
       }
     }
     stage('Package') {
-      when {
-        branch 'master'
-        beforeAgent true
-      }
+      // when {
+      //   branch 'master'
+      //   beforeAgent true
+      // }
       post { failure { slackSend color: '#cb2431' , channel: '#kevm' , message: "Packaging Phase Failed: ${env.BUILD_URL}" } }
       stages {
         stage('Ubuntu Focal') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,10 +49,10 @@ pipeline {
       }
     }
     stage('Package') {
-      // when {
-      //   branch 'master'
-      //   beforeAgent true
-      // }
+      when {
+        branch 'master'
+        beforeAgent true
+      }
       post { failure { slackSend color: '#cb2431' , channel: '#kevm' , message: "Packaging Phase Failed: ${env.BUILD_URL}" } }
       stages {
         stage('Ubuntu Focal') {

--- a/Makefile
+++ b/Makefile
@@ -189,7 +189,7 @@ $(KEVM_INCLUDE)/kframework/lemmas/%.k: tests/specs/%.k
 	@mkdir -p $(dir $@)
 	install $< $@
 
-KOMPILE_OPTS = --debug
+KOMPILE_OPTS = --debug -I $(INSTALL_INCLUDE)/kframework -I $(INSTALL_LIB)/blockchain-k-plugin/include/kframework
 
 ifneq (,$(RELEASE))
     KOMPILE_OPTS += -O2
@@ -400,12 +400,7 @@ tests/specs/%.provex: tests/specs/% tests/specs/$$(firstword $$(subst /, ,$$*))/
 	$(KEVM) prove $< $(TEST_OPTIONS) --backend $(TEST_SYMBOLIC_BACKEND) --format-failures $(KPROVE_OPTS)        \
 	    --provex --backend-dir tests/specs/$(firstword $(subst /, ,$*))/$(KPROVE_FILE)/$(TEST_SYMBOLIC_BACKEND)
 
-.SECONDEXPANSION:
-tests/specs/%.klab-provex: tests/specs/% tests/specs/$$(firstword $$(subst /, ,$$*))/$$(KPROVE_FILE)/$(TEST_SYMBOLIC_BACKEND)/$$(KPROVE_FILE)-kompiled/timestamp
-	$(KEVM) klab-prove $< $(TEST_OPTIONS) --backend $(TEST_SYMBOLIC_BACKEND) --format-failures $(KPROVE_OPTS)   \
-	    --provex --backend-dir tests/specs/$(firstword $(subst /, ,$*))/$(KPROVE_FILE)/$(TEST_SYMBOLIC_BACKEND)
-
-tests/specs/%-kompiled/timestamp: tests/specs/$$(firstword $$(subst /, ,$$*))/$$(KPROVE_FILE).$$(KPROVE_EXT) tests/specs/$$(firstword $$(subst /, ,$$*))/concrete-rules.txt $(kevm_includes) $(plugin_includes)
+tests/specs/%-kompiled/timestamp: tests/specs/$$(firstword $$(subst /, ,$$*))/$$(KPROVE_FILE).$$(KPROVE_EXT) tests/specs/$$(firstword $$(subst /, ,$$*))/concrete-rules.txt
 	$(KOMPILE) --backend $(TEST_SYMBOLIC_BACKEND) $<                                                 \
 	    --directory tests/specs/$(firstword $(subst /, ,$*))/$(KPROVE_FILE)/$(TEST_SYMBOLIC_BACKEND) \
 	    --main-module $(KPROVE_MODULE)                                                               \
@@ -483,7 +478,8 @@ test-prove-optimizations: $(prove_optimization_tests:=.provex)
 
 test-failing-prove: $(prove_failing_tests:=.prove)
 
-test-klab-prove: $(smoke_tests_prove:=.klab-provex)
+test-klab-prove: KPROVE_OPTS += --debugger
+test-klab-prove: $(smoke_tests_prove:=.provex)
 
 # to generate optimizations.md, run: ./optimizer/optimize.sh &> output
 tests/specs/opcodes/evm-optimizations-spec.md: optimizations.md

--- a/Makefile
+++ b/Makefile
@@ -400,6 +400,11 @@ tests/specs/%.provex: tests/specs/% tests/specs/$$(firstword $$(subst /, ,$$*))/
 	$(KEVM) prove $< $(TEST_OPTIONS) --backend $(TEST_SYMBOLIC_BACKEND) --format-failures $(KPROVE_OPTS)        \
 	    --provex --backend-dir tests/specs/$(firstword $(subst /, ,$*))/$(KPROVE_FILE)/$(TEST_SYMBOLIC_BACKEND)
 
+.SECONDEXPANSION:
+tests/specs/%.klab-provex: tests/specs/% tests/specs/$$(firstword $$(subst /, ,$$*))/$$(KPROVE_FILE)/$(TEST_SYMBOLIC_BACKEND)/$$(KPROVE_FILE)-kompiled/timestamp
+	$(KEVM) klab-prove $< $(TEST_OPTIONS) --backend $(TEST_SYMBOLIC_BACKEND) --format-failures $(KPROVE_OPTS)   \
+	    --provex --backend-dir tests/specs/$(firstword $(subst /, ,$*))/$(KPROVE_FILE)/$(TEST_SYMBOLIC_BACKEND)
+
 tests/specs/%-kompiled/timestamp: tests/specs/$$(firstword $$(subst /, ,$$*))/$$(KPROVE_FILE).$$(KPROVE_EXT) tests/specs/$$(firstword $$(subst /, ,$$*))/concrete-rules.txt $(kevm_includes) $(plugin_includes)
 	$(KOMPILE) --backend $(TEST_SYMBOLIC_BACKEND) $<                                                 \
 	    --directory tests/specs/$(firstword $(subst /, ,$*))/$(KPROVE_FILE)/$(TEST_SYMBOLIC_BACKEND) \
@@ -412,9 +417,6 @@ tests/%.search: tests/%
 	$(KEVM) search $< "<statusCode> EVMC_INVALID_INSTRUCTION </statusCode>" $(TEST_OPTIONS) --backend $(TEST_SYMBOLIC_BACKEND) > $@-out
 	$(CHECK) $@-out $@-expected
 	$(KEEP_OUTPUTS) || rm -rf $@-out
-
-tests/%.klab-prove: tests/%
-	$(KEVM) klab-prove $< --verif-module $(KPROVE_MODULE) $(TEST_OPTIONS) --backend $(TEST_SYMBOLIC_BACKEND) --format-failures $(KPROVE_OPTS) --concrete-rules-file $(dir $@)concrete-rules.txt
 
 # Smoke Tests
 
@@ -481,7 +483,7 @@ test-prove-optimizations: $(prove_optimization_tests:=.provex)
 
 test-failing-prove: $(prove_failing_tests:=.prove)
 
-test-klab-prove: $(smoke_tests_prove:=.klab-prove)
+test-klab-prove: $(smoke_tests_prove:=.klab-provex)
 
 # to generate optimizations.md, run: ./optimizer/optimize.sh &> output
 tests/specs/opcodes/evm-optimizations-spec.md: optimizations.md

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ export PLUGIN_SUBMODULE
         test-vm test-rest-vm test-all-vm test-bchain test-rest-bchain test-all-bchain                                            \
         test-prove test-failing-prove                                                                                            \
         test-prove-benchmarks test-prove-functional test-prove-opcodes test-prove-erc20 test-prove-bihu test-prove-examples      \
-        test-prove-mcd test-klab-prove test-haskell-dry-run                                                                      \
+        test-prove-mcd test-klab-prove                                                                                           \
         test-parse test-failure                                                                                                  \
         test-interactive test-interactive-help test-interactive-run test-interactive-prove test-interactive-search               \
         media media-pdf metropolis-theme                                                                                         \
@@ -408,9 +408,6 @@ tests/specs/%-kompiled/timestamp: tests/specs/$$(firstword $$(subst /, ,$$*))/$$
 	    --concrete-rules-file tests/specs/$(firstword $(subst /, ,$*))/concrete-rules.txt            \
 	    $(KOMPILE_OPTS)
 
-tests/%.prove-dry-run: tests/%
-	$(KEVM) prove $< --verif-module $(KPROVE_MODULE) $(TEST_OPTIONS) --backend haskell --format-failures $(KPROVE_OPTS) --dry-run --concrete-rules-file $(dir $@)concrete-rules.txt
-
 tests/%.search: tests/%
 	$(KEVM) search $< "<statusCode> EVMC_INVALID_INSTRUCTION </statusCode>" $(TEST_OPTIONS) --backend $(TEST_SYMBOLIC_BACKEND) > $@-out
 	$(CHECK) $@-out $@-expected
@@ -489,11 +486,6 @@ test-klab-prove: $(smoke_tests_prove:=.klab-prove)
 # to generate optimizations.md, run: ./optimizer/optimize.sh &> output
 tests/specs/opcodes/evm-optimizations-spec.md: optimizations.md
 	cat $< | sed 's/^rule/claim/' | sed 's/EVM-OPTIMIZATIONS/EVM-OPTIMIZATIONS-SPEC/' | grep -v 'priority(40)' > $@
-
-haskell_dry_run_failing := $(shell cat tests/failing-symbolic.haskell-dry-run)
-haskell_dry_run         := $(filter-out $(haskell_dry_run_failing), $(wildcard $(prove_specs_dir)/*-spec.k) $(wildcard $(prove_specs_dir)/*/*-spec.k) $(wildcard $(prove_specs_dir)/*/*/*-spec.k))
-
-test-haskell-dry-run: $(haskell_dry_run:=.prove-dry-run)
 
 # Parse Tests
 

--- a/kevm
+++ b/kevm
@@ -118,7 +118,6 @@ run_prove() {
     local def_module run_dir proof_args haskell_backend_command bug_report_name eventlog_name kprove
 
     check_k_install
-    ! ${debug} || set -x
 
     bug_report_name="kevm-bug-$(basename "${run_file%-spec.k}")"
     eventlog_name="${run_file}.eventlog"
@@ -339,6 +338,7 @@ while [[ $# -gt 0 ]]; do
         *)                     args+=("$1")              ; shift   ;;
     esac
 done
+
 [[ "${#args[@]}" -le 0 ]] || set -- "${args[@]}"
 backend_dir="${backend_dir:-$INSTALL_LIB/$backend}"
 
@@ -364,6 +364,8 @@ cCHAINID_kore="\dv{SortInt{}}(\"${chainid}\")"
 cMODE_kast="\`${mode}\`(.KList)"
 cSCHEDULE_kast="\`${schedule}_EVM\`(.KList)"
 cCHAINID_kast="#token(\"${chainid}\",\"Int\")"
+
+! ${debug} || set -x
 
 case "$run_command-$backend" in
     kompile-@(java|llvm|haskell)   ) run_kompile                     "$@" ;;

--- a/kevm
+++ b/kevm
@@ -154,7 +154,7 @@ run_prove() {
                      proof_args+=( --output json                                                                   )
                  fi
                  ;;
-        *) fatal "Unknown backend for proving! ${backend}" ;;
+        *)       fatal "Unknown backend for proving! ${backend}" ;;
     esac
 
     if ${profile}; then

--- a/kevm
+++ b/kevm
@@ -115,7 +115,7 @@ run_kast() {
 }
 
 run_prove() {
-    local def_module run_dir proof_args haskell_backend_command bug_report_name eventlog_name kprove
+    local def_module run_dir proof_args haskell_backend_command bug_report_name eventlog_name kprove omit_cells omit_labels klab_log
 
     check_k_install
 
@@ -128,14 +128,34 @@ run_prove() {
     ! ${provex} || kprove=kprovex
       ${provex} || proof_args+=(--def-module "$verif_module")
 
-    haskell_backend_command=(kore-exec)
-    ! ${bug_report} || haskell_backend_command+=(--bug-report "${bug_report_name}")
-    ! ${profile}    || haskell_backend_command+=(+RTS -l -ol${eventlog_name} -RTS)
+    ! ${debug}                        || proof_args+=(--debug)
+    [[ ! -f ${concrete_rules_file} ]] || proof_args+=(--concrete-rules "$(cat ${concrete_rules_file} | tr '\n' ',')")
 
-    ! ${debug}                                 || proof_args+=(--debug)
-    ! ${debugger}                              || proof_args+=(--debugger)
-    [[ ${#haskell_backend_command[@]} -le 1 ]] || proof_args+=(--haskell-backend-command "${haskell_backend_command[*]}")
-    [[ ! -f ${concrete_rules_file} ]]          || proof_args+=(--concrete-rules "$(cat ${concrete_rules_file} | tr '\n' ',')")
+    haskell_backend_command=(kore-exec)
+
+    case "${backend}" in
+        haskell) ! ${bug_report} || haskell_backend_command+=(--bug-report "${bug_report_name}")
+                 ! ${profile}    || haskell_backend_command+=(+RTS -l -ol${eventlog_name} -RTS)
+
+                 ! ${debugger}                              || proof_args+=(--debugger)
+                 [[ ${#haskell_backend_command[@]} -le 1 ]] || proof_args+=(--haskell-backend-command "${haskell_backend_command[*]}")
+                 ;;
+
+        java)    if ${debugger}; then
+                     omit_cells='<substate> <jumpDests> <program> <code> <callGas> <touchedAccounts> <interimStates> <callStack> <callData> <block> <txOrder> <txPending> <messages>'
+                     omit_labels='#mkCall________EVM #callWithCode_________EVM #create_____EVM #mkCreate_____EVM #newAddrCreate2 #finishCodeDeposit___EVM'
+                     klab_log="$(basename "${run_file%-spec.k}").k"
+
+                     proof_args+=( --state-log --state-log-path "${KLAB_OUT}/data" --state-log-id "${klab_log}"    )
+                     proof_args+=( --state-log-events OPEN,REACHINIT,REACHTARGET,REACHPROVED,RULE,SRULE,NODE,CLOSE )
+                     proof_args+=( --output-flatten "_Map_ #And"                                                   )
+                     proof_args+=( --output-omit "${omit_cells} ${omit_labels}"                                    )
+                     proof_args+=( --no-alpha-renaming --restore-original-names --no-sort-collections              )
+                     proof_args+=( --output json                                                                   )
+                 fi
+                 ;;
+        *) fatal "Unknown backend for proving! ${backend}" ;;
+    esac
 
     if ${profile}; then
         timeout -s INT "${profile_timeout}" ${kprove} "${proof_args[@]}" "$@" || true
@@ -149,26 +169,6 @@ run_search() {
     local search_pattern
     search_pattern="$1" ; shift
     run_krun --search --pattern "$search_pattern" "$@"
-}
-
-run_klab() {
-    local run_mode klab_log def_module omit_cells omit_labels
-
-    run_mode="$1" ; shift
-    klab_log="$(basename "${run_file%-spec.k}").k"
-
-    omit_cells='<substate> <jumpDests> <program> <code> <callGas> <touchedAccounts> <interimStates> <callStack> <callData> <block> <txOrder> <txPending> <messages>'
-    omit_labels='#mkCall________EVM #callWithCode_________EVM #create_____EVM #mkCreate_____EVM #newAddrCreate2 #finishCodeDeposit___EVM'
-
-    "$0" "${run_mode}" --backend java "${run_file}" --verif-module "${verif_module}"    \
-        --concrete-rules-file "${concrete_rules_file}"                                  \
-        --state-log --state-log-path "${KLAB_OUT}/data" --state-log-id "${klab_log}"    \
-        --state-log-events OPEN,REACHINIT,REACHTARGET,REACHPROVED,RULE,SRULE,NODE,CLOSE \
-        --output-flatten "_Map_ #And"                                                   \
-        --output-omit "${omit_cells} ${omit_labels}"                                    \
-        --no-alpha-renaming --restore-original-names --no-sort-collections              \
-        --output json                                                                   \
-        "$@"
 }
 
 view_klab() {
@@ -244,8 +244,6 @@ if [[ "$run_command" == 'help' ]] || [[ "$run_command" == '--help' ]] ; then
                $0 prove        [--backend (java|haskell)]                            <spec> <KEVM_arg>* <K arg>*
                $0 search       [--backend (java|haskell)]                            <pgm>  <pattern> <K arg>*
                $0 kompile      [--backend (java|llvm|haskell)]                       <main> <K arg>*
-               $0 klab-run                                                           <pgm>  <K arg>*
-               $0 klab-prove                                                         <spec> <def_module> <K arg>*
                $0 klab-view                                                          <spec>
 
                $0 [help|--help|version|--version]
@@ -256,7 +254,6 @@ if [[ "$run_command" == 'help' ]] || [[ "$run_command" == '--help' ]] ; then
            $0 prove     : Run an EVM K proof
            $0 search    : Search for a K pattern in an EVM program execution
            $0 kompile   : Run kompile with arguments setup to include KEVM parameters as defaults
-           $0 klab-(run|prove) : Run program or prove spec and dump StateLogs which KLab can read
            $0 klab-view : View the statelog associated with a given program or spec
 
            $0 help    : Display this help message.
@@ -342,7 +339,6 @@ done
 [[ "${#args[@]}" -le 0 ]] || set -- "${args[@]}"
 backend_dir="${backend_dir:-$INSTALL_LIB/$backend}"
 
-! $debugger || [[ "$backend" == haskell ]] || [[ "$backend" == llvm ]] || fatal "Option --debugger only usable with --backend [llvm|haskell]!"
 ! $profile  || [[ "$backend" == haskell ]] || fatal "Option --profile only usable with --backend haskell!"
 [[ $profile_timeout = "0" ]] || $profile   || fatal "Option --profile-timeout only usable with --profile!"
 [[ $kore_prof_args = "" ]]   || $profile   || fatal "Option --kore-prof-args only usable with --profile!"
@@ -368,13 +364,12 @@ cCHAINID_kast="#token(\"${chainid}\",\"Int\")"
 ! ${debug} || set -x
 
 case "$run_command-$backend" in
-    kompile-@(java|llvm|haskell)   ) run_kompile                     "$@" ;;
-    run-@(java|llvm|haskell)       ) run_krun                        "$@" ;;
-    kast-@(java|llvm|haskell)      ) run_kast                        "$@" ;;
-    interpret-@(llvm|haskell|java) ) run_interpret                   "$@" ;;
-    prove-@(java|haskell)          ) run_prove                       "$@" ;;
-    search-@(java|haskell)         ) run_search                      "$@" ;;
-    klab-@(run|prove)-java         ) run_klab "${run_command#klab-}" "$@" ;;
-    klab-view-java                 ) view_klab                       "$@" ;;
+    kompile-@(java|llvm|haskell)   ) run_kompile   "$@" ;;
+    run-@(java|llvm|haskell)       ) run_krun      "$@" ;;
+    kast-@(java|llvm|haskell)      ) run_kast      "$@" ;;
+    interpret-@(llvm|haskell|java) ) run_interpret "$@" ;;
+    prove-@(java|haskell)          ) run_prove     "$@" ;;
+    search-@(java|haskell)         ) run_search    "$@" ;;
+    klab-view-java                 ) view_klab     "$@" ;;
     *) $0 help ; fatal "Unknown command on backend: $run_command $backend" ;;
 esac


### PR DESCRIPTION
Release builds were not including `-I /usr/lib/kevm/include/kframework` in their builds, which leads to the release failing for non-provex definitions.

- Option `--debugger` is now used to enable the Java backend debugging capabilities too, instead of having a separate function.
- `Makefile` adds `-I $(INSTALL_INCLUDE)/kframework` and similarly for the blockchain-k-plugin to every build.

