### PR TITLE
Add `--pyk-minimize` option for `kevm prove`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -393,7 +393,8 @@ tests/%.parse: tests/%
 	$(KEEP_OUTPUTS) || rm -rf $@-out
 
 tests/%.prove: tests/%
-	$(KEVM) prove $< --verif-module $(KPROVE_MODULE) $(TEST_OPTIONS) --backend $(TEST_SYMBOLIC_BACKEND) --format-failures $(KPROVE_OPTS) --concrete-rules-file $(dir $@)concrete-rules.txt
+	$(KEVM) prove $< --verif-module $(KPROVE_MODULE) $(TEST_OPTIONS) --backend $(TEST_SYMBOLIC_BACKEND) \
+	    --format-failures $(KPROVE_OPTS) --concrete-rules-file $(dir $@)concrete-rules.txt
 
 .SECONDEXPANSION:
 tests/specs/%.provex: tests/specs/% tests/specs/$$(firstword $$(subst /, ,$$*))/$$(KPROVE_FILE)/$(TEST_SYMBOLIC_BACKEND)/$$(KPROVE_FILE)-kompiled/timestamp

--- a/kevm
+++ b/kevm
@@ -343,7 +343,7 @@ while [[ $# -gt 0 ]]; do
         --provex)              provex=true               ; shift   ;;
         --verif-module)        verif_module="$2"         ; shift 2 ;;
         --pyk-minimize)        pyk_minimize=true         ; shift   ;;
-        --pyk-omit-labels)     pyk_omit_labels="$2"       ; shift 2 ;;
+        --pyk-omit-labels)     pyk_omit_labels="$2"      ; shift 2 ;;
         --max-counterexamples) max_counterexamples="$2"  ; shift 2 ;;
         --mode)                mode="$2"                 ; shift 2 ;;
         --schedule)            schedule="$2"             ; shift 2 ;;

--- a/kevm
+++ b/kevm
@@ -116,7 +116,7 @@ run_kast() {
 
 run_prove() {
     local def_module run_dir proof_args haskell_backend_command bug_report_name \
-          eventlog_name kprove omit_cells omit_labels klab_log
+          eventlog_name kprove omit_cells omit_labels klab_log pyk_args
 
     check_k_install
 
@@ -165,7 +165,9 @@ run_prove() {
         kore-prof "${eventlog_name}" ${kore_prof_args} > "${eventlog_name}.json"
     else
         if ${pyk_minimize}; then
-            ${kprove} "${proof_args[@]}" "$@" --output json | kpyk ${backend_dir}/*-kompiled minimize /dev/stdin
+            pyk_args=(${backend_dir}/*-kompiled minimize /dev/stdin)
+            [[ -z "${pyk_omit_labels}" ]] || pyk_args+=(--omit-labels "${pyk_omit_labels}")
+            ${kprove} "${proof_args[@]}" "$@" --output json | kpyk "${pyk_args[@]}"
         else
             ${kprove} "${proof_args[@]}" "$@"
         fi
@@ -279,6 +281,9 @@ if [[ "$run_command" == 'help' ]] || [[ "$run_command" == '--help' ]] ; then
                                       [--kore-prof-args \"<kore-prof arg>*\"]
                                       [--provex]
                                       [--verif-module <verification_module>]
+                                      [--pyk-minimize]
+                                      [--pyk-omit-labels <comma_separated_labels>]
+                                      [--max-counterexamples <number_counterexamples>]
                  <K arg> is an argument you want to pass to K.
                  <interpreter arg> is an argument you want to pass to the derived interpreter.
                  <kore-prof arg> is an argument you want to pass to kore-prof.
@@ -314,6 +319,7 @@ concrete_rules_file=
 provex=false
 verif_module=VERIFICATION
 pyk_minimize=false
+pyk_omit_labels=
 max_counterexamples=
 [[ ! "$run_command" == 'prove' ]] || backend='java'
 [[ ! "$run_command" =~ klab*   ]] || backend='java'
@@ -337,6 +343,7 @@ while [[ $# -gt 0 ]]; do
         --provex)              provex=true               ; shift   ;;
         --verif-module)        verif_module="$2"         ; shift 2 ;;
         --pyk-minimize)        pyk_minimize=true         ; shift   ;;
+        --pyk-omit-labels)     pyk_omit_labels="$2"       ; shift 2 ;;
         --max-counterexamples) max_counterexamples="$2"  ; shift 2 ;;
         --mode)                mode="$2"                 ; shift 2 ;;
         --schedule)            schedule="$2"             ; shift 2 ;;
@@ -356,6 +363,8 @@ backend_dir="${backend_dir:-$INSTALL_LIB/$backend}"
 if ${pyk_minimize}; then
     ! ${debugger} || fatal "Option --pyk-minimize not usable with --debugger!"
     ! ${profile}  || fatal "Option --pyk-minimize not usable with --profile!"
+elif [[ ! -z ${pyk_omit_labels} ]]; then
+    fatal "Option --pyk-label-omit only usable with --pyk-minimize!"
 fi
 
 # get the run file

--- a/kevm
+++ b/kevm
@@ -115,7 +115,8 @@ run_kast() {
 }
 
 run_prove() {
-    local def_module run_dir proof_args haskell_backend_command bug_report_name eventlog_name kprove omit_cells omit_labels klab_log
+    local def_module run_dir proof_args haskell_backend_command bug_report_name \
+          eventlog_name kprove omit_cells omit_labels klab_log
 
     check_k_install
 
@@ -161,7 +162,11 @@ run_prove() {
         timeout -s INT "${profile_timeout}" ${kprove} "${proof_args[@]}" "$@" || true
         kore-prof "${eventlog_name}" ${kore_prof_args} > "${eventlog_name}.json"
     else
-        ${kprove} "${proof_args[@]}" "$@"
+        if ${pyk_minimize}; then
+            ${kprove} "${proof_args[@]}" "$@" --output json | kpyk ${backend_dir}/*-kompiled minimize /dev/stdin
+        else
+            ${kprove} "${proof_args[@]}" "$@"
+        fi
     fi
 }
 
@@ -306,6 +311,7 @@ chainid=1
 concrete_rules_file=
 provex=false
 verif_module=VERIFICATION
+pyk_minimize=false
 [[ ! "$run_command" == 'prove' ]] || backend='java'
 [[ ! "$run_command" =~ klab*   ]] || backend='java'
 kevm_port='8545'
@@ -327,6 +333,7 @@ while [[ $# -gt 0 ]]; do
         --concrete-rules-file) concrete_rules_file="$2"  ; shift 2 ;;
         --provex)              provex=true               ; shift   ;;
         --verif-module)        verif_module="$2"         ; shift 2 ;;
+        --pyk-minimize)        pyk_minimize=true         ; shift   ;;
         --mode)                mode="$2"                 ; shift 2 ;;
         --schedule)            schedule="$2"             ; shift 2 ;;
         --chainid)             chainid="$2"              ; shift 2 ;;
@@ -339,9 +346,13 @@ done
 [[ "${#args[@]}" -le 0 ]] || set -- "${args[@]}"
 backend_dir="${backend_dir:-$INSTALL_LIB/$backend}"
 
-! $profile  || [[ "$backend" == haskell ]] || fatal "Option --profile only usable with --backend haskell!"
-[[ $profile_timeout = "0" ]] || $profile   || fatal "Option --profile-timeout only usable with --profile!"
-[[ $kore_prof_args = "" ]]   || $profile   || fatal "Option --kore-prof-args only usable with --profile!"
+! $profile  || [[ "$backend" == haskell ]]         || fatal "Option --profile only usable with --backend haskell!"
+[[ $profile_timeout = "0" ]] || $profile           || fatal "Option --profile-timeout only usable with --profile!"
+[[ $kore_prof_args = "" ]]   || $profile           || fatal "Option --kore-prof-args only usable with --profile!"
+if ${pyk_minimize}; then
+    ! ${debugger} || fatal "Option --pyk-minimize not usable with --debugger!"
+    ! ${profile}  || fatal "Option --pyk-minimize not usable with --profile!"
+fi
 
 # get the run file
 run_file="$1" ; shift

--- a/kevm
+++ b/kevm
@@ -136,8 +136,9 @@ run_prove() {
     haskell_backend_command=(kore-exec)
 
     case "${backend}" in
-        haskell) ! ${bug_report} || haskell_backend_command+=(--bug-report "${bug_report_name}")
-                 ! ${profile}    || haskell_backend_command+=(+RTS -l -ol${eventlog_name} -RTS)
+        haskell) ! ${bug_report}                 || haskell_backend_command+=(--bug-report "${bug_report_name}")
+                 ! ${profile}                    || haskell_backend_command+=(+RTS -l -ol${eventlog_name} -RTS)
+                 [[ -z ${max_counterexamples} ]] || haskell_backend_command+=(--max-counterexamples ${max_counterexamples})
 
                  ! ${debugger}                              || proof_args+=(--debugger)
                  [[ ${#haskell_backend_command[@]} -le 1 ]] || proof_args+=(--haskell-backend-command "${haskell_backend_command[*]}")
@@ -313,6 +314,7 @@ concrete_rules_file=
 provex=false
 verif_module=VERIFICATION
 pyk_minimize=false
+max_counterexamples=
 [[ ! "$run_command" == 'prove' ]] || backend='java'
 [[ ! "$run_command" =~ klab*   ]] || backend='java'
 kevm_port='8545'
@@ -335,6 +337,7 @@ while [[ $# -gt 0 ]]; do
         --provex)              provex=true               ; shift   ;;
         --verif-module)        verif_module="$2"         ; shift 2 ;;
         --pyk-minimize)        pyk_minimize=true         ; shift   ;;
+        --max-counterexamples) max_counterexamples="$2"  ; shift 2 ;;
         --mode)                mode="$2"                 ; shift 2 ;;
         --schedule)            schedule="$2"             ; shift 2 ;;
         --chainid)             chainid="$2"              ; shift 2 ;;


### PR DESCRIPTION
This enables using the `kpyk minimize` command to print out smaller configurations (with useless parts abstracted) in the final state printed by the haskell backend.

Blocked on: https://github.com/kframework/k/pull/2199

Additional options supported:

- `--max-counterexamples N`: tell the haskell backend to supply more conuterexamples than the first one it finds.
- `--pyk-minimize`: filter the output through `kpyk minimize`, which is used for abstracting away uninteresting parts of the configuration.
- `--pyk-omit-labels LABELS_LIST`: list of labels to not include in the output of the kpyk minimizer.