### PR TITLE
Make ecrecoverloop00-sig1-invalid-spec.k pass with Haskell backend

### DIFF
--- a/tests/failing-symbolic.haskell
+++ b/tests/failing-symbolic.haskell
@@ -1,4 +1,3 @@
-tests/specs/benchmarks/ecrecover00-sigvalid-spec.k
 tests/specs/benchmarks/ecrecoverloop00-sig1-invalid-spec.k
 tests/specs/bihu/collectToken-spec.k
 tests/specs/bihu/forwardToHotWallet-success-1-spec.k

--- a/tests/specs/benchmarks/functional-spec.k
+++ b/tests/specs/benchmarks/functional-spec.k
@@ -15,6 +15,14 @@ endmodule
 module FUNCTIONAL-SPEC
     imports FUNCTIONAL-SPEC-SYNTAX
    
+    claim <k> runLemma (#range ( B [ 128 := #ecrec ( #buf ( 32 , HASH ) , #buf ( 32 , SIGV ) , #buf ( 32 , SIGR ) , #buf ( 32 , SIGS ) ) ] [ 160 := #buf ( 32 , HASH ) ] [ 192 := #buf ( 32 , SIGV ) ] [ 224 := #buf ( 32 , SIGR ) ] [ 256 := #buf ( 32 , SIGS ) ] [ 160 := #padToWidth ( 32 , #asByteStack ( #asWord ( #ecrec ( #buf ( 32 , HASH ) , #buf ( 32 , SIGV ) , #buf ( 32 , SIGR ) , #buf ( 32 , SIGS ) ) ) ) ) ] , 160 , 32 )) => doneLemma (#buf(32, RECOVERED)) ... </k>
+      requires notBool #ecrecEmpty(#bufStrict(32, HASH), #bufStrict(32, SIGV), #bufStrict(32, SIGR), #bufStrict(32, SIGS))
+       andBool RECOVERED ==Int #asWord(#ecrec(#bufStrict(32, HASH), #bufStrict(32, SIGV), #bufStrict(32, SIGR), #bufStrict(32, SIGS)))
+       andBool #rangeUInt(256, HASH)
+       andBool #rangeUInt(8, SIGV)
+       andBool #rangeBytes(32, SIGR)
+       andBool #rangeBytes(32, SIGS)
+
     claim <k> runLemma ( #sizeByteArray ( #ecrec ( #buf ( 32 , HASH ) , #buf ( 32 , 255 &Int SIGV ) , #buf ( 32 , SIGR ) , #buf ( 32 , SIGS ) ) ) ) => doneLemma ( 0 ) ... </k>
       requires #rangeUInt(256, HASH)
        andBool #rangeUInt(8, SIGV)

--- a/tests/specs/lemmas.k
+++ b/tests/specs/lemmas.k
@@ -47,6 +47,9 @@ module LEMMAS
 
     rule #isPrecompiledAccount(#newAddr(_, _), _) => false [simplification]
 
+    rule 0 <=Int #asWord(_WS)             => true [simplification]
+    rule         #asWord(_WS) <Int pow256 => true [simplification]
+
   // ########################
   // Keccak
   // ########################

--- a/tests/specs/lemmas.k
+++ b/tests/specs/lemmas.k
@@ -246,9 +246,6 @@ module LEMMAS-JAVA [symbolic, kast]
     rule notBool  (X ==K 1) => X ==K 0  requires #rangeBool(X) [simplification]
     rule bool2Word(X ==K 1) => X        requires #rangeBool(X) [simplification]
 
-    rule 0 <=Int #asWord(_WS)             => true [simplification]
-    rule         #asWord(_WS) <Int pow256 => true [simplification]
-
     rule X <=Int maxUInt256 => X <Int pow256 [simplification]
     rule X <=Int maxUInt160 => X <Int pow160 [simplification]
     rule X <=Int 255        => X <Int 256    [simplification]


### PR DESCRIPTION
The lemmas I added were already present in [`LEMMAS-JAVA` module](https://github.com/kframework/evm-semantics/blob/af66662b9db26f2317f073cf8b32e6218005ca46/tests/specs/lemmas.k#L246).

I think they hold because these are all the rules I found that implement `#asWord`:
```
    rule #asWord(WS) => chop(Bytes2Int(WS, BE, Unsigned)) [concrete]
```
```
    rule [#asWord.base-empty]:  #asWord( .WordStack     ) => 0
    rule [#asWord.base-single]: #asWord( W : .WordStack ) => W
    rule [#asWord.recursive]:   #asWord( W0 : W1 : WS   ) => #asWord(((W0 *Word 256) +Word W1) : WS)
```
- [`chop` interprets an integer modulo `2^256`](https://github.com/kframework/evm-semantics/blob/af66662b9db26f2317f073cf8b32e6218005ca46/evm-types.md?plain=1#L156)
- `+Word` is implemented in terms of `chop` (https://github.com/kframework/evm-semantics/blob/af66662b9db26f2317f073cf8b32e6218005ca46/evm-types.md?plain=1#L236)

I'm not completely sure that the rhs of `#asWord.base-single` (`W`) is always greather or equal to 0 and less than `2^256`, but think this is the case [because it's a word](https://github.com/kframework/evm-semantics/blob/master/evm-types.md#data-structures-over-word).
