### PR TITLE
Apple Silicon notes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 /optimizer/*.k
 /optimizer/*.json
 /tests/specs/opcodes/evm-optimizations-spec.md
+.envrc

--- a/Makefile
+++ b/Makefile
@@ -125,6 +125,10 @@ ifneq ($(SKIP_HASKELL),)
     K_MVN_ARGS += -Dhaskell.backend.skip
 endif
 
+ifneq ($(APPLE_SILICON),)
+    K_MVN_ARGS += -Dstack.extra-opts='--compiler ghc-8.10.7 --system-ghc'
+endif
+
 ifneq ($(RELEASE),)
     K_BUILD_TYPE := FastBuild
 else

--- a/README.md
+++ b/README.md
@@ -117,6 +117,11 @@ make libsecp256k1
 **NOTE**: Previous versions of these instructions required the user to use either the homebrew version of `flex` or the xcode command line tools version, with the wrong option giving an error.
 The current recommendation is to use the homebrew version.
 
+If you are building on an Apple Silicon machine, ensure that your `PATH` is set
+up correctly before running `make k-deps`. You can do so using
+[`direnv`](https://direnv.net/) by copying `macos-envrc` to `.envrc`, then
+running `direnv allow`.
+
 #### Haskell Stack (all platforms)
 
 -   [Haskell Stack](https://docs.haskellstack.org/en/stable/install_and_upgrade/#installupgrade).
@@ -146,6 +151,13 @@ If you don't need either the LLVM or Haskell backend, there are flags to skip th
 
 ```sh
 make k-deps SKIP_LLVM=true SKIP_HASKELL=true
+```
+
+On an Apple Silicon machine, an additional flag to `make` is required to
+correctly build the Haskell backend:
+
+```sh
+make k-deps APPLE_SILICON=true
 ```
 
 #### Blockchain Plugin

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ make libsecp256k1
 The current recommendation is to use the homebrew version.
 
 If you are building on an Apple Silicon machine, ensure that your `PATH` is set
-up correctly before running `make k-deps`. You can do so using
+up correctly before running `make deps` or `make k-deps`. You can do so using
 [`direnv`](https://direnv.net/) by copying `macos-envrc` to `.envrc`, then
 running `direnv allow`.
 

--- a/macos-envrc
+++ b/macos-envrc
@@ -1,0 +1,7 @@
+# Copy this file to .envrc, then run `direnv allow` to automatically set
+# relevant environment variables when entering this directory.
+
+PATH_add `brew --prefix bison`/bin
+PATH_add `brew --prefix flex`/bin
+PATH_add `brew --prefix llvm`/bin
+PATH_add `brew --prefix openjdk`/bin


### PR DESCRIPTION
This PR makes some very minor changes to permit easy building on Apple Silicon machines.

Note that `make build` is broken due to non-portability of `libff`; `make test-prove` should succeed, however.