### PR TITLE
Switch to Haskell backend/provex by default for symbolic execution, updates to kevm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -415,14 +415,14 @@ tests/%.parse: tests/%
 	$(CHECK) $@-out $@-expected
 	$(KEEP_OUTPUTS) || rm -rf $@-out
 
-tests/%.prove: tests/%
+tests/%.prove-legacy: tests/%
 	$(KEVM) prove $< --verif-module $(KPROVE_MODULE) $(TEST_OPTIONS) --backend $(TEST_SYMBOLIC_BACKEND) \
 	    --format-failures $(KPROVE_OPTS) --concrete-rules-file $(dir $@)concrete-rules.txt
 
 .SECONDEXPANSION:
-tests/specs/%.provex: tests/specs/% tests/specs/$$(firstword $$(subst /, ,$$*))/$$(KPROVE_FILE)/$(TEST_SYMBOLIC_BACKEND)/$$(KPROVE_FILE)-kompiled/timestamp
-	$(KEVM) prove $< $(TEST_OPTIONS) --backend $(TEST_SYMBOLIC_BACKEND) --format-failures $(KPROVE_OPTS)        \
-	    --provex --backend-dir tests/specs/$(firstword $(subst /, ,$*))/$(KPROVE_FILE)/$(TEST_SYMBOLIC_BACKEND)
+tests/specs/%.prove: tests/specs/% tests/specs/$$(firstword $$(subst /, ,$$*))/$$(KPROVE_FILE)/$(TEST_SYMBOLIC_BACKEND)/$$(KPROVE_FILE)-kompiled/timestamp
+	$(KEVM) prove $< $(TEST_OPTIONS) --backend $(TEST_SYMBOLIC_BACKEND) --format-failures $(KPROVE_OPTS) \
+	    --backend-dir tests/specs/$(firstword $(subst /, ,$*))/$(KPROVE_FILE)/$(TEST_SYMBOLIC_BACKEND)
 
 tests/specs/%-kompiled/timestamp: tests/specs/$$(firstword $$(subst /, ,$$*))/$$(KPROVE_FILE).$$(KPROVE_EXT) tests/specs/$$(firstword $$(subst /, ,$$*))/concrete-rules.txt $(kevm_includes) $(lemma_includes) $(plugin_includes) $(KEVM_BIN)/kevm
 	$(KOMPILE) --backend $(word 3, $(subst /, , $*)) $<                                                 \
@@ -522,19 +522,19 @@ provex_definitions :=                                                           
 build-provex: $(provex_definitions)
 
 test-prove: test-prove-benchmarks test-prove-functional test-prove-opcodes test-prove-erc20 test-prove-bihu test-prove-examples test-prove-mcd test-prove-optimizations
-test-prove-benchmarks:    $(prove_benchmarks_tests:=.provex)
-test-prove-functional:    $(prove_functional_tests:=.provex)
-test-prove-opcodes:       $(prove_opcodes_tests:=.provex)
-test-prove-erc20:         $(prove_erc20_tests:=.provex)
-test-prove-bihu:          $(prove_bihu_tests:=.provex)
-test-prove-examples:      $(prove_examples_tests:=.provex)
-test-prove-mcd:           $(prove_mcd_tests:=.provex)
-test-prove-optimizations: $(prove_optimization_tests:=.provex)
+test-prove-benchmarks:    $(prove_benchmarks_tests:=.prove)
+test-prove-functional:    $(prove_functional_tests:=.prove)
+test-prove-opcodes:       $(prove_opcodes_tests:=.prove)
+test-prove-erc20:         $(prove_erc20_tests:=.prove)
+test-prove-bihu:          $(prove_bihu_tests:=.prove)
+test-prove-examples:      $(prove_examples_tests:=.prove)
+test-prove-mcd:           $(prove_mcd_tests:=.prove)
+test-prove-optimizations: $(prove_optimization_tests:=.prove)
 
 test-failing-prove: $(prove_failing_tests:=.prove)
 
 test-klab-prove: KPROVE_OPTS += --debugger
-test-klab-prove: $(smoke_tests_prove:=.provex)
+test-klab-prove: $(smoke_tests_prove:=.prove)
 
 # to generate optimizations.md, run: ./optimizer/optimize.sh &> output
 tests/specs/opcodes/evm-optimizations-spec.md: optimizations.md

--- a/Makefile
+++ b/Makefile
@@ -222,7 +222,6 @@ endif
 $(KEVM_LIB)/$(haskell_kompiled): $(kevm_includes) $(plugin_includes) $(KEVM_BIN)/kevm
 	$(KOMPILE) --backend haskell                     \
 	    $(haskell_main_file) $(HASKELL_KOMPILE_OPTS) \
-	    --directory $(KEVM_LIB)/$(haskell_dir)       \
 	    --main-module $(haskell_main_module)         \
 	    --syntax-module $(haskell_syntax_module)     \
 	    $(KOMPILE_OPTS)
@@ -243,7 +242,6 @@ endif
 $(KEVM_LIB)/$(llvm_kompiled): $(kevm_includes) $(plugin_includes) $(plugin_c_includes) $(libff_out) $(KEVM_BIN)/kevm
 	$(KOMPILE) --backend llvm                 \
 	    $(llvm_main_file)                     \
-	    --directory $(KEVM_LIB)/$(llvm_dir)   \
 	    --main-module $(llvm_main_module)     \
 	    --syntax-module $(llvm_syntax_module) \
 	    $(KOMPILE_OPTS)
@@ -263,7 +261,6 @@ export node_main_filename
 $(KEVM_LIB)/$(node_kore): $(kevm_includes) $(plugin_includes) $(plugin_c_includes) $(libff_out) $(KEVM_BIN)/kevm
 	$(KOMPILE) --backend node                 \
 	    $(node_main_file)                     \
-	    --directory $(KEVM_LIB)/$(node_dir)   \
 	    --main-module $(node_main_module)     \
 	    --syntax-module $(node_syntax_module) \
 	    $(KOMPILE_OPTS)

--- a/Makefile
+++ b/Makefile
@@ -200,7 +200,7 @@ $(KEVM_INCLUDE)/kframework/lemmas/%.k: tests/specs/%.k
 	@mkdir -p $(dir $@)
 	install $< $@
 
-KOMPILE_OPTS = --debug -I $(INSTALL_INCLUDE)/kframework -I $(INSTALL_LIB)/blockchain-k-plugin/include/kframework
+KOMPILE_OPTS = -I $(INSTALL_INCLUDE)/kframework -I $(INSTALL_LIB)/blockchain-k-plugin/include/kframework
 
 ifneq (,$(RELEASE))
     KOMPILE_OPTS += -O2

--- a/Makefile
+++ b/Makefile
@@ -345,7 +345,7 @@ uninstall:
 # -----
 
 TEST_CONCRETE_BACKEND := llvm
-TEST_SYMBOLIC_BACKEND := java
+TEST_SYMBOLIC_BACKEND := haskell
 
 TEST_OPTIONS :=
 CHECK        := git --no-pager diff --no-index --ignore-all-space -R

--- a/Makefile
+++ b/Makefile
@@ -417,7 +417,7 @@ tests/%.parse: tests/%
 
 tests/%.prove-legacy: tests/%
 	$(KEVM) prove $< --verif-module $(KPROVE_MODULE) $(TEST_OPTIONS) --backend $(TEST_SYMBOLIC_BACKEND) \
-	    --format-failures $(KPROVE_OPTS) --concrete-rules-file $(dir $@)concrete-rules.txt
+	    --no-provex --format-failures $(KPROVE_OPTS) --concrete-rules-file $(dir $@)concrete-rules.txt
 
 .SECONDEXPANSION:
 tests/specs/%.prove: tests/specs/% tests/specs/$$(firstword $$(subst /, ,$$*))/$$(KPROVE_FILE)/$(TEST_SYMBOLIC_BACKEND)/$$(KPROVE_FILE)-kompiled/timestamp

--- a/Makefile
+++ b/Makefile
@@ -422,7 +422,7 @@ tests/%.prove-legacy: tests/%
 .SECONDEXPANSION:
 tests/specs/%.prove: tests/specs/% tests/specs/$$(firstword $$(subst /, ,$$*))/$$(KPROVE_FILE)/$(TEST_SYMBOLIC_BACKEND)/$$(KPROVE_FILE)-kompiled/timestamp
 	$(KEVM) prove $< $(TEST_OPTIONS) --backend $(TEST_SYMBOLIC_BACKEND) --format-failures $(KPROVE_OPTS) \
-	    --backend-dir tests/specs/$(firstword $(subst /, ,$*))/$(KPROVE_FILE)/$(TEST_SYMBOLIC_BACKEND)
+	    --directory tests/specs/$(firstword $(subst /, ,$*))/$(KPROVE_FILE)/$(TEST_SYMBOLIC_BACKEND)
 
 tests/specs/%-kompiled/timestamp: tests/specs/$$(firstword $$(subst /, ,$$*))/$$(KPROVE_FILE).$$(KPROVE_EXT) tests/specs/$$(firstword $$(subst /, ,$$*))/concrete-rules.txt $(kevm_includes) $(lemma_includes) $(plugin_includes) $(KEVM_BIN)/kevm
 	$(KOMPILE) --backend $(word 3, $(subst /, , $*)) $<                                                 \

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ Installing/Building
 
 ### K Backends
 
-There are three backends of K available: LLVM (default) for concrete execution and Java (default) and Haskell for symbolic execution.
-This repository generates the build-products for each backend in `.build/defn/`.
+There are three backends of K available: LLVM (default) for concrete execution and Haskell (default) and Java for symbolic execution.
+This repository generates the build-products for each backend in `.build/usr/lib/kevm`.
 
 ### System Dependencies
 

--- a/evm-node.md
+++ b/evm-node.md
@@ -51,7 +51,7 @@ have been paid, and it may be to expensive to compute the hash of the init code.
       [priority(35)]
 
     rule <k> (. => #loadAccount #newAddr(ACCT, SALT, #range(LM, MEMSTART, MEMWIDTH)))
-          ~> CREATE2 VALUE MEMSTART MEMWIDTH SALT
+          ~> CREATE2 _VALUE MEMSTART MEMWIDTH SALT
          ...
          </k>
          <id> ACCT </id>
@@ -343,7 +343,7 @@ This minimizes the amount of information which must be stored in the configurati
     rule warmStorage2Set( (ListItem(ACCT) => .List) _, STORAGE, RESULT => RESULT |Set warmStorage2SetAux(ACCT, Set2List({STORAGE[ACCT]}:>Set), .Set) )
 
     rule warmStorage2SetAux( _, .List, RESULT ) => RESULT
-    rule warmStorage2SetAux( ACCT, (ListItem(LOCATION) => .List) LOCATIONS, RESULT => RESULT |Set SetItem(storageLocation(ACCT, LOCATION)) )
+    rule warmStorage2SetAux( ACCT, (ListItem(LOCATION) => .List) _LOCATIONS, RESULT => RESULT |Set SetItem(storageLocation(ACCT, LOCATION)) )
 ```
 
 -   `contractBytes` takes the contents of the `<code>` cell and returns its binary representation as a String.

--- a/kevm
+++ b/kevm
@@ -279,7 +279,7 @@ if [[ "$run_command" == 'help' ]] || [[ "$run_command" == '--help' ]] ; then
                                       [--profile]
                                       [--profile-timeout <duration>]
                                       [--kore-prof-args \"<kore-prof arg>*\"]
-                                      [--provex]
+                                      [--no-provex]
                                       [--verif-module <verification_module>]
                                       [--pyk-minimize]
                                       [--pyk-omit-labels <comma_separated_labels>]
@@ -320,7 +320,7 @@ mode=NORMAL
 schedule=BERLIN
 chainid=1
 concrete_rules_file=
-provex=false
+provex=true
 verif_module=VERIFICATION
 pyk_minimize=false
 pyk_omit_labels=
@@ -344,7 +344,7 @@ while [[ $# -gt 0 ]]; do
         --backend)             backend="$2"                    ; shift 2 ;;
         --backend-dir)         backend_dir="$2"                ; shift 2 ;;
         --concrete-rules-file) concrete_rules_file="$2"        ; shift 2 ;;
-        --provex)              provex=true                     ; shift   ;;
+        --no-provex)           provex=false                    ; shift   ;;
         --verif-module)        verif_module="$2"               ; shift 2 ;;
         --pyk-minimize)        pyk_minimize=true               ; shift   ;;
         --pyk-omit-labels)     pyk_omit_labels="$2"            ; shift 2 ;;

--- a/kevm
+++ b/kevm
@@ -8,7 +8,7 @@ fatal() { notif "[FATAL] $@" ; exit 1 ; }
 
 notif_exec() {
     notif "$@"
-    $@
+    "$@"
 }
 
 check_k_install() {

--- a/kevm
+++ b/kevm
@@ -3,8 +3,13 @@
 set -euo pipefail
 shopt -s extglob
 
-notif() { echo "== $@" >&2 ; }
-fatal() { echo "[FATAL] $@" ; exit 1 ; }
+notif() { echo "== [$(date)]: $@" >&2 ; }
+fatal() { notif "[FATAL] $@" ; exit 1 ; }
+
+notif_exec() {
+    notif "$@"
+    $@
+}
 
 check_k_install() {
     which kast &> /dev/null \
@@ -73,7 +78,7 @@ run_kompile() {
                    ;;
         *)       fatal "Unknown backend for kompile: ${backend}" ;;
     esac
-    kompile "${kompile_opts[@]}" "$@"
+    notif_exec kompile "${kompile_opts[@]}" "$@"
 }
 
 run_krun() {
@@ -95,7 +100,7 @@ run_krun() {
             parser='cat'
             ;;
     esac
-    krun --directory "$backend_dir"                   \
+    notif_exec krun --directory "$backend_dir"        \
          -cSCHEDULE="$cschedule" -pSCHEDULE="$parser" \
          -cMODE="$cmode"         -pMODE="$parser"     \
          -cCHAINID="$cchainid"   -pCHAINID="$parser"  \
@@ -162,14 +167,14 @@ run_prove() {
 
     if ${profile}; then
         timeout -s INT "${profile_timeout}" ${kprove} "${proof_args[@]}" "$@" || true
-        kore-prof "${eventlog_name}" ${kore_prof_args} > "${eventlog_name}.json"
+        notif_exec kore-prof "${eventlog_name}" ${kore_prof_args} > "${eventlog_name}.json"
     else
         if ${pyk_minimize}; then
             pyk_args=(${backend_dir}/*-kompiled minimize /dev/stdin)
             [[ -z "${pyk_omit_labels}" ]] || pyk_args+=(--omit-labels "${pyk_omit_labels}")
-            ${kprove} "${proof_args[@]}" "$@" --output json | kpyk "${pyk_args[@]}"
+            notif_exec ${kprove} "${proof_args[@]}" "$@" --output json | kpyk "${pyk_args[@]}"
         else
-            ${kprove} "${proof_args[@]}" "$@"
+            notif_exec ${kprove} "${proof_args[@]}" "$@"
         fi
     fi
 }
@@ -217,8 +222,7 @@ run_interpret() {
 
         llvm)    run_kast kore > "$kast"
                  if $debugger; then cmdprefix="gdb --args"; fi
-                 $cmdprefix "$interpreter" "$kast" -1 "$output" "$@" \
-                     || exit_status="$?"
+                 notif_exec $cmdprefix "$interpreter" "$kast" -1 "$output" "$@" || exit_status="$?"
                  if [[ "$unparse" == 'true' ]] && [[ "$exit_status" != '0' ]]; then
                      cat "$output" | "$0" kast --backend "$backend" - pretty --input "$output_format" --sort GeneratedTopCell
                  fi
@@ -226,8 +230,7 @@ run_interpret() {
                  ;;
 
         haskell) run_kast kore > "$kast"
-                 kore-exec "$backend_dir/driver-kompiled/definition.kore" --pattern "$kast" --module ETHEREUM-SIMULATION --smt none --output "$output" \
-                     || exit_status="$?"
+                 notif_exec kore-exec "$backend_dir/driver-kompiled/definition.kore" --pattern "$kast" --module ETHEREUM-SIMULATION --smt none --output "$output" || exit_status="$?"
                  if [[ "$unparse" == 'true' ]] && [[ "$exit_status" != '0' ]]; then
                      cat "$output" | "$0" kast --backend "$backend" - pretty --input "$output_format" --sort GeneratedTopCell
                  fi

--- a/kevm
+++ b/kevm
@@ -296,6 +296,8 @@ if [[ "$run_command" == 'help' ]] || [[ "$run_command" == '--help' ]] ; then
 
            klab-view: Make sure that the 'klab/bin' directory is on your PATH to use this option.
     "
+    find /usr -name kompile
+    which kompile
     exit 0
 fi
 
@@ -325,8 +327,7 @@ pyk_omit_labels=
 max_counterexamples=
 branching_allowed=
 haskell_backend_command=(kore-exec)
-[[ ! "$run_command" == 'prove' ]] || backend='java'
-[[ ! "$run_command" =~ klab*   ]] || backend='java'
+[[ ! "$run_command" == 'prove' ]] || backend='haskell'
 kevm_port='8545'
 kevm_host='127.0.0.1'
 args=()
@@ -399,6 +400,6 @@ case "$run_command-$backend" in
     interpret-@(llvm|haskell|java)    ) run_interpret "$@" ;;
     prove-@(java|haskell)             ) run_prove     "$@" ;;
     search-@(java|haskell)            ) run_search    "$@" ;;
-    klab-view-java                    ) view_klab     "$@" ;;
+    klab-view-*                       ) view_klab     "$@" ;;
     *) $0 help ; fatal "Unknown command on backend: $run_command $backend" ;;
 esac

--- a/kevm
+++ b/kevm
@@ -342,7 +342,7 @@ while [[ $# -gt 0 ]]; do
         --kore-prof-args)      kore_prof_args="$2"             ; shift 2 ;;
         --bug-report)          bug_report=true                 ; shift   ;;
         --backend)             backend="$2"                    ; shift 2 ;;
-        --backend-dir)         backend_dir="$2"                ; shift 2 ;;
+        --directory)           backend_dir="$2"                ; shift 2 ;;
         --concrete-rules-file) concrete_rules_file="$2"        ; shift 2 ;;
         --no-provex)           provex=false                    ; shift   ;;
         --verif-module)        verif_module="$2"               ; shift 2 ;;

--- a/kevm
+++ b/kevm
@@ -42,7 +42,7 @@ export KLAB_OUT="${KLAB_OUT:-~/.klab}"
 run_kompile() {
     local kompile_opts openssl_root
 
-    kompile_opts=( "${run_file}" )
+    kompile_opts=( "${run_file}" --directory "${backend_dir}" )
     kompile_opts+=( -I "${INSTALL_INCLUDE}/kframework" -I "${plugin_include}/kframework" )
     kompile_opts+=( --hook-namespaces "JSON KRYPTO BLOCKCHAIN"                           )
     kompile_opts+=( --emit-json                                                          )

--- a/kevm
+++ b/kevm
@@ -3,7 +3,7 @@
 set -euo pipefail
 shopt -s extglob
 
-notif() { echo "== [$(date)]: $@" >&2 ; }
+notif() { echo "== $0 [$(date)]: $@" >&2 ; }
 fatal() { notif "[FATAL] $@" ; exit 1 ; }
 
 notif_exec() {
@@ -376,13 +376,13 @@ fi
 
 # get the run file
 run_file="$1" ; shift
-if [[ "$run_file" == '-' ]]; then
+if [[ "${run_file}" == '-' ]]; then
     tmp_input="$(mktemp)"
-    trap "rm -rf $tmp_input" INT TERM EXIT
-    cat - > "$tmp_input"
-    run_file="$tmp_input"
+    trap "rm -rf ${tmp_input}" INT TERM EXIT
+    cat - > "${tmp_input}"
+    run_file="${tmp_input}"
 fi
-[[ -f "$run_file" ]] || fatal "File does not exist: $run_file"
+[[ -f "${run_file}" ]] || fatal "File does not exist: ${run_file}"
 
 cMODE_kore="Lbl${mode}{}()"
 cSCHEDULE_kore="Lbl${schedule}'Unds'EVM{}()"

--- a/kevm
+++ b/kevm
@@ -299,8 +299,6 @@ if [[ "$run_command" == 'help' ]] || [[ "$run_command" == '--help' ]] ; then
 
            klab-view: Make sure that the 'klab/bin' directory is on your PATH to use this option.
     "
-    find /usr -name kompile
-    which kompile
     exit 0
 fi
 


### PR DESCRIPTION
This PR:

- Switches to Haskell backend by default. Devs are realistically only using `--backend haskell`, so this just makes it more convenient, and the Haskell backend behaves well enough to make it default now.
- Make `--provex` default, and switch to providing a `--no-provex` argument (provex has not given us any problems in a while).
- Switch the option `--backend-dir => --directory`, so that tools which integrate with `kprove` won't have to translate this argument to `kevm prove` (eg. the pyk library KProve object).
- More informative logging messages (with `notif`), and add `notif_exec` to tell people the commands being run.