### PR TITLE
Integer equality simplification for Haskell backend

### DIFF
--- a/tests/failing-symbolic.haskell
+++ b/tests/failing-symbolic.haskell
@@ -33,11 +33,8 @@ tests/specs/mcd/vat-fold-pass-rough-spec.k
 tests/specs/mcd/vat-fork-diff-pass-rough-spec.k
 tests/specs/mcd/vat-frob-diff-zero-dart-pass-rough-spec.k
 tests/specs/mcd/vat-move-diff-rough-spec.k
-tests/specs/mcd/vat-mului-pass-spec.k
 tests/specs/mcd/vat-slip-pass-rough-spec.k
 tests/specs/mcd/vat-subui-fail-rough-spec.k
-tests/specs/mcd/vat-subui-pass-rough-spec.k
-tests/specs/mcd/vat-subui-pass-spec.k
 tests/specs/mcd/vow-cage-deficit-pass-rough-spec.k
 tests/specs/mcd/vow-cage-surplus-pass-rough-spec.k
 tests/specs/mcd/vow-fess-fail-rough-spec.k

--- a/tests/specs/mcd/verification.k
+++ b/tests/specs/mcd/verification.k
@@ -83,6 +83,11 @@ module LEMMAS-MCD-HASKELL [symbolic, kore]
        andBool #rangeUInt(48, Y)
        andBool notBool #rangeUInt(48, X +Int Y) [simplification]
 
+    rule sgn(chop(X)) ==Int  1 => 0 <=Int X requires #rangeSInt(256, X) [simplification]
+    rule sgn(chop(X)) ==Int -1 => X  <Int 0 requires #rangeSInt(256, X) [simplification]
+
+    rule chop(X) ==Int 0 => X ==Int 0 requires #rangeSInt(256, X) [simplification]
+
   // ########################
   // Map
   // ########################
@@ -104,6 +109,11 @@ module LEMMAS-MCD-JAVA [symbolic, kast]
       requires #rangeUInt(48, X)
        andBool #rangeUInt(48, Y)
        andBool notBool #rangeUInt(48, X +Int Y) [simplification]
+
+    rule sgn(chop(X)) ==K  1 => 0 <=Int X requires #rangeSInt(256, X) [simplification]
+    rule sgn(chop(X)) ==K -1 => X  <Int 0 requires #rangeSInt(256, X) [simplification]
+
+    rule chop(X) ==K 0 => X ==K 0 requires #rangeSInt(256, X) [simplification]
 
   // ########################
   // Range
@@ -291,8 +301,6 @@ module LEMMAS-MCD-COMMON
     // Note that this case comes from a solidity struct being accessed (hence the integer offsets), so it's an assumption built into the Solidity compiler anyway.
     rule chop(keccak(BA) +Int N) => keccak(BA) +Int N requires 0 <=Int N andBool N <Int 6 [simplification]
 
-    rule sgn(chop(X)) ==Int -1 => X <Int 0  requires #rangeSInt(256, X) [simplification]
-
     rule chop(X *Int chop(Y)) => chop(X *Int Y) [simplification]
 
     // Proof #rangeUInt(256, X) andBool #rangeSInt(256, Y) andBool #rangeSInt(256, X *Int Y) andBool Y =/=Int 0
@@ -384,15 +392,6 @@ module LEMMAS-MCD-COMMON
       requires #rangeUInt(48, X)
        andBool #rangeUInt(48, Y)
        andBool notBool (X +Int Y <Int pow48) [simplification]
-
-    // Via Z3 4.7.1:
-    // (push)
-    // (assert (not (=> (sint256 y) (= (= (sgn (chop y)) 1) (<= 0 y) ) ) ))
-    // (check-sat)
-    // (pop)
-    rule sgn(chop(Y)) ==K 1 => 0 <=Int Y requires #rangeSInt(256, Y) [simplification]
-
-    rule chop(X) ==K 0 => X ==Int 0 requires #rangeSInt(256, X) [simplification]
 
     rule 0 <=Int X |Int Y => true requires 0 <=Int X andBool 0 <=Int Y [simplification]
     rule 0 <=Int X &Int Y => true requires 0 <=Int X andBool 0 <=Int Y [simplification]


### PR DESCRIPTION
The Java bcakend normalizes terms to use `==K`, and the Haskell backend uses the more specific `==Int`. So semantic rules simplifying out equalities need to be specific per backend.