### PR TITLE
Actually include function selector aliases in generated K

### DIFF
--- a/scripts/kevm_pyk/solc_to_k.py
+++ b/scripts/kevm_pyk/solc_to_k.py
@@ -41,6 +41,7 @@ def solc_to_k(*, command: str, kompiled_directory: str, contract_file: str, cont
                                     + storage_sentences
                                     + function_sentences
                                     + [binRuntimeProduction, contractMacro]
+                                    + function_selector_alias_sentences
                                   )
     binRuntimeDefinition = KDefinition(binRuntimeModuleName, [binRuntimeModule], requires=[KRequire('edsl.md')])
 


### PR DESCRIPTION
Simple bug where the function selector aliases (which were being computed) were not being included in the generated verification module.