### PR TITLE
RLP encoding improvements

### DIFF
--- a/serialization.md
+++ b/serialization.md
@@ -235,7 +235,12 @@ We need to interperet a `ByteArray` as a `String` again so that we can call `Kec
     rule #unparseData( DATA, LENGTH ) => #unparseDataByteArray(#padToWidth(LENGTH,#asByteStack(DATA)))
 
     rule #unparseDataByteArray( DATA ) => replaceFirst(Base2String(#asInteger(#asByteStack(1) ++ DATA), 16), "1", "0x")
+```
 
+- `#addrBytes` Takes an Account and represents it as a 20-byte wide ByteArray (or an empty ByteArray for a null address)
+- `#wordBytes` Takes an Int and represents it as a 32-byte wide ByteArray
+
+```k
     syntax ByteArray ::= #addrBytes( Account ) [function]
                        | #wordBytes( Int )     [function]
  // -----------------------------------------------------
@@ -267,8 +272,13 @@ For details about RLP encoding, see the [YellowPaper Appendix B](http://gavwood.
 Encoding
 --------
 
--   `#rlpEncodeWord` RLP encodes a single EVM word.
--   `#rlpEncodeString` RLP encodes a single `String`.
+-   `#rlpEncodeInt` RLP encodes an arbitrary precision integer.
+-   `#rlpEncodeWord` RLP encodes a 256-bit wide EVM word.
+-   `#rlpEncodeAddress` RLP encodes a 160-bit wide Ethereum address (or the null address: .Account).
+-   `#rlpEncodeBytes` RLP encodes a ByteArray.
+-   `#rlpEncodeString` RLP encodes a String.
+-   `#rlpEncode( JSON )` can take a JSON array and make an rlp encoding. It must be a JSON array! JSON objects aren't supported.
+    example: `#rlpEncode( [ 0, 1, 1, "", #parseByteStack("0xef880") ] )`
 
 ```k
     syntax String ::= #rlpEncodeInt ( Int )              [function]

--- a/serialization.md
+++ b/serialization.md
@@ -245,8 +245,8 @@ We need to interperet a `ByteArray` as a `String` again so that we can call `Kec
                        | #wordBytes( Int )     [function]
  // -----------------------------------------------------
     rule #addrBytes(.Account) => .ByteArray
-    rule #addrBytes(ACCT)     => #padToWidth(20, #asByteStack(ACCT))
-    rule #wordBytes(WORD)     => #padToWidth(32, #asByteStack(WORD))
+    rule #addrBytes(ACCT)     => #padToWidth(20, #asByteStack(ACCT)) requires #rangeAddress(ACCT)
+    rule #wordBytes(WORD)     => #padToWidth(32, #asByteStack(WORD)) requires #rangeUInt(256, WORD)
 ```
 
 String Helper Functions

--- a/serialization.md
+++ b/serialization.md
@@ -34,8 +34,8 @@ Address/Hash Helpers
     syntax Int ::= #newAddr ( Int , Int ) [function]
                  | #newAddr ( Int , Int , ByteArray ) [function, klabel(#newAddrCreate2)]
  // -------------------------------------------------------------------------------------
-    rule [#newAddr]:        #newAddr(ACCT, NONCE) => #addr(#parseHexWord(Keccak256(#rlpEncodeLength(#rlpEncodeAddress(ACCT) +String #rlpEncodeInt(NONCE), 192))))
-    rule [#newAddrCreate2]: #newAddr(ACCT, SALT, INITCODE) => #addr(#parseHexWord(Keccak256("\xff" +String #unparseByteStack(#padToWidth(20, #asByteStack(ACCT))) +String #unparseByteStack(#padToWidth(32, #asByteStack(SALT))) +String #unparseByteStack(#parseHexBytes(Keccak256(#unparseByteStack(INITCODE)))))))
+    rule [#newAddr]:        #newAddr(ACCT, NONCE) => #addr(#parseHexWord(Keccak256(#rlpEncode([#addrBytes(ACCT), NONCE]))))
+    rule [#newAddrCreate2]: #newAddr(ACCT, SALT, INITCODE) => #addr(#parseHexWord(Keccak256("\xff" +String #unparseByteStack(#addrBytes(ACCT)) +String #unparseByteStack(#wordBytes(SALT)) +String #unparseByteStack(#parseHexBytes(Keccak256(#unparseByteStack(INITCODE)))))))
 
     syntax Account ::= #sender ( Int , Int , Int , Int , Account , Int , String , Int , JSONs , Int , ByteArray, ByteArray )    [function]
                      | #sender ( String , Int , String , String )                                                               [function, klabel(#senderAux) ]
@@ -670,7 +670,7 @@ Tree Root Helper Functions
 
     rule #intMap2StorageMapAux( SMAP, _, .List ) => SMAP
     rule #intMap2StorageMapAux( SMAP, IMAP, ListItem(K) REST )
-      => #intMap2StorageMapAux( #padToWidth( 32, #asByteStack(K) ) |-> #rlpEncodeInt({IMAP[K]}:>Int) SMAP, IMAP, REST )
+      => #intMap2StorageMapAux( #wordBytes(K) |-> #rlpEncodeInt({IMAP[K]}:>Int) SMAP, IMAP, REST )
       requires {IMAP[K]}:>Int =/=Int 0
 
     rule #intMap2StorageMapAux( SMAP, IMAP, ListItem(K) REST )

--- a/serialization.md
+++ b/serialization.md
@@ -321,8 +321,8 @@ Encoding
 
     syntax String ::= #rlpEncodeReceipt ( Int , Int , ByteArray , List ) [function]
                     | #rlpEncodeLogs    ( List )                         [function]
-                    | #rlpEncodeLogsAux ( List, String )                 [function]
-                    | #rlpEncodeTopics  ( List, String )                 [function]
+                    | #rlpEncodeLogsAux ( List, StringBuffer )           [function]
+                    | #rlpEncodeTopics  ( List, StringBuffer )           [function]
  // -------------------------------------------------------------------------------
     rule [rlpReceipt]: #rlpEncodeReceipt(RS, RG, RB, RL)
                     => #rlpEncodeLength(         #rlpEncodeInt(RS)
@@ -332,19 +332,19 @@ Encoding
                                        , 192
                                        )
 
-    rule #rlpEncodeLogs( LOGS ) => #rlpEncodeLogsAux( LOGS, "" )
+    rule #rlpEncodeLogs( LOGS ) => #rlpEncodeLogsAux( LOGS, .StringBuffer )
 
-    rule #rlpEncodeLogsAux( .List, OUT ) => #rlpEncodeLength(OUT,192)
+    rule #rlpEncodeLogsAux( .List, OUT ) => #rlpEncodeLength(StringBuffer2String(OUT),192)
     rule #rlpEncodeLogsAux( ( ListItem({ ACCT | TOPICS | DATA }) => .List ) _
                           , ( OUT => OUT +String #rlpEncodeLength(         #rlpEncodeAddress(ACCT)
-                                                                   +String #rlpEncodeTopics(TOPICS,"")
+                                                                   +String #rlpEncodeTopics(TOPICS,.StringBuffer)
                                                                    +String #rlpEncodeString(#unparseByteStack(DATA))
                                                                  , 192
                                                                  )
                             )
                           )
 
-    rule #rlpEncodeTopics( .List, OUT ) => #rlpEncodeLength(OUT,192)
+    rule #rlpEncodeTopics( .List, OUT ) => #rlpEncodeLength(StringBuffer2String(OUT),192)
     rule #rlpEncodeTopics( ( ListItem( X:Int ) => .List ) _
                          , ( OUT => OUT +String #rlpEncodeWord(X) )
                          )


### PR DESCRIPTION
This is a WIP for some improvements to the semantics involving rlp. The primary goal is to create some utility functions that can compress semantics rules into fewer lines, improve performance on existing rlp rules, and potentially remove some redundant rlp encoding rules.

- [x] Create an `#rlpEncode( JSON )` function which can encode a JSON list (encoding of lists is a common pattern)
- [x] Use the new rlpEncode function in rules which can benefit from it
- [x] Use `StringBuffer` sort instead of `String` to build rlp strings (`rlpEncode{Logs,Topics,JSONBytes,AccessList}`)
- [x] Find and remove redundant rlp encoding rules (`rlpEncode{Transaction,JSONBytes}`??)