### PR TITLE
More ergonomic interaction with provex/haskell backend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -337,7 +337,7 @@ build-haskell: $(KEVM_LIB)/$(haskell_kompiled) $(KEVM_LIB)/kore-json.py $(lemma_
 build-llvm:    $(KEVM_LIB)/$(llvm_kompiled)    $(KEVM_LIB)/kore-json.py
 build-java:    $(KEVM_LIB)/$(java_kompiled)    $(KEVM_LIB)/kast-json.py $(lemma_includes)
 build-node:    $(KEVM_LIB)/$(node_kompiled)
-build-kevm:    $(KEVM_BIN)/kevm
+build-kevm:    $(KEVM_BIN)/kevm $(kevm_includes) $(lemma_includes)
 
 all_bin_sources := $(shell find $(KEVM_BIN) -type f | sed 's|^$(KEVM_BIN)/||')
 all_lib_sources := $(shell find $(KEVM_LIB) -type f                                            \

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ export PLUGIN_SUBMODULE
 
 .PHONY: all clean distclean                                                                                                      \
         deps k-deps plugin-deps libsecp256k1 libff protobuf                                                                      \
-        build build-java build-haskell build-llvm build-provex build-node                                                        \
+        build build-java build-haskell build-llvm build-provex build-node build-kevm                                             \
         test test-all test-conformance test-rest-conformance test-all-conformance test-slow-conformance test-failing-conformance \
         test-vm test-rest-vm test-all-vm test-bchain test-rest-bchain test-all-bchain test-kevm-vm                               \
         test-prove test-failing-prove                                                                                            \
@@ -337,6 +337,7 @@ build-haskell: $(KEVM_LIB)/$(haskell_kompiled) $(KEVM_LIB)/kore-json.py $(lemma_
 build-llvm:    $(KEVM_LIB)/$(llvm_kompiled)    $(KEVM_LIB)/kore-json.py
 build-java:    $(KEVM_LIB)/$(java_kompiled)    $(KEVM_LIB)/kast-json.py $(lemma_includes)
 build-node:    $(KEVM_LIB)/$(node_kompiled)
+build-kevm:    $(KEVM_BIN)/kevm
 
 all_bin_sources := $(shell find $(KEVM_BIN) -type f | sed 's|^$(KEVM_BIN)/||')
 all_lib_sources := $(shell find $(KEVM_LIB) -type f                                            \

--- a/Makefile
+++ b/Makefile
@@ -444,7 +444,7 @@ tests/specs/%.provex: tests/specs/% tests/specs/$$(firstword $$(subst /, ,$$*))/
 	$(KEVM) prove $< $(TEST_OPTIONS) --backend $(TEST_SYMBOLIC_BACKEND) --format-failures $(KPROVE_OPTS)        \
 	    --provex --backend-dir tests/specs/$(firstword $(subst /, ,$*))/$(KPROVE_FILE)/$(TEST_SYMBOLIC_BACKEND)
 
-tests/specs/%-kompiled/timestamp: tests/specs/$$(firstword $$(subst /, ,$$*))/$$(KPROVE_FILE).$$(KPROVE_EXT) tests/specs/$$(firstword $$(subst /, ,$$*))/concrete-rules.txt $(kevm_includes) $(lemma_includes) $(plugin_includes) 
+tests/specs/%-kompiled/timestamp: tests/specs/$$(firstword $$(subst /, ,$$*))/$$(KPROVE_FILE).$$(KPROVE_EXT) tests/specs/$$(firstword $$(subst /, ,$$*))/concrete-rules.txt $(kevm_includes) $(lemma_includes) $(plugin_includes)
 	$(KOMPILE) --backend $(word 3, $(subst /, , $*)) $<                                                 \
 	    --directory tests/specs/$(firstword $(subst /, ,$*))/$(KPROVE_FILE)/$(word 3, $(subst /, , $*)) \
 	    --main-module $(KPROVE_MODULE)                                                                  \

--- a/kevm
+++ b/kevm
@@ -115,7 +115,7 @@ run_kast() {
 }
 
 run_prove() {
-    local def_module run_dir proof_args haskell_backend_command bug_report_name \
+    local def_module run_dir proof_args bug_report_name \
           eventlog_name kprove omit_cells omit_labels klab_log pyk_args
 
     check_k_install
@@ -132,8 +132,6 @@ run_prove() {
 
     ! ${debug}                        || proof_args+=(--debug)
     [[ ! -f ${concrete_rules_file} ]] || proof_args+=(--concrete-rules "$(cat ${concrete_rules_file} | tr '\n' ',')")
-
-    haskell_backend_command=(kore-exec)
 
     case "${backend}" in
         haskell) ! ${bug_report}                 || haskell_backend_command+=(--bug-report "${bug_report_name}")
@@ -287,6 +285,7 @@ if [[ "$run_command" == 'help' ]] || [[ "$run_command" == '--help' ]] ; then
                                       [--pyk-omit-labels <comma_separated_labels>]
                                       [--max-counterexamples <number_counterexamples>]
                                       [--branching-allowed <max_branches>]
+                                      [--haskell-backend-arg <haskell_backend_arg>]
                  <K arg> is an argument you want to pass to K.
                  <interpreter arg> is an argument you want to pass to the derived interpreter.
                  <kore-prof arg> is an argument you want to pass to kore-prof.
@@ -325,37 +324,38 @@ pyk_minimize=false
 pyk_omit_labels=
 max_counterexamples=
 branching_allowed=
+haskell_backend_command=(kore-exec)
 [[ ! "$run_command" == 'prove' ]] || backend='java'
 [[ ! "$run_command" =~ klab*   ]] || backend='java'
 kevm_port='8545'
 kevm_host='127.0.0.1'
 args=()
 while [[ $# -gt 0 ]]; do
-    arg="$1"
-    case $arg in
-        --debug)               debug=true ; args+=("$1") ; shift   ;;
-        --dump)                dump=true                 ; shift   ;;
-        --no-unparse)          unparse=false             ; shift   ;;
-        --debugger)            debugger=true             ; shift   ;;
-        --profile)             profile=true              ; shift   ;;
-        --profile-timeout)     profile_timeout="$2"      ; shift 2 ;;
-        --kore-prof-args)      kore_prof_args="$2"       ; shift 2 ;;
-        --bug-report)          bug_report=true           ; shift   ;;
-        --backend)             backend="$2"              ; shift 2 ;;
-        --backend-dir)         backend_dir="$2"          ; shift 2 ;;
-        --concrete-rules-file) concrete_rules_file="$2"  ; shift 2 ;;
-        --provex)              provex=true               ; shift   ;;
-        --verif-module)        verif_module="$2"         ; shift 2 ;;
-        --pyk-minimize)        pyk_minimize=true         ; shift   ;;
-        --pyk-omit-labels)     pyk_omit_labels="$2"      ; shift 2 ;;
-        --max-counterexamples) max_counterexamples="$2"  ; shift 2 ;;
-        --branching-allowed)   branching_allowed="$2"    ; shift 2 ;;
-        --mode)                mode="$2"                 ; shift 2 ;;
-        --schedule)            schedule="$2"             ; shift 2 ;;
-        --chainid)             chainid="$2"              ; shift 2 ;;
-        -p|--port)             kevm_port="$2"            ; shift 2 ;;
-        -h|--host|--hostname)  kevm_host="$2"            ; shift 2 ;;
-        *)                     args+=("$1")              ; shift   ;;
+    case "$1" in
+        --debug)               debug=true ; args+=("$1")       ; shift   ;;
+        --dump)                dump=true                       ; shift   ;;
+        --no-unparse)          unparse=false                   ; shift   ;;
+        --debugger)            debugger=true                   ; shift   ;;
+        --profile)             profile=true                    ; shift   ;;
+        --profile-timeout)     profile_timeout="$2"            ; shift 2 ;;
+        --kore-prof-args)      kore_prof_args="$2"             ; shift 2 ;;
+        --bug-report)          bug_report=true                 ; shift   ;;
+        --backend)             backend="$2"                    ; shift 2 ;;
+        --backend-dir)         backend_dir="$2"                ; shift 2 ;;
+        --concrete-rules-file) concrete_rules_file="$2"        ; shift 2 ;;
+        --provex)              provex=true                     ; shift   ;;
+        --verif-module)        verif_module="$2"               ; shift 2 ;;
+        --pyk-minimize)        pyk_minimize=true               ; shift   ;;
+        --pyk-omit-labels)     pyk_omit_labels="$2"            ; shift 2 ;;
+        --max-counterexamples) max_counterexamples="$2"        ; shift 2 ;;
+        --branching-allowed)   branching_allowed="$2"          ; shift 2 ;;
+        --haskell-backend-arg) haskell_backend_command+=("$2") ; shift 2 ;;
+        --mode)                mode="$2"                       ; shift 2 ;;
+        --schedule)            schedule="$2"                   ; shift 2 ;;
+        --chainid)             chainid="$2"                    ; shift 2 ;;
+        -p|--port)             kevm_port="$2"                  ; shift 2 ;;
+        -h|--host|--hostname)  kevm_host="$2"                  ; shift 2 ;;
+        *)                     args+=("$1")                    ; shift   ;;
     esac
 done
 

--- a/kevm
+++ b/kevm
@@ -139,6 +139,7 @@ run_prove() {
         haskell) ! ${bug_report}                 || haskell_backend_command+=(--bug-report "${bug_report_name}")
                  ! ${profile}                    || haskell_backend_command+=(+RTS -l -ol${eventlog_name} -RTS)
                  [[ -z ${max_counterexamples} ]] || haskell_backend_command+=(--max-counterexamples ${max_counterexamples})
+                 [[ -z ${branching_allowed}   ]] || haskell_backend_command+=(--breadth ${branching_allowed})
 
                  ! ${debugger}                              || proof_args+=(--debugger)
                  [[ ${#haskell_backend_command[@]} -le 1 ]] || proof_args+=(--haskell-backend-command "${haskell_backend_command[*]}")
@@ -156,6 +157,7 @@ run_prove() {
                      proof_args+=( --no-alpha-renaming --restore-original-names --no-sort-collections              )
                      proof_args+=( --output json                                                                   )
                  fi
+                 [[ -z ${branching_allowed} ]] || proof_args+=(--branching-allowed ${branching_allowed})
                  ;;
         *)       fatal "Unknown backend for proving! ${backend}" ;;
     esac
@@ -284,6 +286,7 @@ if [[ "$run_command" == 'help' ]] || [[ "$run_command" == '--help' ]] ; then
                                       [--pyk-minimize]
                                       [--pyk-omit-labels <comma_separated_labels>]
                                       [--max-counterexamples <number_counterexamples>]
+                                      [--branching-allowed <max_branches>]
                  <K arg> is an argument you want to pass to K.
                  <interpreter arg> is an argument you want to pass to the derived interpreter.
                  <kore-prof arg> is an argument you want to pass to kore-prof.
@@ -321,6 +324,7 @@ verif_module=VERIFICATION
 pyk_minimize=false
 pyk_omit_labels=
 max_counterexamples=
+branching_allowed=
 [[ ! "$run_command" == 'prove' ]] || backend='java'
 [[ ! "$run_command" =~ klab*   ]] || backend='java'
 kevm_port='8545'
@@ -345,6 +349,7 @@ while [[ $# -gt 0 ]]; do
         --pyk-minimize)        pyk_minimize=true         ; shift   ;;
         --pyk-omit-labels)     pyk_omit_labels="$2"      ; shift 2 ;;
         --max-counterexamples) max_counterexamples="$2"  ; shift 2 ;;
+        --branching-allowed)   branching_allowed="$2"    ; shift 2 ;;
         --mode)                mode="$2"                 ; shift 2 ;;
         --schedule)            schedule="$2"             ; shift 2 ;;
         --chainid)             chainid="$2"              ; shift 2 ;;


### PR DESCRIPTION
- Add `build-kevm` target which builds the runner script and copies include files into the correct places.
- Add option `--branching-allowed` to `kevm prove` which allows specifying the maximum number of paths to explore when proving.
- Add option `--haskell-backend-arg` for easily injecting new arguments to pass to the haskell backend when proving.

The option `--branching-allowed` can be removed once https://github.com/kframework/k/issues/2224 is addressed.