### PR TITLE
Apple silicon build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,10 @@ else
     LIBFF_CMAKE_FLAGS += -DWITH_PROCPS=OFF
 endif
 
+ifneq ($(APPLE_SILICON),)
+    LIBFF_CMAKE_FLAGS += -DCURVE=ALT_BN128 -DUSE_ASM=Off
+endif
+
 $(libff_out): $(PLUGIN_SUBMODULE)/deps/libff/CMakeLists.txt
 	@mkdir -p $(PLUGIN_SUBMODULE)/deps/libff/build
 	cd $(PLUGIN_SUBMODULE)/deps/libff/build                                                                     \

--- a/cmake/node/CMakeLists.txt
+++ b/cmake/node/CMakeLists.txt
@@ -40,7 +40,7 @@ link_directories(AFTER SYSTEM
   $ENV{KEVM_LIB_ABS}/cryptopp/lib)
 
 if(APPLE)
-  link_directories(AFTER SYSTEM ${BREW_PREFIX}/opt/openssl/lib)
+  link_directories(AFTER SYSTEM "${BREW_PREFIX}/opt/openssl/lib")
 endif()
 
 add_executable(kevm-vm
@@ -61,7 +61,7 @@ endif()
 
 if (APPLE)
   target_include_directories(kevm-vm
-    PUBLIC ${BREW_PREFIX}/include)
+    PUBLIC "${BREW_PREFIX}/opt/openssl/include")
 endif()
 
 target_include_directories(kevm-vm

--- a/cmake/node/CMakeLists.txt
+++ b/cmake/node/CMakeLists.txt
@@ -1,5 +1,27 @@
 cmake_minimum_required (VERSION 3.4)
 
+if(APPLE)
+  if(DEFINED ENV{HOMEBREW_PREFIX})
+    set(BREW_PREFIX $ENV{HOMEBREW_PREFIX})
+  else()
+    execute_process(
+      COMMAND brew --prefix
+      OUTPUT_VARIABLE BREW_PREFIX
+      ERROR_VARIABLE BREW_ERROR
+      RESULT_VARIABLE BREW_RESULT
+      OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+    if(NOT BREW_RESULT EQUAL 0)
+      message(WARNING "Error running brew --prefix; you may need to manually configure package search paths.")
+      message(WARNING "  : ${BREW_ERROR}")
+    endif() # BREW_RESULT
+  endif() # ENV{HOMEBREW_PREFIX}
+
+  message(STATUS "Looking for Homebrew dependencies in ${BREW_PREFIX}")
+  include_directories(AFTER SYSTEM "${BREW_PREFIX}/include")
+  link_directories(AFTER "${BREW_PREFIX}/lib")
+endif() # APPLE
+
 execute_process(COMMAND which kompile OUTPUT_VARIABLE KOMPILE_PATH
     OUTPUT_STRIP_TRAILING_WHITESPACE)
 execute_process(COMMAND dirname ${KOMPILE_PATH} OUTPUT_VARIABLE K_BIN
@@ -13,7 +35,13 @@ set(KOMPILED_DIR $ENV{KEVM_LIB_ABS}/$ENV{node_dir}/$ENV{node_main_filename}-komp
 set(KOMPILE_USE_MAIN "library")
 set(TARGET_NAME "kevm-vm")
 
-link_directories(AFTER SYSTEM $ENV{LIBRARY_PATH})
+link_directories(AFTER SYSTEM
+  $ENV{LIBRARY_PATH}
+  $ENV{KEVM_LIB_ABS}/cryptopp/lib)
+
+if(APPLE)
+  link_directories(AFTER SYSTEM ${BREW_PREFIX}/opt/openssl/lib)
+endif()
 
 add_executable(kevm-vm
 	$ENV{NODE_DIR}/vm/init.cpp
@@ -31,6 +59,11 @@ if(UNIX AND NOT APPLE)
 	set(LINK_PROCPS procps)
 endif()
 
+if (APPLE)
+  target_include_directories(kevm-vm
+    PUBLIC ${BREW_PREFIX}/include)
+endif()
+
 target_include_directories(kevm-vm
 	PUBLIC $ENV{PLUGIN_SUBMODULE}/plugin-c
 	PUBLIC $ENV{LOCAL_LIB}/proto
@@ -39,6 +72,7 @@ target_include_directories(kevm-vm
 	PUBLIC $ENV{NODE_DIR}/vm/kevm
 	PUBLIC ${CMAKE_SOURCE_DIR}/..
 	PUBLIC $ENV{KEVM_LIB_ABS}/libff/include
+	PUBLIC $ENV{KEVM_LIB_ABS}/cryptopp/include
 	PUBLIC ${K_LIB}/../include/kllvm)
 target_compile_options(kevm-vm
 	PUBLIC $ENV{LLVM_KOMPILE_OPTS}


### PR DESCRIPTION
This makes some small changes to the build system to allow the semantics to build properly on Apple Silicon machines.

There seems to be a similar bug to the one fixed in https://github.com/kframework/llvm-backend/pull/459 for KEVM on the LLVM backend, but the Haskell backend (`make test-prove`) seems to work correctly.