### PR TITLE
Make sure solc is present to test packages

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -86,7 +86,7 @@ pipeline {
               }
               options {
                 skipDefaultCheckout()
-                timeout(time: 25, unit: 'MINUTES')
+                timeout(time: 35, unit: 'MINUTES')
               }
               steps {
                 dir('focal-test') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,10 +15,6 @@ pipeline {
       steps { script { currentBuild.displayName = "PR ${env.CHANGE_ID}: ${env.CHANGE_TITLE}" } }
     }
     stage('Build and Test') {
-      when {
-        branch 'master'
-        beforeAgent true
-      }
       agent {
         dockerfile {
           additionalBuildArgs '--build-arg K_COMMIT="${K_VERSION}" --build-arg USER_ID=$(id -u) --build-arg GROUP_ID=$(id -g)'
@@ -53,10 +49,10 @@ pipeline {
       }
     }
     stage('Package') {
-      //when {
-      //  branch 'master'
-      //  beforeAgent true
-      //}
+      when {
+        branch 'master'
+        beforeAgent true
+      }
       post { failure { slackSend color: '#cb2431' , channel: '#kevm' , message: "Packaging Phase Failed: ${env.BUILD_URL}" } }
       stages {
         stage('Ubuntu Focal') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -92,7 +92,10 @@ pipeline {
                     export KLAB_OUT=$(pwd)
                     sudo DEBIAN_FRONTEND=noninteractive apt-get update
                     sudo DEBIAN_FRONTEND=noninteractive apt-get upgrade --yes
+                    sudo DEBIAN_FRONTEND=noninteractive apt-get install --yes software-properties-common
+                    sudo DEBIAN_FRONTEND=noninteractive add-apt-repository ppa:ethereum/ethereum
                     sudo DEBIAN_FRONTEND=noninteractive apt-get install --yes ./kevm_${VERSION}_amd64.deb
+                    sudo DEBIAN_FRONTEND=noninteractive apt-get install --yes solc
                     ./package/test-package.sh
                   '''
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,6 +15,10 @@ pipeline {
       steps { script { currentBuild.displayName = "PR ${env.CHANGE_ID}: ${env.CHANGE_TITLE}" } }
     }
     stage('Build and Test') {
+      when {
+        branch 'master'
+        beforeAgent true
+      }
       agent {
         dockerfile {
           additionalBuildArgs '--build-arg K_COMMIT="${K_VERSION}" --build-arg USER_ID=$(id -u) --build-arg GROUP_ID=$(id -g)'
@@ -49,10 +53,10 @@ pipeline {
       }
     }
     stage('Package') {
-      when {
-        branch 'master'
-        beforeAgent true
-      }
+      //when {
+      //  branch 'master'
+      //  beforeAgent true
+      //}
       post { failure { slackSend color: '#cb2431' , channel: '#kevm' , message: "Packaging Phase Failed: ${env.BUILD_URL}" } }
       stages {
         stage('Ubuntu Focal') {


### PR DESCRIPTION
Our CI for testing the built Ubuntu package is not currently installing solc ahead of time, which means that the testing of `kevm solc-to-k ...` is not working on package testing.

This installs `solc` first, then does the package testing.

Note that I don't want to add `solc` as a dependency in the Ubuntu package directly `package/debian/control.focal`, because it requires adding a PPA, and will make it harder for a user to specify the version of solc they want.