### PR TITLE
Fix release process

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,6 +15,7 @@ pipeline {
       steps { script { currentBuild.displayName = "PR ${env.CHANGE_ID}: ${env.CHANGE_TITLE}" } }
     }
     stage('Build and Test') {
+      when { branch 'master' }
       agent {
         dockerfile {
           additionalBuildArgs '--build-arg K_COMMIT="${K_VERSION}" --build-arg USER_ID=$(id -u) --build-arg GROUP_ID=$(id -g)'
@@ -49,10 +50,10 @@ pipeline {
       }
     }
     stage('Package') {
-      when {
-        branch 'master'
-        beforeAgent true
-      }
+      //when {
+      //  branch 'master'
+      //  beforeAgent true
+      //}
       post { failure { slackSend color: '#cb2431' , channel: '#kevm' , message: "Packaging Phase Failed: ${env.BUILD_URL}" } }
       stages {
         stage('Ubuntu Focal') {
@@ -109,6 +110,7 @@ pipeline {
           }
         }
         stage('DockerHub') {
+          when { branch 'master' }
           environment {
             DOCKERHUB_TOKEN   = credentials('rvdockerhub')
             FOCAL_VERSION_TAG = "ubuntu-focal-${env.SHORT_REV}"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,6 @@ pipeline {
       steps { script { currentBuild.displayName = "PR ${env.CHANGE_ID}: ${env.CHANGE_TITLE}" } }
     }
     stage('Build and Test') {
-      when { branch 'master' }
       agent {
         dockerfile {
           additionalBuildArgs '--build-arg K_COMMIT="${K_VERSION}" --build-arg USER_ID=$(id -u) --build-arg GROUP_ID=$(id -g)'
@@ -50,10 +49,10 @@ pipeline {
       }
     }
     stage('Package') {
-      //when {
-      //  branch 'master'
-      //  beforeAgent true
-      //}
+      when {
+        branch 'master'
+        beforeAgent true
+      }
       post { failure { slackSend color: '#cb2431' , channel: '#kevm' , message: "Packaging Phase Failed: ${env.BUILD_URL}" } }
       stages {
         stage('Ubuntu Focal') {
@@ -102,7 +101,6 @@ pipeline {
           }
         }
         stage('DockerHub') {
-          when { branch 'master' }
           environment {
             DOCKERHUB_TOKEN   = credentials('rvdockerhub')
             FOCAL_VERSION_TAG = "ubuntu-focal-${env.SHORT_REV}"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -97,10 +97,10 @@ pipeline {
                     which kevm
                     kevm help
                     kevm version
-                    make -j4 test-interactive-run    TEST_CONCRETE_BACKEND=llvm
-                    make -j4 test-interactive-run    TEST_CONCRETE_BACKEND=haskell
-                    make -j4 test-parse              TEST_CONCRETE_BACKEND=llvm
-                    make -j4 test-failure            TEST_CONCRETE_BACKEND=llvm
+                    #make -j4 test-interactive-run    TEST_CONCRETE_BACKEND=llvm
+                    #make -j4 test-interactive-run    TEST_CONCRETE_BACKEND=haskell
+                    #make -j4 test-parse              TEST_CONCRETE_BACKEND=llvm
+                    #make -j4 test-failure            TEST_CONCRETE_BACKEND=llvm
                     make -j4 test-klab-prove         TEST_SYMBOLIC_BACKEND=java
                     make -j4 test-interactive-search TEST_SYMBOLIC_BACKEND=haskell
                   '''

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -94,15 +94,7 @@ pipeline {
                     sudo DEBIAN_FRONTEND=noninteractive apt-get update
                     sudo DEBIAN_FRONTEND=noninteractive apt-get upgrade --yes
                     sudo DEBIAN_FRONTEND=noninteractive apt-get install --yes ./kevm_${VERSION}_amd64.deb
-                    which kevm
-                    kevm help
-                    kevm version
-                    #make -j4 test-interactive-run    TEST_CONCRETE_BACKEND=llvm
-                    #make -j4 test-interactive-run    TEST_CONCRETE_BACKEND=haskell
-                    #make -j4 test-parse              TEST_CONCRETE_BACKEND=llvm
-                    #make -j4 test-failure            TEST_CONCRETE_BACKEND=llvm
-                    make -j4 test-klab-prove         TEST_SYMBOLIC_BACKEND=java
-                    make -j4 test-interactive-search TEST_SYMBOLIC_BACKEND=haskell
+                    ./package/test-package.sh
                   '''
                 }
               }

--- a/kevm
+++ b/kevm
@@ -3,6 +3,9 @@
 set -euo pipefail
 shopt -s extglob
 
+debug=false
+verbose=false
+
 notif() {
     if ${verbose}; then
         echo "== $0 [$(date)]: $@" >&2
@@ -316,8 +319,6 @@ if [[ "$run_command" == 'version' ]] || [[ "$run_command" == '--version' ]]; the
 fi
 
 backend="llvm"
-debug=false
-verbose=false
 dump=false
 unparse=true
 debugger=false

--- a/kevm
+++ b/kevm
@@ -2,7 +2,6 @@
 
 set -euo pipefail
 shopt -s extglob
-set -x
 
 notif() { echo "== $0 [$(date)]: $@" >&2 ; }
 fatal() { notif "[FATAL] $@" ; exit 1 ; }
@@ -397,8 +396,6 @@ cCHAINID_kore="\dv{SortInt{}}(\"${chainid}\")"
 cMODE_kast="\`${mode}\`(.KList)"
 cSCHEDULE_kast="\`${schedule}_EVM\`(.KList)"
 cCHAINID_kast="#token(\"${chainid}\",\"Int\")"
-which kompile
-notif_exec kompile --version
 
 ! ${debug} || set -x
 

--- a/kevm
+++ b/kevm
@@ -3,7 +3,14 @@
 set -euo pipefail
 shopt -s extglob
 
-notif() { echo "== $0 [$(date)]: $@" >&2 ; }
+notif() {
+    if ${verbose}; then
+        echo "== $0 [$(date)]: $@" >&2
+    else
+        echo "== $0: $@" >&2
+    fi
+}
+
 fatal() { notif "[FATAL] $@" ; exit 1 ; }
 
 notif_exec() {
@@ -249,14 +256,14 @@ run_command="$1" ; shift
 
 if [[ "$run_command" == 'help' ]] || [[ "$run_command" == '--help' ]] ; then
     echo "
-        usage: $0 run          [--backend (llvm|java|haskell)]           <KEVM_arg>* <pgm>  <K arg>*
-               $0 interpret    [--backend (llvm)] [--debug|--no-unparse] <KEVM_arg>* <pgm>  <interpreter arg>*
-               $0 interpret    [--backend (java|haskell)] [--no-unparse] <KEVM_arg>* <pgm>
-               $0 kast         [--backend (llvm|java|haskell)]           <KEVM_arg>* <pgm>  <output format> <K arg>*
-               $0 prove        [--backend (java|haskell)]                            <spec> <KEVM_arg>* <K arg>*
-               $0 search       [--backend (java|haskell)]                            <pgm>  <pattern> <K arg>*
-               $0 kompile      [--backend (java|llvm|haskell)]                       <main> <K arg>*
-               $0 klab-view                                                          <spec>
+        usage: $0 run          [--backend (llvm|java|haskell)]           [--verbose|--debug] <KEVM_arg>* <pgm>  <K arg>*
+               $0 interpret    [--backend (llvm)]         [--no-unparse] [--verbose|--debug] <KEVM_arg>* <pgm>  <interpreter arg>*
+               $0 interpret    [--backend (java|haskell)] [--no-unparse] [--verbose|--debug] <KEVM_arg>* <pgm>
+               $0 kast         [--backend (llvm|java|haskell)]           [--verbose|--debug] <KEVM_arg>* <pgm>  <output format> <K arg>*
+               $0 prove        [--backend (java|haskell)]                [--verbose|--debug]             <spec> <KEVM_arg>* <K arg>*
+               $0 search       [--backend (java|haskell)]                [--verbose|--debug]             <pgm>  <pattern> <K arg>*
+               $0 kompile      [--backend (java|llvm|haskell)]           [--verbose|--debug]             <main> <K arg>*
+               $0 klab-view                                              [--verbose|--debug]             <spec>
 
                $0 [help|--help|version|--version]
 
@@ -310,6 +317,7 @@ fi
 
 backend="llvm"
 debug=false
+verbose=false
 dump=false
 unparse=true
 debugger=false
@@ -334,7 +342,8 @@ kevm_host='127.0.0.1'
 args=()
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        --debug)               debug=true ; args+=("$1")       ; shift   ;;
+        --debug)               debug=true   ; args+=("$1")     ; shift   ;;
+        --verbose)             verbose=true ; args+=("$1")     ; shift   ;;
         --dump)                dump=true                       ; shift   ;;
         --no-unparse)          unparse=false                   ; shift   ;;
         --debugger)            debugger=true                   ; shift   ;;

--- a/kevm
+++ b/kevm
@@ -296,6 +296,8 @@ if [[ "$run_command" == 'help' ]] || [[ "$run_command" == '--help' ]] ; then
 
            klab-view: Make sure that the 'klab/bin' directory is on your PATH to use this option.
     "
+    find /usr -name kompile
+    which kompile
     exit 0
 fi
 

--- a/kevm
+++ b/kevm
@@ -42,6 +42,9 @@ export KLAB_OUT="${KLAB_OUT:-~/.klab}"
 run_kompile() {
     local kompile_opts openssl_root
 
+    which kompile
+    notif_exec kompile --version
+
     kompile_opts=( "${run_file}" --directory "${backend_dir}" )
     kompile_opts+=( -I "${INSTALL_INCLUDE}/kframework" -I "${plugin_include}/kframework" )
     kompile_opts+=( --hook-namespaces "JSON KRYPTO BLOCKCHAIN"                           )
@@ -78,6 +81,8 @@ run_kompile() {
                    ;;
         *)       fatal "Unknown backend for kompile: ${backend}" ;;
     esac
+    which kompile
+    notif_exec kompile --version
     notif_exec kompile "${kompile_opts[@]}" "$@"
 }
 
@@ -299,8 +304,6 @@ if [[ "$run_command" == 'help' ]] || [[ "$run_command" == '--help' ]] ; then
 
            klab-view: Make sure that the 'klab/bin' directory is on your PATH to use this option.
     "
-    find /usr -name kompile
-    which kompile
     exit 0
 fi
 

--- a/kevm
+++ b/kevm
@@ -2,6 +2,7 @@
 
 set -euo pipefail
 shopt -s extglob
+set -x
 
 notif() { echo "== $0 [$(date)]: $@" >&2 ; }
 fatal() { notif "[FATAL] $@" ; exit 1 ; }
@@ -396,6 +397,8 @@ cCHAINID_kore="\dv{SortInt{}}(\"${chainid}\")"
 cMODE_kast="\`${mode}\`(.KList)"
 cSCHEDULE_kast="\`${schedule}_EVM\`(.KList)"
 cCHAINID_kast="#token(\"${chainid}\",\"Int\")"
+which kompile
+notif_exec kompile --version
 
 ! ${debug} || set -x
 

--- a/kevm
+++ b/kevm
@@ -42,9 +42,6 @@ export KLAB_OUT="${KLAB_OUT:-~/.klab}"
 run_kompile() {
     local kompile_opts openssl_root
 
-    which kompile
-    notif_exec kompile --version
-
     kompile_opts=( "${run_file}" --directory "${backend_dir}" )
     kompile_opts+=( -I "${INSTALL_INCLUDE}/kframework" -I "${plugin_include}/kframework" )
     kompile_opts+=( --hook-namespaces "JSON KRYPTO BLOCKCHAIN"                           )
@@ -81,8 +78,6 @@ run_kompile() {
                    ;;
         *)       fatal "Unknown backend for kompile: ${backend}" ;;
     esac
-    which kompile
-    notif_exec kompile --version
     notif_exec kompile "${kompile_opts[@]}" "$@"
 }
 
@@ -304,6 +299,8 @@ if [[ "$run_command" == 'help' ]] || [[ "$run_command" == '--help' ]] ; then
 
            klab-view: Make sure that the 'klab/bin' directory is on your PATH to use this option.
     "
+    find /usr -name kompile
+    which kompile
     exit 0
 fi
 

--- a/kevm
+++ b/kevm
@@ -299,8 +299,6 @@ if [[ "$run_command" == 'help' ]] || [[ "$run_command" == '--help' ]] ; then
 
            klab-view: Make sure that the 'klab/bin' directory is on your PATH to use this option.
     "
-    find /usr -name kompile
-    which kompile
     exit 0
 fi
 

--- a/package/test-package.sh
+++ b/package/test-package.sh
@@ -36,6 +36,14 @@ kevm kompile --backend haskell tests/specs/erc20/verification.k \
 kevm prove tests/specs/erc20/ds/transfer-failure-1-a-spec.k --backend haskell --format-failures \
     --directory tests/specs/erc20/verification/haskell
 
+kevm kompile --backend java tests/specs/erc20/verification.k \
+    --directory tests/specs/erc20/verification/java          \
+    --main-module VERIFICATION                               \
+    --syntax-module VERIFICATION                             \
+    --concrete-rules-file tests/specs/erc20/concrete-rules.txt
+kevm prove tests/specs/erc20/ds/transfer-failure-1-a-spec.k --backend java --format-failures --debugger \
+    --directory tests/specs/erc20/verification/java
+
 kevm search tests/interactive/search/branching-invalid.evm "<statusCode> EVMC_INVALID_INSTRUCTION </statusCode>"  --backend haskell > tests/interactive/search/branching-invalid.evm.search-out
 git --no-pager diff --no-index --ignore-all-space -R tests/interactive/search/branching-invalid.evm.search-out tests/interactive/search/branching-invalid.evm.search-expected
 rm -rf tests/interactive/search/branching-invalid.evm.search-out

--- a/package/test-package.sh
+++ b/package/test-package.sh
@@ -28,14 +28,14 @@ kevm run tests/failing/static_callcodecallcodecall_110_OOGMAfter_2_d0g0v0.json -
     || git --no-pager diff --no-index --ignore-all-space -R tests/failing/static_callcodecallcodecall_110_OOGMAfter_2_d0g0v0.json.llvm-out tests/failing/static_callcodecallcodecall_110_OOGMAfter_2_d0g0v0.json.expected
 rm -rf tests/failing/static_callcodecallcodecall_110_OOGMAfter_2_d0g0v0.json.llvm-out
 
-kevm kompile --backend haskell tests/specs/erc20/verification.k \
-    --directory tests/specs/erc20/verification/haskell          \
-    --main-module VERIFICATION                                  \
-    --syntax-module VERIFICATION                                \
-    --concrete-rules-file tests/specs/erc20/concrete-rules.txt  \
+kevm kompile --backend haskell tests/specs/examples/erc20-spec.md \
+    --directory tests/specs/examples/erc20-spec/haskell           \
+    --main-module VERIFICATION                                    \
+    --syntax-module VERIFICATION                                  \
+    --concrete-rules-file tests/specs/examples/concrete-rules.txt \
     --verbose
-kevm prove tests/specs/erc20/ds/transfer-failure-1-a-spec.k --backend haskell --format-failures \
-    --directory tests/specs/erc20/verification/haskell
+kevm prove tests/specs/examples/erc20-spec.md --backend haskell --format-failures  \
+    --directory tests/specs/examples/erc20-spec/haskell
 
 kevm kompile --backend java tests/specs/erc20/verification.k   \
     --directory tests/specs/erc20/verification/java            \

--- a/package/test-package.sh
+++ b/package/test-package.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+set -xueo pipefail
+
+which kevm
+kevm help
+kevm version
+
+kevm run tests/ethereum-tests/LegacyTests/Constantinople/VMTests/vmArithmeticTest/add0.json --backend llvm \
+    --mode VMTESTS --schedule DEFAULT --chainid 1                                                          \
+    > tests/ethereum-tests/LegacyTests/Constantinople/VMTests/vmArithmeticTest/add0.json.llvm-out          \
+    || git --no-pager diff --no-index --ignore-all-space -R tests/ethereum-tests/LegacyTests/Constantinople/VMTests/vmArithmeticTest/add0.json.llvm-out tests/templates/output-success-llvm.json
+rm -rf tests/ethereum-tests/LegacyTests/Constantinople/VMTests/vmArithmeticTest/add0.json.llvm-out
+
+kevm run tests/ethereum-tests/LegacyTests/Constantinople/VMTests/vmArithmeticTest/add0.json --backend haskell \
+    --mode VMTESTS --schedule DEFAULT --chainid 1                                                             \
+    > tests/ethereum-tests/LegacyTests/Constantinople/VMTests/vmArithmeticTest/add0.json.haskell-out          \
+    || git --no-pager diff --no-index --ignore-all-space -R tests/ethereum-tests/LegacyTests/Constantinople/VMTests/vmArithmeticTest/add0.json.haskell-out tests/templates/output-success-haskell.json
+rm -rf tests/ethereum-tests/LegacyTests/Constantinople/VMTests/vmArithmeticTest/add0.json.haskell-out
+
+kevm kast tests/interactive/log3_MaxTopic_d0g0v0.json kast  --backend llvm > tests/interactive/log3_MaxTopic_d0g0v0.json.parse-out
+git --no-pager diff --no-index --ignore-all-space -R tests/interactive/log3_MaxTopic_d0g0v0.json.parse-out tests/interactive/log3_MaxTopic_d0g0v0.json.parse-expected
+rm -rf tests/interactive/log3_MaxTopic_d0g0v0.json.parse-out
+
+kevm run tests/failing/static_callcodecallcodecall_110_OOGMAfter_2_d0g0v0.json --backend llvm \
+    --mode NORMAL --schedule BERLIN --chainid 1                                               \
+    > tests/failing/static_callcodecallcodecall_110_OOGMAfter_2_d0g0v0.json.llvm-out          \
+    || git --no-pager diff --no-index --ignore-all-space -R tests/failing/static_callcodecallcodecall_110_OOGMAfter_2_d0g0v0.json.llvm-out tests/failing/static_callcodecallcodecall_110_OOGMAfter_2_d0g0v0.json.expected
+rm -rf tests/failing/static_callcodecallcodecall_110_OOGMAfter_2_d0g0v0.json.llvm-out
+
+kevm kompile --backend haskell tests/specs/erc20/verification.k \
+    --directory tests/specs/erc20/verification/haskell          \
+    --main-module VERIFICATION                                  \
+    --syntax-module VERIFICATION                                \
+    --concrete-rules-file tests/specs/erc20/concrete-rules.txt
+kevm prove tests/specs/erc20/ds/transfer-failure-1-a-spec.k --backend haskell --format-failures --debugger \
+    --directory tests/specs/erc20/verification/haskell
+
+kevm search tests/interactive/search/branching-invalid.evm "<statusCode> EVMC_INVALID_INSTRUCTION </statusCode>"  --backend haskell > tests/interactive/search/branching-invalid.evm.search-out
+git --no-pager diff --no-index --ignore-all-space -R tests/interactive/search/branching-invalid.evm.search-out tests/interactive/search/branching-invalid.evm.search-expected
+rm -rf tests/interactive/search/branching-invalid.evm.search-out

--- a/package/test-package.sh
+++ b/package/test-package.sh
@@ -33,7 +33,7 @@ kevm kompile --backend haskell tests/specs/erc20/verification.k \
     --main-module VERIFICATION                                  \
     --syntax-module VERIFICATION                                \
     --concrete-rules-file tests/specs/erc20/concrete-rules.txt
-kevm prove tests/specs/erc20/ds/transfer-failure-1-a-spec.k --backend haskell --format-failures --debugger \
+kevm prove tests/specs/erc20/ds/transfer-failure-1-a-spec.k --backend haskell --format-failures \
     --directory tests/specs/erc20/verification/haskell
 
 kevm search tests/interactive/search/branching-invalid.evm "<statusCode> EVMC_INVALID_INSTRUCTION </statusCode>"  --backend haskell > tests/interactive/search/branching-invalid.evm.search-out

--- a/package/test-package.sh
+++ b/package/test-package.sh
@@ -32,15 +32,17 @@ kevm kompile --backend haskell tests/specs/erc20/verification.k \
     --directory tests/specs/erc20/verification/haskell          \
     --main-module VERIFICATION                                  \
     --syntax-module VERIFICATION                                \
-    --concrete-rules-file tests/specs/erc20/concrete-rules.txt
+    --concrete-rules-file tests/specs/erc20/concrete-rules.txt  \
+    --verbose
 kevm prove tests/specs/erc20/ds/transfer-failure-1-a-spec.k --backend haskell --format-failures \
     --directory tests/specs/erc20/verification/haskell
 
-kevm kompile --backend java tests/specs/erc20/verification.k \
-    --directory tests/specs/erc20/verification/java          \
-    --main-module VERIFICATION                               \
-    --syntax-module VERIFICATION                             \
-    --concrete-rules-file tests/specs/erc20/concrete-rules.txt
+kevm kompile --backend java tests/specs/erc20/verification.k   \
+    --directory tests/specs/erc20/verification/java            \
+    --main-module VERIFICATION                                 \
+    --syntax-module VERIFICATION                               \
+    --concrete-rules-file tests/specs/erc20/concrete-rules.txt \
+    --debug
 kevm prove tests/specs/erc20/ds/transfer-failure-1-a-spec.k --backend java --format-failures --debugger \
     --directory tests/specs/erc20/verification/java
 


### PR DESCRIPTION
The main problem was that we were using the `Makefile` to test the installed package, but the makefile automatically tries to build the semantics in the repository clone.

So I switched to just normal calls to `kevm` for testing, which is more appropriate anyway because we shouldn't be accidentally using things the Makefile helps us with to test installed versions.

I also add a `--verbose` flag to KEVM that prints out timing information when executing, and passes through to sub-commands.