### PR TITLE
Jenkinsfile: make sure we only run on big nodes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 pipeline {
-  agent { label 'docker' }
+  agent { label 'docker && big' }
   environment {
     GITHUB_TOKEN     = credentials('rv-jenkins-access-token')
     VERSION          = '1.0.1'


### PR DESCRIPTION
CI was timing out when this was running on rvwork-2 or rvwork-3, so we will just limit this job to only happen on "big" nodes (rvwork-5 and rvwork-6).