### PR TITLE
Build provex definitions ahead of time, fix optimizer

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,7 @@ pipeline {
         }
       }
       stages {
-        stage('Build') { steps { sh 'make build RELEASE=true -j6' } }
+        stage('Build') { steps { sh 'make build build-provex RELEASE=true -j6' } }
         stage('Test') {
           failFast true
           options { timeout(time: 120, unit: 'MINUTES') }

--- a/Makefile
+++ b/Makefile
@@ -400,7 +400,7 @@ tests/specs/%.provex: tests/specs/% tests/specs/$$(firstword $$(subst /, ,$$*))/
 	$(KEVM) prove $< $(TEST_OPTIONS) --backend $(TEST_SYMBOLIC_BACKEND) --format-failures $(KPROVE_OPTS)        \
 	    --provex --backend-dir tests/specs/$(firstword $(subst /, ,$*))/$(KPROVE_FILE)/$(TEST_SYMBOLIC_BACKEND)
 
-tests/specs/%-kompiled/timestamp: tests/specs/$$(firstword $$(subst /, ,$$*))/$$(KPROVE_FILE).$$(KPROVE_EXT) tests/specs/$$(firstword $$(subst /, ,$$*))/concrete-rules.txt
+tests/specs/%-kompiled/timestamp: tests/specs/$$(firstword $$(subst /, ,$$*))/$$(KPROVE_FILE).$$(KPROVE_EXT) tests/specs/$$(firstword $$(subst /, ,$$*))/concrete-rules.txt $(kevm_includes) $(lemma_includes) $(plugin_includes) 
 	$(KOMPILE) --backend $(word 3, $(subst /, , $*)) $<                                                 \
 	    --directory tests/specs/$(firstword $(subst /, ,$*))/$(KPROVE_FILE)/$(word 3, $(subst /, , $*)) \
 	    --main-module $(KPROVE_MODULE)                                                                  \

--- a/Makefile
+++ b/Makefile
@@ -495,7 +495,7 @@ provex_definitions :=                                                           
                       tests/specs/mcd/verification/java/verification-kompiled/timestamp                            \
                       tests/specs/opcodes/evm-optimizations-spec/haskell/evm-optimizations-spec-kompiled/timestamp \
                       tests/specs/opcodes/verification/java/verification-kompiled/timestamp
-build-provex:  $(provex_definitions)
+build-provex: $(provex_definitions)
 
 test-prove: test-prove-benchmarks test-prove-functional test-prove-opcodes test-prove-erc20 test-prove-bihu test-prove-examples test-prove-mcd test-prove-optimizations
 test-prove-benchmarks:    $(prove_benchmarks_tests:=.provex)

--- a/Makefile
+++ b/Makefile
@@ -468,7 +468,7 @@ prove_optimization_tests := $(filter-out $(prove_failing_tests), tests/specs/opc
 
 ## best-effort list of provex kompiled definitions to produce ahead of time
 provex_definitions :=                                                                                              \
-                      tests/specs/benchmarks/functional-spec/haskell/functional-kompiled/timestamp                 \
+                      tests/specs/benchmarks/functional-spec/haskell/functional-spec-kompiled/timestamp            \
                       tests/specs/benchmarks/functional-spec/java/functional-spec-kompiled/timestamp               \
                       tests/specs/benchmarks/verification/haskell/verification-kompiled/timestamp                  \
                       tests/specs/benchmarks/verification/java/verification-kompiled/timestamp                     \
@@ -480,15 +480,15 @@ provex_definitions :=                                                           
                       tests/specs/erc20/verification/java/verification-kompiled/timestamp                          \
                       tests/specs/examples/solidity-code-spec/haskell/solidity-code-spec-kompiled/timestamp        \
                       tests/specs/examples/solidity-code-spec/java/solidity-code-spec-kompiled/timestamp           \
-                      tests/specs/examples/sum-to-n-spec/haskell/sum-kompiled/timestamp                            \
+                      tests/specs/examples/sum-to-n-spec/haskell/sum-to-n-spec-kompiled/timestamp                  \
                       tests/specs/examples/sum-to-n-spec/java/sum-to-n-spec-kompiled/timestamp                     \
                       tests/specs/functional/infinite-gas-spec/haskell/infinite-gas-spec-kompiled/timestamp        \
-                      tests/specs/functional/lemmas-no-smt-spec/haskell/lemmas-kompiled/timestamp                  \
+                      tests/specs/functional/lemmas-no-smt-spec/haskell/lemmas-no-smt-spec-kompiled/timestamp      \
                       tests/specs/functional/lemmas-no-smt-spec/java/lemmas-no-smt-spec-kompiled/timestamp         \
-                      tests/specs/functional/lemmas-spec/haskell/lemmas-kompiled/timestamp                         \
+                      tests/specs/functional/lemmas-spec/haskell/lemmas-spec-kompiled/timestamp                    \
                       tests/specs/functional/lemmas-spec/java/lemmas-spec-kompiled/timestamp                       \
-                      tests/specs/functional/merkle-spec/haskell/merkle-kompiled/timestamp                         \
-                      tests/specs/functional/storageRoot-spec/haskell/storageRoot-kompiled/timestamp               \
+                      tests/specs/functional/merkle-spec/haskell/merkle-spec-kompiled/timestamp                    \
+                      tests/specs/functional/storageRoot-spec/haskell/storageRoot-spec-kompiled/timestamp          \
                       tests/specs/mcd/functional-spec/haskell/functional-spec-kompiled/timestamp                   \
                       tests/specs/mcd/functional-spec/java/functional-spec-kompiled/timestamp                      \
                       tests/specs/mcd/verification/haskell/verification-kompiled/timestamp                         \

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ export PLUGIN_SUBMODULE
 
 .PHONY: all clean distclean                                                                                                      \
         deps k-deps plugin-deps libsecp256k1 libff                                                                               \
-        build build-java build-haskell build-llvm                                                                                \
+        build build-java build-haskell build-llvm build-provex                                                                   \
         test test-all test-conformance test-rest-conformance test-all-conformance test-slow-conformance test-failing-conformance \
         test-vm test-rest-vm test-all-vm test-bchain test-rest-bchain test-all-bchain                                            \
         test-prove test-failing-prove                                                                                            \
@@ -401,11 +401,11 @@ tests/specs/%.provex: tests/specs/% tests/specs/$$(firstword $$(subst /, ,$$*))/
 	    --provex --backend-dir tests/specs/$(firstword $(subst /, ,$*))/$(KPROVE_FILE)/$(TEST_SYMBOLIC_BACKEND)
 
 tests/specs/%-kompiled/timestamp: tests/specs/$$(firstword $$(subst /, ,$$*))/$$(KPROVE_FILE).$$(KPROVE_EXT) tests/specs/$$(firstword $$(subst /, ,$$*))/concrete-rules.txt
-	$(KOMPILE) --backend $(TEST_SYMBOLIC_BACKEND) $<                                                 \
-	    --directory tests/specs/$(firstword $(subst /, ,$*))/$(KPROVE_FILE)/$(TEST_SYMBOLIC_BACKEND) \
-	    --main-module $(KPROVE_MODULE)                                                               \
-	    --syntax-module $(KPROVE_MODULE)                                                             \
-	    --concrete-rules-file tests/specs/$(firstword $(subst /, ,$*))/concrete-rules.txt            \
+	$(KOMPILE) --backend $(word 3, $(subst /, , $*)) $<                                                 \
+	    --directory tests/specs/$(firstword $(subst /, ,$*))/$(KPROVE_FILE)/$(word 3, $(subst /, , $*)) \
+	    --main-module $(KPROVE_MODULE)                                                                  \
+	    --syntax-module $(KPROVE_MODULE)                                                                \
+	    --concrete-rules-file tests/specs/$(firstword $(subst /, ,$*))/concrete-rules.txt               \
 	    $(KOMPILE_OPTS)
 
 tests/%.search: tests/%
@@ -465,6 +465,37 @@ prove_bihu_tests         := $(filter-out $(prove_failing_tests), $(wildcard $(pr
 prove_examples_tests     := $(filter-out $(prove_failing_tests), $(wildcard $(prove_specs_dir)/examples/*-spec.k) $(wildcard $(prove_specs_dir)/examples/*-spec.md))
 prove_mcd_tests          := $(filter-out $(prove_failing_tests), $(wildcard $(prove_specs_dir)/mcd/*-spec.k))
 prove_optimization_tests := $(filter-out $(prove_failing_tests), tests/specs/opcodes/evm-optimizations-spec.md)
+
+## best-effort list of provex kompiled definitions to produce ahead of time
+provex_definitions :=                                                                                              \
+                      tests/specs/benchmarks/functional-spec/haskell/functional-kompiled/timestamp                 \
+                      tests/specs/benchmarks/functional-spec/java/functional-spec-kompiled/timestamp               \
+                      tests/specs/benchmarks/verification/haskell/verification-kompiled/timestamp                  \
+                      tests/specs/benchmarks/verification/java/verification-kompiled/timestamp                     \
+                      tests/specs/bihu/functional-spec/haskell/functional-spec-kompiled/timestamp                  \
+                      tests/specs/bihu/functional-spec/java/functional-spec-kompiled/timestamp                     \
+                      tests/specs/bihu/verification/haskell/verification-kompiled/timestamp                        \
+                      tests/specs/bihu/verification/java/verification-kompiled/timestamp                           \
+                      tests/specs/erc20/verification/haskell/verification-kompiled/timestamp                       \
+                      tests/specs/erc20/verification/java/verification-kompiled/timestamp                          \
+                      tests/specs/examples/solidity-code-spec/haskell/solidity-code-spec-kompiled/timestamp        \
+                      tests/specs/examples/solidity-code-spec/java/solidity-code-spec-kompiled/timestamp           \
+                      tests/specs/examples/sum-to-n-spec/haskell/sum-kompiled/timestamp                            \
+                      tests/specs/examples/sum-to-n-spec/java/sum-to-n-spec-kompiled/timestamp                     \
+                      tests/specs/functional/infinite-gas-spec/haskell/infinite-gas-spec-kompiled/timestamp        \
+                      tests/specs/functional/lemmas-no-smt-spec/haskell/lemmas-kompiled/timestamp                  \
+                      tests/specs/functional/lemmas-no-smt-spec/java/lemmas-no-smt-spec-kompiled/timestamp         \
+                      tests/specs/functional/lemmas-spec/haskell/lemmas-kompiled/timestamp                         \
+                      tests/specs/functional/lemmas-spec/java/lemmas-spec-kompiled/timestamp                       \
+                      tests/specs/functional/merkle-spec/haskell/merkle-kompiled/timestamp                         \
+                      tests/specs/functional/storageRoot-spec/haskell/storageRoot-kompiled/timestamp               \
+                      tests/specs/mcd/functional-spec/haskell/functional-spec-kompiled/timestamp                   \
+                      tests/specs/mcd/functional-spec/java/functional-spec-kompiled/timestamp                      \
+                      tests/specs/mcd/verification/haskell/verification-kompiled/timestamp                         \
+                      tests/specs/mcd/verification/java/verification-kompiled/timestamp                            \
+                      tests/specs/opcodes/evm-optimizations-spec/haskell/evm-optimizations-spec-kompiled/timestamp \
+                      tests/specs/opcodes/verification/java/verification-kompiled/timestamp
+build-provex:  $(provex_definitions)
 
 test-prove: test-prove-benchmarks test-prove-functional test-prove-opcodes test-prove-erc20 test-prove-bihu test-prove-examples test-prove-mcd test-prove-optimizations
 test-prove-benchmarks:    $(prove_benchmarks_tests:=.provex)

--- a/optimizer/optimize-spec.k.tmpl
+++ b/optimizer/optimize-spec.k.tmpl
@@ -1,9 +1,10 @@
-requires "lemmas/mcd/verification.k"
+requires "lemmas/infinite-gas.k"
 
 module OPTIMIZE
     imports INT
-    imports LEMMAS-MCD
+    imports EVM-OPTIMIZATIONS-LEMMAS
     imports EVM
+    imports INFINITE-GAS
 endmodule
 
 module {MODULE}-SPEC

--- a/optimizer/optimize.sh
+++ b/optimizer/optimize.sh
@@ -84,7 +84,7 @@ doOptimization() {
     rule_file="optimizer/${opcode_lower}.k"
     optimize_file="optimizer/optimize-spec.k"
 
-    make build-haskell build-lemmas -j8
+    make build-haskell -j8
 
     notif "Building: ${spec_file}"
     buildSpec "${opcode}" "${wordstack_number}" "$@" > "${spec_file}"

--- a/optimizer/optimize.sh
+++ b/optimizer/optimize.sh
@@ -102,11 +102,10 @@ doOptimization() {
     echo                                                                    >> "${rule_file}"
 
     notif "Building: ${optimize_file}"
-    echo 'requires "lemmas/mcd/verification.k"'  > "${optimize_file}"
     echo ''                                     >> "${optimize_file}"
     echo 'module OPTIMIZE'                      >> "${optimize_file}"
     echo '    imports INT'                      >> "${optimize_file}"
-    echo '    imports LEMMAS-MCD'               >> "${optimize_file}"
+    echo '    imports EVM-OPTIMIZATIONS-LEMMAS' >> "${optimize_file}"
     echo '    imports EVM'                      >> "${optimize_file}"
     echo 'endmodule'                            >> "${optimize_file}"
     echo ''                                     >> "${optimize_file}"

--- a/optimizer/optimize.sh
+++ b/optimizer/optimize.sh
@@ -102,7 +102,7 @@ doOptimization() {
     echo                                                                    >> "${rule_file}"
 
     notif "Building: ${optimize_file}"
-    echo ''                                     >> "${optimize_file}"
+    echo ''                                      > "${optimize_file}"
     echo 'module OPTIMIZE'                      >> "${optimize_file}"
     echo '    imports INT'                      >> "${optimize_file}"
     echo '    imports EVM-OPTIMIZATIONS-LEMMAS' >> "${optimize_file}"

--- a/optimizer/optimize.sh
+++ b/optimizer/optimize.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 export PATH=$(pwd)/.build/usr/bin:$PATH
 export PYTHONPATH=$(pwd)/.build/usr/lib/kevm/kframework/lib/kframework
 
-kevm_json_defn=$(pwd)/.build/usr/lib/kevm/llvm/driver-kompiled/compiled.json
+kevm_json_defn=$(pwd)/.build/usr/lib/kevm/haskell/driver-kompiled/compiled.json
 
 notif() { echo "$@" >&2 ; }
 
@@ -66,7 +66,7 @@ runProve() {
 
     spec="$1" ; shift
 
-    kevm prove --backend haskell ${spec} OPTIMIZE --concrete-rules-file tests/specs/mcd/concrete-rules.txt "$@"
+    kevm prove --backend haskell ${spec} --verif-module OPTIMIZE --concrete-rules-file tests/specs/concrete-rules.txt "$@"
 }
 
 doOptimization() {


### PR DESCRIPTION
This PR adds a "best-effort" build-provex target which is called ahead of time to remove the build stage from the prove stage in Jenkins. It will not fail if a definition is missing, that definition will just be built at prove time instead. So if we add more proofs, we can notice the problem and fix it "lazily".

This PR also makes some minor adjustments to the `optimizer/` to make it work with the new way of running proofs in this repo.